### PR TITLE
Writer list heads

### DIFF
--- a/src/N3Writer.js
+++ b/src/N3Writer.js
@@ -33,6 +33,7 @@ export default class N3Writer {
     if (outputStream && typeof outputStream.write !== 'function')
       options = outputStream, outputStream = null;
     options = options || {};
+    this._lists = options.lists;
 
     // If no output stream given, send the output as string through the end callback
     if (!outputStream) {
@@ -129,8 +130,12 @@ export default class N3Writer {
   // ### `_encodeIriOrBlank` represents an IRI or blank node
   _encodeIriOrBlank(entity) {
     // A blank node or list is represented as-is
-    if (entity.termType !== 'NamedNode')
+    if (entity.termType !== 'NamedNode') {
+      // If it is a list head, pretty-print it
+      if (this._lists && (entity.value in this._lists))
+        entity = this.list(this._lists[entity.value]);
       return 'id' in entity ? entity.id : '_:' + entity.value;
+    }
     // Escape special characters
     var iri = entity.value;
     if (escape.test(iri))

--- a/test/N3Writer-test.js
+++ b/test/N3Writer-test.js
@@ -1,6 +1,6 @@
 import { Writer, DataFactory } from '../src/';
 
-const { NamedNode, Literal, Quad, fromId } = DataFactory.internal;
+const { NamedNode, BlankNode, Literal, Quad, fromId } = DataFactory.internal;
 
 describe('Writer', function () {
   describe('The Writer export', function () {
@@ -476,6 +476,22 @@ describe('Writer', function () {
       writer.addQuad(writer.list([new NamedNode('a1'), new Literal('"b"'), new Literal('"c"')]), new NamedNode('d'), new NamedNode('e'));
       writer.end(function (error, output) {
         output.should.equal('(<a1> "b" "c") <d> <e>.\n');
+        done(error);
+      });
+    });
+
+    it('should serialize subject and object triples passed by options.listHeads', function (done) {
+      var lists = {
+        l1: [new NamedNode('c'), new NamedNode('d'), new NamedNode('e')],
+        l2: [new Literal('c'), new Literal('d'), new Literal('e')],
+      };
+
+      var writer = new Writer({ lists });
+      writer.addQuad(new BlankNode('l1'), new NamedNode('b'), new BlankNode('l2'));
+      writer.addQuad(new NamedNode('a3'), new NamedNode('b'), new BlankNode('m3'));
+      writer.end(function (error, output) {
+        output.should.equal('(<c> <d> <e>) <b> ("c" "d" "e").\n' +
+                            '<a3> <b> _:m3.\n');
         done(error);
       });
     });


### PR DESCRIPTION
Follows up on [#179] by taking the result of `extractLists()` as an N3Writer constructor options:
``` javascript
const lists = graph.extractLists({ remove: true });
const writer = new N3.Writer({ lists });
writer.addQuads(graph.getQuads());
```
Otherwise, the user has to do something like:
``` javascript
const listHeads = sequesterLists(graph)
const writer = new N3.Writer()
writer.addQuads(graph.getQuads().map(q => {
  let members = listHeads.get(q.subject.value)
  if (members)
    q.subject = writer.list(members)
  members = listHeads.get(q.object.value)
  if (members)
    q.object = writer.list(members)
  return q
}))
```