### PR TITLE
Replace setImmediate with setTimeout

### DIFF
--- a/src/N3Lexer.js
+++ b/src/N3Lexer.js
@@ -437,7 +437,7 @@ export default class N3Lexer {
       this._input = input;
       // If a callback was passed, asynchronously call it
       if (typeof callback === 'function')
-        setImmediate(function () { self._tokenizeToEnd(callback, true); });
+        setTimeout(function () { self._tokenizeToEnd(callback, true); }, 0);
       // If no callback was passed, tokenize synchronously and return
       else {
         var tokens = [], error;

--- a/test/N3Lexer-test.js
+++ b/test/N3Lexer-test.js
@@ -1014,16 +1014,13 @@ function shouldNotTokenize(lexer, input, expectedError) {
   };
 }
 
-var immediately = typeof setImmediate === 'function' ? setImmediate :
-                  function setImmediate(func) { setTimeout(func, 0); };
-
 function streamOf() {
   var elements = Array.prototype.slice.call(arguments),
       stream = new EventEmitter();
 
   stream.setEncoding = function (encoding) {
     if (encoding === 'utf8')
-      immediately(next, 0);
+      setTimeout(function () { next(0); }, 0);
   };
 
   function next() {
@@ -1032,7 +1029,7 @@ function streamOf() {
       // use "null" to stall the stream
       if (element !== null) {
         stream.emit('data', element);
-        immediately(next, 0);
+        setTimeout(function () { next(0); }, 0);
       }
     }
     else {


### PR DESCRIPTION
It seems like [setImmediate](https://developer.mozilla.org/en-US/docs/Web/API/Window/setImmediate) is not recommended for production code. I found about this when I realized it isn't available in worker threads.

One approach would be to create a helper method, but given that it isn't used a lot in the project I think the best approach is just to use setTimeout.