### PR TITLE
Add possibility to remove triples.

### DIFF
--- a/lib/N3Store.js
+++ b/lib/N3Store.js
@@ -1,4 +1,5 @@
 // **N3Store** objects store N3 triples with an associated context in memory.
+
 var prefixMatcher = /^([^:\/#"']*):[^\/]/;
 
 // ## Constructor
@@ -105,25 +106,20 @@ N3Store.prototype = {
     return results;
   },
  
-  // ### `_removFromIndex` removes a triple from a three layred index
+  // ### `_removeFromIndex` removes a triple from a three layered index
   // check _findInIndex for more information.
-  _removeFromIndex: function(index0, key0, key1, key2){
-    
-	// Deletes the given key in the three layered index.
-	delete index0[key0][key1][key2];
-	
-	// If the branch doesn't have any other leaf, removes it too.
- 	if(Object.keys(index0[key0][key1]).length == 0){
-	  delete index0[key0][key1];
-	  
-	  // Idem.
-	  if(Object.keys(index0[key0]).length == 0){
-	    delete index0[key0];
-	  }
-	}
-
-	// Enable method chaining.
-	return this;
+  _removeFromIndex: function(index0, key0, key1, key2) {
+    // Deletes the given key in the three layered index.
+    delete index0[key0][key1][key2];
+      
+    // If the second layer branch doesn't have any other leaf, removes it too.
+    if(Object.keys(index0[key0][key1]).length == 0){
+      delete index0[key0][key1];	  
+      // If the first layer branch doesn't have any other leaf, removes it too.
+      if(Object.keys(index0[key0]).length == 0){
+        delete index0[key0];
+      }
+    }
   },
 
   // ## Public methods
@@ -169,43 +165,48 @@ N3Store.prototype = {
     // Enable method chaining.
     return this;
   },
-	
-  // ### `removeTriple` removes a triple from the store.
-  removeTriple: function(triple, context){
-
-	// Find the context to which the triple belongs.
-	context = context || this.defaultContext;
-	var contextItem = this._contexts[context];
-
-	// Retrieve numbers mapped from entities 
-	// since only those values are stored in the three layered indices.
-	var entities = this._entities,
-	subject = entities[triple.subject],
-	predicate = entities[triple.predicate],
-	object = entities[triple.object];
-
-	this._removeFromIndex(contextItem.subjects, subject, predicate, object);
-	this._removeFromIndex(contextItem.predicates, predicate, object, subject);
-	this._removeFromIndex(contextItem.objects, object, subject, predicate);
-	
-	// The cached triple count is now invalid.
-	this._size = null;
-	
-	// Enable method chaining.
-	return this;
-  },
-
-  // ### `removeTriples`removes multiple N3 triples from the store.
-  removeTriples: function(triples, context){
-	for(var i = triples.length -1; i >=0; i--)
-	  this.removeTriple(triples[i], context);
-	return this;
-  },
 
   // ### `addTriples` adds multiple N3 triples to the store.
   addTriples: function (triples) {
     for (var i = triples.length - 1; i >= 0; i--)
       this.addTriple(triples[i]);
+    return this;
+  },
+	
+  // ### `removeTriple` removes a triple from the store.
+  removeTriple: function (subject, predicate, object, context) {
+    // Shift arguments if a triple object is given instead of components
+    if (!predicate)
+      context = subject.context, object = subject.object,
+        predicate = subject.predicate, subject = subject.subject;
+
+    // Find the context to which the triple belongs.
+    context = context || this.defaultContext;
+    var contextItem = this._contexts[context];
+
+    // Retrieve numbers mapped from entities 
+    // since only those values are stored in the three layered indices.
+    var entities = this._entities;
+
+    subject   = entities[subject];
+    predicate = entities[predicate];
+    object    = entities[object];
+
+    this._removeFromIndex(contextItem.subjects, subject, predicate, object);
+    this._removeFromIndex(contextItem.predicates, predicate, object, subject);
+    this._removeFromIndex(contextItem.objects, object, subject, predicate);
+	
+    // The cached triple count is now invalid.
+    this._size = null;
+	
+    // Enable method chaining.
+    return this;
+  },
+
+  // ### `removeTriples` removes multiple N3 triples from the store.
+  removeTriples: function(triples) {
+    for(var i = triples.length -1; i >= 0; i--)
+      this.removeTriple(triples[i]);
     return this;
   },
 


### PR DESCRIPTION
Hi Ruben, still on the removal of triples described in issue #23. We've implemented something ourselves as we needed it for our project. Just sharing in case you find it useful. We tried to match your code style as much as possible. The implementation is very close to the addTriple method. To remove a triple, we remove the leaf in the 3 indexes as well as branches when there are no more leaves. We decided not to touch the entities map as we never remove entities themselves but rather modify the links between them. I think this is also fail safe...

Btw, congrats on the 3 cyclic 3-layered indexes, pretty darn efficient :).
