### PR TITLE
allow empty relative IRIs

### DIFF
--- a/src/N3Parser.js
+++ b/src/N3Parser.js
@@ -29,7 +29,7 @@ export default class N3Parser {
     this._supportsQuads = !(isTurtle || isTriG || isNTriples || isN3);
     // Disable relative IRIs in N-Triples or N-Quads mode
     if (isLineMode)
-      this._resolveRelativeIRI = function (iri) { return ''; };
+      this._resolveRelativeIRI = function (iri) { return null; };
     this._blankNodePrefix = typeof options.blankNodePrefix !== 'string' ? '' :
                               options.blankNodePrefix.replace(/^(?!_:)/, '_:');
     this._lexer = options.lexer || new N3Lexer({ lineMode: isLineMode, n3: isN3 });
@@ -154,7 +154,7 @@ export default class N3Parser {
     case 'IRI':
     case 'typeIRI':
       var iri = this._resolveIRI(token.value);
-      if (iri === '')
+      if (iri === null)
         return this._error('Invalid IRI', token);
       value = this._namedNode(iri);
       break;
@@ -828,7 +828,7 @@ export default class N3Parser {
     // Resolve all other IRIs at the base IRI's path
     default:
       // Relative IRIs cannot contain a colon in the first path segment
-      return (/^[^/:]*:/.test(iri)) ? '' : this._removeDotSegments(this._basePath + iri);
+      return (/^[^/:]*:/.test(iri)) ? null : this._removeDotSegments(this._basePath + iri);
     }
   }
 

--- a/test/N3Parser-test.js
+++ b/test/N3Parser-test.js
@@ -897,13 +897,21 @@ describe('Parser', function () {
   describe('An Parser instance without document IRI', function () {
     function parser() { return new Parser(); }
 
-    it('should not resolve the IRIs',
+    it('should keep relative IRIs',
       shouldParse(parser,
         '@prefix : <#>.\n' +
         '<a> <b> <c> <g>.\n' +
         ':d :e :f :g.',
         [fromId('a'), fromId('b'), fromId('c'), fromId('g')],
         [fromId('#d'), fromId('#e'), fromId('#f'), fromId('#g')]));
+
+    it('should keep empty IRIs',
+      shouldParse(parser,
+        '@prefix : <>.\n' +
+        '<> <> <> <>.\n' +
+        ': : : :.',
+        [new NamedNode(''), new NamedNode(''), new NamedNode(''), new NamedNode('')],
+        [new NamedNode(''), new NamedNode(''), new NamedNode(''), new NamedNode('')]));
   });
 
   describe('An Parser instance with a document IRI', function () {


### PR DESCRIPTION
#182 added support for relative IRIs, but it doesn't cover the case where the IRI is empty. An error was thrown, that the IRI was invalid. This PR fixes the problem by:

- use `null` and not an empty string for invalid IRIs
- adding a test case for empty relative IRIs

From my point of view using `null` for invalid IRIs makes it more clear that something is wrong. So this PR could be also seen as a very small refactoring with the side effect of supporting empty relative IRIs :-)