### PR TITLE
use empty string as base to support relative IRIs

### DIFF
--- a/src/N3Parser.js
+++ b/src/N3Parser.js
@@ -56,7 +56,8 @@ export default class N3Parser {
     if (!baseIRI) {
       this._base = '';
       this._basePath = '';
-    } else {
+    }
+    else {
       // Remove fragment if present
       var fragmentPos = baseIRI.indexOf('#');
       if (fragmentPos >= 0)

--- a/src/N3Parser.js
+++ b/src/N3Parser.js
@@ -53,9 +53,10 @@ export default class N3Parser {
 
   // ### `_setBase` sets the base IRI to resolve relative IRIs
   _setBase(baseIRI) {
-    if (!baseIRI)
-      this._base = null;
-    else {
+    if (!baseIRI) {
+      this._base = '';
+      this._basePath = '';
+    } else {
       // Remove fragment if present
       var fragmentPos = baseIRI.indexOf('#');
       if (fragmentPos >= 0)

--- a/test/N3Parser-test.js
+++ b/test/N3Parser-test.js
@@ -894,6 +894,18 @@ describe('Parser', function () {
     });
   });
 
+  describe('An Parser instance without document IRI', function () {
+    function parser() { return new Parser(); }
+
+    it('should not resolve the IRIs',
+      shouldParse(parser,
+        '@prefix : <#>.\n' +
+        '<a> <b> <c> <g>.\n' +
+        ':d :e :f :g.',
+        ['a', 'b', 'c', 'g'],
+        ['#d', '#e', '#f', '#g']));
+  });
+
   describe('An Parser instance with a document IRI', function () {
     function parser() { return new Parser({ baseIRI: 'http://ex.org/x/yy/zzz/f.ttl' }); }
 

--- a/test/N3Parser-test.js
+++ b/test/N3Parser-test.js
@@ -902,8 +902,8 @@ describe('Parser', function () {
         '@prefix : <#>.\n' +
         '<a> <b> <c> <g>.\n' +
         ':d :e :f :g.',
-        ['a', 'b', 'c', 'g'],
-        ['#d', '#e', '#f', '#g']));
+        [fromId('a'), fromId('b'), fromId('c'), fromId('g')],
+        [fromId('#d'), fromId('#e'), fromId('#f'), fromId('#g')]));
   });
 
   describe('An Parser instance with a document IRI', function () {
@@ -2006,6 +2006,10 @@ function shouldParse(parser, input) {
     var results = [];
     var items = expected.map(function (item) {
       item = item.map(function (t) {
+        // don't touch if it's already an object
+        if (typeof t === 'object')
+          return t;
+
         // Append base to relative IRIs
         if (!/^$|^["?]|:/.test(t))
           t = BASE_IRI + t;


### PR DESCRIPTION
When no `baseIRI` is given, relative IRIs are prepended with `undefined` in the current version. I guess this is not an expected behavior. With this PR, relative IRIs are resolved against an empty string, so they are kept without changes. In an older version it was already like this and it's still possible with a workaround (`{ baseIRI: new String('') }`).

This is useful for LDP to POST to a container with relative IRIs and some other more exotic use cases.

I wasn't sure how to get the test running without big changes. @RubenVerborgh would be great if you can give me a hint how you would like to have it implemented or you just take over that part.