### PR TITLE
add support for periods in local IRI part

### DIFF
--- a/lib/N3Writer.js
+++ b/lib/N3Writer.js
@@ -229,7 +229,7 @@ class N3Writer {
       }
       IRIlist = IRIlist.replace(/[\]\/\(\)\*\+\?\.\\\$]/g, '\\$&');
       this._prefixRegex = new RegExp('^(?:' + prefixList + ')[^\/]*$|' +
-                                     '^(' + IRIlist + ')([a-zA-Z][\\-_a-zA-Z0-9]*)$');
+                                     '^(' + IRIlist + ')([a-zA-Z](?:[\\-_.a-zA-Z0-9]*[\\-_a-zA-Z0-9])?)$');
     }
     // End a prefix block with a newline
     this._write(hasPrefixes ? '\n' : '', done);

--- a/test/N3Writer-test.js
+++ b/test/N3Writer-test.js
@@ -135,11 +135,15 @@ describe('N3Writer', function () {
     it('should use prefixes when possible',
       shouldSerialize({ prefixes: { a: 'http://a.org/', b: 'http://a.org/b#', c: 'http://a.org/b' } },
                       ['http://a.org/bc', 'http://a.org/b#ef', 'http://a.org/bhi'],
+                      ['http://a.org/bc.d', 'http://a.org/b#ef', 'http://a.org/bhi'],
+                      ['http://a.org/bc.', 'http://a.org/b#ef', 'http://a.org/bhi'],
                       ['http://a.org/bc/de', 'http://a.org/b#e#f', 'http://a.org/b#x/t'],
                       ['http://a.org/3a', 'http://a.org/b#3a', 'http://a.org/b#a3'],
                       '@prefix a: <http://a.org/>.\n' +
                       '@prefix b: <http://a.org/b#>.\n\n' +
                       'a:bc b:ef a:bhi.\n' +
+                      'a:bc.d b:ef a:bhi.\n' +
+                      '<http://a.org/bc.> b:ef a:bhi.\n' +
                       '<http://a.org/bc/de> <http://a.org/b#e#f> <http://a.org/b#x/t>.\n' +
                       '<http://a.org/3a> <http://a.org/b#3a> b:a3.\n'));
 


### PR DESCRIPTION
Turtle syntax allows for periods (`'.'`) in the local part of a prefixed IRI, as long as it's not in the leading or terminal position:

https://dvcs.w3.org/hg/rdf/raw-file/default/rdf-turtle/index.html#grammar-production-PN_LOCAL

This PR modifies the regex that matches IRIs which can be shortened to allow for periods as appropriate, and updates the `should use prefixes when possible` test to account for this.

_note: there are still more things which are permissible by the spec that N3.js will not shorten, this only addresses the inclusion of periods in permissible locations in an IRI local part, not the entire spec_