### PR TITLE
Add documentation about base IRI of N3.Parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ Then, we find triples with `:Mickey` as subject.
 ```JavaScript
 const store = N3.Store();
 store.addQuad(
-  namedNode('http://ex.org/Pluto'),
+  namedNode('http://ex.org/Pluto'), 
   namedNode('http://ex.org/type'),
   namedNode('http://ex.org/Dog')
 );

--- a/README.md
+++ b/README.md
@@ -106,6 +106,12 @@ const parser4 = N3.Parser({ format: 'Notation3' });
 const parser5 = N3.Parser({ format: 'text/n3' });
 ```
 
+It is possible to provide the base IRI of the document that you want to parse.
+This is done by passing a `baseIRI` argument upon creation:
+```JavaScript
+const parser = new N3.Parser({baseIRI: 'http://example.org/'});
+``` 
+
 ### From an RDF stream to quads
 
 `N3.Parser` can parse [Node.js streams](http://nodejs.org/api/stream.html) as they grow,
@@ -252,7 +258,7 @@ Then, we find triples with `:Mickey` as subject.
 ```JavaScript
 const store = N3.Store();
 store.addQuad(
-  namedNode('http://ex.org/Pluto'), 
+  namedNode('http://ex.org/Pluto'),
   namedNode('http://ex.org/type'),
   namedNode('http://ex.org/Dog')
 );


### PR DESCRIPTION
 I added an example in the documentation that shows how to add the base IRI to the N3.Parser (#149)