### PR TITLE
Implement RDFJS Store (and Source) interface on N3Store

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,6 +286,8 @@ The store provides the following manipulation methods
 - `addQuads` to insert an array of quads
 - `removeQuad` to remove one quad
 - `removeQuads` to remove an array of quads
+- `remove` to remove a stream of quads
+- `removeMatches` to remove all quads matching the given pattern
 - `createBlankNode` returns an unused blank node identifier
 
 ### Searching quads or entities

--- a/README.md
+++ b/README.md
@@ -288,6 +288,7 @@ The store provides the following manipulation methods
 - `removeQuads` to remove an array of quads
 - `remove` to remove a stream of quads
 - `removeMatches` to remove all quads matching the given pattern
+- `deleteGraph` to remove all quads with the given graph
 - `createBlankNode` returns an unused blank node identifier
 
 ### Searching quads or entities

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ It is possible to provide the base IRI of the document that you want to parse.
 This is done by passing a `baseIRI` argument upon creation:
 ```JavaScript
 const parser = new N3.Parser({ baseIRI: 'http://example.org/' });
-``` 
+```
 
 ### From an RDF stream to quads
 
@@ -265,7 +265,7 @@ Then, we find triples with `:Mickey` as subject.
 ```JavaScript
 const store = new N3.Store();
 store.addQuad(
-  namedNode('http://ex.org/Pluto'), 
+  namedNode('http://ex.org/Pluto'),
   namedNode('http://ex.org/type'),
   namedNode('http://ex.org/Dog')
 );
@@ -292,6 +292,7 @@ The store provides the following manipulation methods
 The store provides the following search methods
 ([documentation](http://rdfjs.github.io/N3.js/docs/N3Store.html)):
 - `getQuads` returns an array of quads matching the given pattern
+- `match` returns a stream of quads matching the given pattern
 - `countQuads` counts the number of quads matching the given pattern
 - `forEach` executes a callback on all matching quads
 - `every` returns whether a callback on matching quads always returns true
@@ -347,6 +348,7 @@ The N3.js submodules are compatible with the following [RDF.js](http://rdf.js.or
   and
   [`Sink`](http://rdf.js.org/#sink-interface)
 - `N3.Store` implements
+  [`Source`](http://rdf.js.org/#source-interface)
   [`Sink`](http://rdf.js.org/#sink-interface)
 
 ## License and contributions

--- a/README.md
+++ b/README.md
@@ -330,29 +330,30 @@ for strict, fault-intolerant behavior.
 The N3.js submodules are compatible with the following [RDF.js](http://rdf.js.org) interfaces:
 
 - `N3.DataFactory` implements
-  [`DataFactory`](http://rdf.js.org/#datafactory-interface)
-  - the terms it creates implement [`Term`](http://rdf.js.org/#term-interface)
+  [`DataFactory`](http://rdf.js.org/data-model-spec/#datafactory-interface)
+  - the terms it creates implement [`Term`](http://rdf.js.org/data-model-spec/#term-interface)
     and one of
-    [`NamedNode`](http://rdf.js.org/#namednode-interface),
-    [`BlankNode`](http://rdf.js.org/#blanknode-interface),
-    [`Literal`](http://rdf.js.org/#litereal-interface),
-    [`Variable`](http://rdf.js.org/#variable-interface),
-    [`DefaultGraph`](http://rdf.js.org/#defaultgraph-interface)
+    [`NamedNode`](http://rdf.js.org/data-model-spec/#namednode-interface),
+    [`BlankNode`](http://rdf.js.org/data-model-spec/#blanknode-interface),
+    [`Literal`](http://rdf.js.org/data-model-spec/#litereal-interface),
+    [`Variable`](http://rdf.js.org/data-model-spec/#variable-interface),
+    [`DefaultGraph`](http://rdf.js.org/data-model-spec/#defaultgraph-interface)
   - the triples/quads it creates implement
-    [`Triple`](http://rdf.js.org/#triple-interface)
+    [`Triple`](http://rdf.js.org/data-model-spec/#triple-interface)
     and
-    [`Quad`](http://rdf.js.org/#quad-interface)
+    [`Quad`](http://rdf.js.org/data-model-spec/#quad-interface)
 - `N3.StreamParser` implements
-  [`Stream`](http://rdf.js.org/#stream-interface)
+  [`Stream`](http://rdf.js.org/stream-spec/#stream-interface)
   and
-  [`Sink`](http://rdf.js.org/#sink-interface)
+  [`Sink`](http://rdf.js.org/stream-spec/#sink-interface)
 - `N3.StreamWriter` implements
-  [`Stream`](http://rdf.js.org/#stream-interface)
+  [`Stream`](http://rdf.js.org/stream-spec/#stream-interface)
   and
-  [`Sink`](http://rdf.js.org/#sink-interface)
+  [`Sink`](http://rdf.js.org/stream-spec/#sink-interface)
 - `N3.Store` implements
-  [`Source`](http://rdf.js.org/#source-interface)
-  [`Sink`](http://rdf.js.org/#sink-interface)
+  [`Store`](http://rdf.js.org/stream-spec/#store-interface)
+  [`Source`](http://rdf.js.org/stream-spec/#source-interface)
+  [`Sink`](http://rdf.js.org/stream-spec/#sink-interface)
 
 ## License and contributions
 The N3.js library is copyrighted by [Ruben Verborgh](https://ruben.verborgh.org/)

--- a/lib/N3Store.js
+++ b/lib/N3Store.js
@@ -314,6 +314,12 @@ class N3Store {
     return stream;
   }
 
+  // ### `removeMatches` removes all matching quads from the store
+  // Setting any field to `undefined` or `null` indicates a wildcard.
+  removeMatches(subject, predicate, object, graph) {
+    return this.remove(this.match(subject, predicate, object, graph));
+  }
+
   // ### `getQuads` returns an array of quads matching a pattern.
   // Setting any field to `undefined` or `null` indicates a wildcard.
   getQuads(subject, predicate, object, graph) {

--- a/lib/N3Store.js
+++ b/lib/N3Store.js
@@ -1,6 +1,7 @@
 // **N3Store** objects store N3 quads by graph in memory.
 
-var DataFactory = require('./N3DataFactory');
+var DataFactory = require('./N3DataFactory'),
+    Readable = require('stream').Readable;
 var toId = DataFactory.internal.toId,
     fromId = DataFactory.internal.fromId;
 
@@ -360,6 +361,25 @@ class N3Store {
       }
     }
     return quads;
+  }
+
+  // ### `match` returns a stream of quads matching a pattern.
+  // Setting any field to `undefined` or `null` indicates a wildcard.
+  match(subject, predicate, object, graph) {
+    var self = this;
+    var stream = new Readable({ objectMode: true });
+
+    // Initialize stream once it is being read
+    stream._read = function () {
+      stream._read = function () {};
+      var quads = self.getQuads(subject, predicate, object, graph);
+      for (var quad of quads) {
+        stream.push(quad);
+      }
+      stream.push(null);
+    };
+
+    return stream;
   }
 
   // ### `countQuads` returns the number of quads matching a pattern.

--- a/lib/N3Store.js
+++ b/lib/N3Store.js
@@ -320,6 +320,11 @@ class N3Store {
     return this.remove(this.match(subject, predicate, object, graph));
   }
 
+  // ### `deleteGraph` removes all triples with the given graph from the store
+  deleteGraph(graph) {
+    return this.removeMatches(null, null, null, graph);
+  }
+
   // ### `getQuads` returns an array of quads matching a pattern.
   // Setting any field to `undefined` or `null` indicates a wildcard.
   getQuads(subject, predicate, object, graph) {

--- a/test/N3Store-test.js
+++ b/test/N3Store-test.js
@@ -116,10 +116,11 @@ describe('N3Store', function () {
       new Quad(new NamedNode('s1'), new NamedNode('p1'), new NamedNode('o1')),
       new Quad(new NamedNode('s1'), new NamedNode('p1'), new NamedNode('o2')),
       new Quad(new NamedNode('s1'), new NamedNode('p1'), new NamedNode('o3')),
+      new Quad(new NamedNode('s2'), new NamedNode('p2'), new NamedNode('o2'), new NamedNode('g1')),
     ]);
 
     it('should have size 3', function () {
-      store.size.should.eql(3);
+      store.size.should.eql(4);
     });
 
     describe('adding a triple that already exists', function () {
@@ -128,7 +129,7 @@ describe('N3Store', function () {
       });
 
       it('should not increase the size', function () {
-        store.size.should.eql(3);
+        store.size.should.eql(4);
       });
     });
 
@@ -138,7 +139,7 @@ describe('N3Store', function () {
       });
 
       it('should increase the size', function () {
-        store.size.should.eql(4);
+        store.size.should.eql(5);
       });
     });
 
@@ -148,7 +149,7 @@ describe('N3Store', function () {
       });
 
       it('should decrease the size', function () {
-        store.size.should.eql(3);
+        store.size.should.eql(4);
       });
     });
 
@@ -158,7 +159,7 @@ describe('N3Store', function () {
       });
 
       it('should not decrease the size', function () {
-        store.size.should.eql(3);
+        store.size.should.eql(4);
       });
     });
 
@@ -168,6 +169,16 @@ describe('N3Store', function () {
           ['s1', 'p1', 'o1'],
           ['s1', 'p1', 'o2'],
           ['s1', 'p1', 'o3']));
+
+      it('should decrease the size', function () {
+        store.size.should.eql(1);
+      });
+    });
+
+    describe('removing a graph', function () {
+      it('should return the removed quads',
+        forResultStream(shouldIncludeAll, function () { return store.deleteGraph('g1'); },
+          ['s2', 'p2', 'o2', 'g1']));
 
       it('should decrease the size', function () {
         store.size.should.eql(0);

--- a/test/N3Store-test.js
+++ b/test/N3Store-test.js
@@ -161,6 +161,18 @@ describe('N3Store', function () {
         store.size.should.eql(3);
       });
     });
+
+    describe('removing matching quads', function () {
+      it('should return the removed quads',
+        forResultStream(shouldIncludeAll, function () { return store.removeMatches('s1', 'p1'); },
+          ['s1', 'p1', 'o1'],
+          ['s1', 'p1', 'o2'],
+          ['s1', 'p1', 'o3']));
+
+      it('should decrease the size', function () {
+        store.size.should.eql(0);
+      });
+    });
   });
 
   describe('An N3Store with 5 elements', function () {
@@ -1096,6 +1108,7 @@ function shouldIncludeAll(result) {
 function forResultStream(testFunction, result) {
   var items = Array.prototype.slice.call(arguments, 2);
   return function (done) {
+    if (typeof result === 'function') result = result();
     arrayifyStream(result)
       .then(function (array) {
         items.unshift(array);


### PR DESCRIPTION
As requested in #145.

Note that Source#match used to accept RegExp as terms, but this has been removed now from the RDFJS spec, which simplifies implementation a lot.

I saw that #162 and #168 also offer a (partial) implementation of this, but they seem to have stalled a bit, and I need support for this ASAP, so I created this new PR (which is a bit less invasive).