### PR TITLE
+ instructions, scripts and testbed for browser products

### DIFF
--- a/N3-webpack.js
+++ b/N3-webpack.js
@@ -1,0 +1,1 @@
+N3 = require('./N3.js')

--- a/README.md
+++ b/README.md
@@ -38,8 +38,29 @@ const N3 = require('n3');
 
 N3.js seamlessly works in browsers via [webpack](https://webpack.js.org/)
 or [browserify](http://browserify.org/).
-If you're unfamiliar with these tools,
-you can read
+
+**browserify**
+```Bash
+$ npm install browserify terser
+$ npm run browser-browserify
+```
+
+**webpack**
+```Bash
+$ npm install webpack-cli terser-webpack-plugin
+$ npm run browser-webpack
+```
+
+You can test out the results with the `browser/simple.html` page. You can choose at the bottom which browser version to load:
+
+```html
+<script src="n3-browserify.js"></script>
+<!-- <script src="n3-browserify.min.js"></script> -->
+<!-- <script src="n3-webpack.js"></script> -->
+<!-- <script src="n3-webpack.min.js"></script> -->
+```
+
+If you're unfamiliar with these tools, you can read
 [_webpack: Creating a Bundle – getting started_](https://webpack.js.org/guides/getting-started/#creating-a-bundle)
 or
 [_Introduction to browserify_](https://writingjavascript.org/posts/introduction-to-browserify).

--- a/browser/simple.html
+++ b/browser/simple.html
@@ -1,0 +1,16 @@
+<html>
+  <head>
+    <title>Simple N3 WebApp</title>
+    <style>
+      pre { margin-left: 1em; border-left: medium solid #ddd; padding-left: 1em; background-color: #eee; }
+    </style>
+  </head>
+  <body>
+    <div id="target">If you see this, something didn't load.</div>
+    <script src="n3-browserify.js"></script>
+    <!-- <script src="n3-browserify.min.js"></script> -->
+    <!-- <script src="n3-webpack.js"></script> -->
+    <!-- <script src="n3-webpack.min.js"></script> -->
+    <script src="simple.js"></script>
+  </body>
+</html>

--- a/browser/simple.js
+++ b/browser/simple.js
@@ -1,0 +1,223 @@
+
+const README = 'https://github.com/rdfjs/N3.js#'
+
+console.log(N3);
+let target = document.getElementById("target");
+target.innerHTML = "";
+let title = document.createElement("h1");
+title.textContent = "N3.js in the Browser";
+target.appendChild(title);
+
+let Cartoons = `PREFIX c: <http://example.org/cartoons#>
+   c:Tom a c:Cat.
+   c:Jerry a c:Mouse;
+           c:smarterThan c:Tom.`
+
+class Log {
+  pre = null
+
+  section (h, title, fragment) {
+    let hElt = document.createElement(h)
+    let a = document.createElement("a")
+    a.setAttribute("href", README + fragment)
+    a.appendChild(document.createTextNode(title))
+    hElt.appendChild(a)
+    this.pre = document.createElement("pre")
+    target.appendChild(hElt)
+    target.appendChild(this.pre)
+  }
+
+  write (msg) {
+    let toAdd = typeof msg === "object"
+        ? JSON.stringify(msg, null, 2)
+        : msg
+    this.pre.innerHTML += toAdd + "\n"
+  }
+  // writable () {
+  //   readableStream.on('data', function(chunk) {
+  //     writableStream.write(chunk);
+  //   });
+  // }
+}
+
+/** create a ReadableStream from a string
+ */
+function createReadStream (str) {
+  const chunkSize = 10
+  let nowAt = -chunkSize
+
+  return new ReadableStream({
+    pull (controller) {
+      return pump();
+      function pump() {
+        if (nowAt > str.length)
+          controller.close();
+        else
+          controller.enqueue(str.substr(nowAt += chunkSize, chunkSize))
+        // return pump();
+      }
+    }  
+  });
+}
+
+const { DataFactory } = N3;
+const { namedNode, literal, defaultGraph, quad } = DataFactory;
+
+Promise.resolve(new Log()).then(log => {
+  log.section("h2", "Creating triples/quads", "creating-triplesquads")
+
+  const myQuad = quad(
+    namedNode('https://ruben.verborgh.org/profile/#me'),
+    namedNode('http://xmlns.com/foaf/0.1/givenName'),
+    literal('Ruben', 'en'),
+    defaultGraph(),
+  );
+  log.write(myQuad.subject.value);         // https://ruben.verborgh.org/profile/#me
+  log.write(myQuad.object.value);          // Ruben
+  log.write(myQuad.object.datatype.value); // http://www.w3.org/1999/02/22-rdf-syntax-ns#langString
+  log.write(myQuad.object.language);       // en
+
+  return log;
+}).then(log => {
+  log.section("h2", "Parsing", "parsing")
+  log.section("h3", "From an RDF document to quads", "from-an-rdf-document-to-quads")
+  return new Promise((resolve, reject) => {
+
+    const parser = new N3.Parser();
+    parser.parse(Cartoons,
+      (error, quad, prefixes) => {
+        if (quad)
+          log.write(quad);
+        else {
+          log.write("# That's all, folks!", prefixes);
+          resolve(log)
+        }
+      });
+
+  })
+}).then(log => {
+  log.section("h3", "From an RDF stream to quads", "from-an-rdf-stream-to-quads")
+  return new Promise((resolve, reject) => {
+
+    const streamParser = new N3.StreamParser(),
+          rdfStream = createReadStream(Cartoons);
+resolve(log); return; // !! broken here
+    rdfStream.pipeTo(streamParser);
+    streamParser.pipeTo(new SlowConsumer());
+
+    function SlowConsumer() {
+      const writer = new WritableStream({ objectMode: true });
+      writer._write = (quad, encoding, done) => {
+        log.write(quad);
+        setTimeout(done, 1000);
+      };
+      return writer;
+    }
+
+  })
+}).then(log => {
+  log.section("h2", "Writing", "writing")
+  log.section("h3", "From quads to a string", "from-quads-to-a-string")
+  return new Promise((resolve, reject) => {
+
+    const writer = new N3.Writer({ prefixes: { c: 'http://example.org/cartoons#' } });
+    writer.addQuad(
+      namedNode('http://example.org/cartoons#Tom'),
+      namedNode('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'),
+      namedNode('http://example.org/cartoons#Cat')
+    );
+    writer.addQuad(quad(
+      namedNode('http://example.org/cartoons#Tom'),
+      namedNode('http://example.org/cartoons#name'),
+      literal('Tom')
+    ));
+    writer.end((error, result) => {
+      log.write(result)
+      resolve(log)
+    });
+
+  })
+}).then(log => {
+  log.section("h3", "From quads to an RDF stream", "from-quads-to-an-rdf-stream")
+
+  const writer = new N3.Writer(log, { end: false, prefixes: { c: 'http://example.org/cartoons#' } });
+  writer.addQuad(
+    namedNode('http://example.org/cartoons#Tom'),
+    namedNode('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'),
+    namedNode('http://example.org/cartoons#Cat')
+  );
+  writer.addQuad(quad(
+    namedNode('http://example.org/cartoons#Tom'),
+    namedNode('http://example.org/cartoons#name'),
+    literal('Tom')
+  ));
+  writer.end();
+
+  return log
+}).then(log => {
+  log.section("h3", "From a quad stream to an RDF stream", "from-a-quad-stream-to-an-rdf-stream")
+
+  const streamParser = new N3.StreamParser(),
+        inputStream = createReadStream(Cartoons),
+        streamWriter = new N3.StreamWriter({ prefixes: { c: 'http://example.org/cartoons#' } });
+return log; // !! broken here
+  inputStream.pipe(streamParser);
+  streamParser.pipe(streamWriter);
+  streamWriter.pipe(log);
+
+  return log
+}).then(log => {
+  log.section("h3", "Blank nodes and lists", "blank-nodes-and-lists")
+
+  const writer = new N3.Writer({ prefixes: { c: 'http://example.org/cartoons#',
+                                             foaf: 'http://xmlns.com/foaf/0.1/' } });
+  writer.addQuad(
+    writer.blank(
+      namedNode('http://xmlns.com/foaf/0.1/givenName'),
+      literal('Tom', 'en')),
+    namedNode('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'),
+    namedNode('http://example.org/cartoons#Cat')
+  );
+  writer.addQuad(quad(
+    namedNode('http://example.org/cartoons#Jerry'),
+    namedNode('http://xmlns.com/foaf/0.1/knows'),
+    writer.blank([{
+      predicate: namedNode('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'),
+      object:    namedNode('http://example.org/cartoons#Cat'),
+    },{
+      predicate: namedNode('http://xmlns.com/foaf/0.1/givenName'),
+      object:    literal('Tom', 'en'),
+    }])
+  ));
+  writer.addQuad(
+    namedNode('http://example.org/cartoons#Mammy'),
+    namedNode('http://example.org/cartoons#hasPets'),
+    writer.list([
+      namedNode('http://example.org/cartoons#Tom'),
+      namedNode('http://example.org/cartoons#Jerry'),
+    ])
+  );
+  writer.end((error, result) => log.write(result));
+
+  return log
+}).then(log => {
+  log.section("h2", "Storing", "storing")
+
+  const store = new N3.Store();
+  store.addQuad(
+    namedNode('http://ex.org/Pluto'), 
+    namedNode('http://ex.org/type'),
+    namedNode('http://ex.org/Dog')
+  );
+  store.addQuad(
+    namedNode('http://ex.org/Mickey'),
+    namedNode('http://ex.org/type'),
+    namedNode('http://ex.org/Mouse')
+  );
+
+  const mickey = store.getQuads(namedNode('http://ex.org/Mickey'), null, null)[0];
+  log.write(mickey);
+
+  return log
+})
+

--- a/package.json
+++ b/package.json
@@ -33,6 +33,8 @@
     "streamify-string": "^1.0.1"
   },
   "scripts": {
+    "browser-browserify": "npx browserify -s N3 -o browser/n3-browserify.js node_modules/n3/N3.js && npx terser browser/n3-browserify.js -o browser/n3-browserify.min.js -c -m",
+    "browser-webpack": "npx webpack --config webpack.config.js --mode production",
     "test": "nyc mocha",
     "lint": "eslint lib perf test spec",
     "spec": "npm run spec-turtle && npm run spec-ntriples && npm run spec-nquads && npm run spec-trig",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,32 @@
+const path = require('path');
+const TerserPlugin = require('terser-webpack-plugin');
+const webpack = require("webpack");
+
+/*
+TODO: Make webpack assign "./N3.js"'s exports to the global name `N3`,
+      analogous to browserify's `-s N3` command line argument. `N3-webpack.js`
+      is a hack to get the same effect. Using "./N3.js" directly results in all
+      of it's members being assigned to window (window.DataFactory, etc):
+      `for(var i in a) (typeof exports === 'object' ? exports : root)[i] = a[i];`
+ */
+
+module.exports = {
+  entry: {
+    "n3-webpack": "./N3-webpack.js",
+    "n3-webpack.min": "./N3-webpack.js",
+  },
+  output: {
+    filename: "[name].js",
+    path: path.resolve(__dirname, 'browser'),
+    // libraryTarget: 'umd',
+    // libraryExport: 'N3',
+    // umdNamedDefine: true,
+    // // globalObject: 'this'
+  },
+  optimization: {
+    minimize: true,
+    minimizer: [new TerserPlugin({
+      include: /\.min\.js$/
+    })]
+  }
+};


### PR DESCRIPTION
I wanted to shorten the learniing curve for using N3.js in a browser.

Remaining issues:
1. I screwed around reading webpack docs for while then gave up to create a hack `N3-webpack.js` to emualte the behavior of `browserify -s N3`
2. The browser/simple.html page doesn't demonstrate reading from `ReadableStreams` as I never figured out how to. Other than that, it covers pretty much everything in the README.md.