### PR TITLE
Added RDF* support by extending Quad from Term

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -17,6 +17,8 @@ import {
   DefaultGraph,
   Quad,
   Triple,
+  escape,
+  unescape,
 
   termFromId,
   termToId,
@@ -41,6 +43,8 @@ export {
   DefaultGraph,
   Quad,
   Triple,
+  escape,
+  unescape,
 
   termFromId,
   termToId,

--- a/src/index.js
+++ b/src/index.js
@@ -17,8 +17,6 @@ import {
   DefaultGraph,
   Quad,
   Triple,
-  escape,
-  unescape,
 
   termFromId,
   termToId,
@@ -43,8 +41,6 @@ export {
   DefaultGraph,
   Quad,
   Triple,
-  escape,
-  unescape,
 
   termFromId,
   termToId,

--- a/test/N3DataFactory-test.js
+++ b/test/N3DataFactory-test.js
@@ -130,6 +130,54 @@ describe('DataFactory', function () {
       ));
     });
 
+    it('should return a nested quad', function () {
+      DataFactory.quad(
+        new Quad(
+          new NamedNode('http://ex.org/a'),
+          new NamedNode('http://ex.org/b'),
+          new Literal('abc'),
+          new NamedNode('http://ex.org/d')
+        ),
+        new NamedNode('http://ex.org/b'),
+        new Literal('abc'),
+        new NamedNode('http://ex.org/d')
+      ).should.deep.equal(new Quad(
+        new Quad(
+          new NamedNode('http://ex.org/a'),
+          new NamedNode('http://ex.org/b'),
+          new Literal('abc'),
+          new NamedNode('http://ex.org/d')
+        ),
+        new NamedNode('http://ex.org/b'),
+        new Literal('abc'),
+        new NamedNode('http://ex.org/d')
+      ));
+    });
+
+    it('should return a nested quad', function () {
+      DataFactory.quad(
+        new NamedNode('http://ex.org/a'),
+        new NamedNode('http://ex.org/b'),
+        new Literal('abc'),
+        new Quad(
+          new NamedNode('http://ex.org/a'),
+          new NamedNode('http://ex.org/b'),
+          new Literal('abc'),
+          new NamedNode('http://ex.org/d')
+        )
+      ).should.deep.equal(new Quad(
+        new NamedNode('http://ex.org/a'),
+        new NamedNode('http://ex.org/b'),
+        new Literal('abc'),
+        new Quad(
+          new NamedNode('http://ex.org/a'),
+          new NamedNode('http://ex.org/b'),
+          new Literal('abc'),
+          new NamedNode('http://ex.org/d')
+        )
+      ));
+    });
+
     it('without graph parameter returns a quad in the default graph', function () {
       DataFactory.quad(
         new NamedNode('http://ex.org/a'),

--- a/test/Quad-test.js
+++ b/test/Quad-test.js
@@ -1,4 +1,4 @@
-import { Quad, Triple, DefaultGraph, termFromId } from '../src/';
+import { Quad, Triple, DefaultGraph, termFromId, Term } from '../src/';
 
 describe('Quad', function () {
   describe('The Quad module', function () {
@@ -27,6 +27,14 @@ describe('Quad', function () {
 
     it('should be a Quad', function () {
       quad.should.be.an.instanceof(Quad);
+    });
+
+    it('should be a Term', function () {
+      quad.should.be.an.instanceof(Term);
+    });
+
+    it('should have the correct termType', function () {
+      quad.termType.should.equal('Quad');
     });
 
     it('should have the correct subject', function () {
@@ -115,6 +123,14 @@ describe('Quad', function () {
       quad.should.be.an.instanceof(Quad);
     });
 
+    it('should be a Term', function () {
+      quad.should.be.an.instanceof(Term);
+    });
+
+    it('should have the correct termType', function () {
+      quad.termType.should.equal('Quad');
+    });
+
     it('should have the correct subject', function () {
       quad.subject.should.equal(subject);
     });
@@ -182,6 +198,107 @@ describe('Quad', function () {
         predicate: { termType: 'NamedNode', value: 'p' },
         object:    { termType: 'NamedNode', value: 'o' },
         graph:     { termType: 'NamedNode', value: 'g' },
+      });
+    });
+  });
+
+  describe('A Quad instance with nested quads', function () {
+    var quad, subject, predicate, object;
+    before(function () {
+      quad = new Quad(
+        subject   = termFromId('<<_:n3-123 ?var-a ?var-b _:n3-000>>'),
+        predicate = termFromId('p'),
+        object    = termFromId('<<http://ex.org/a http://ex.org/b http://ex.org/c>>')
+      );
+    });
+
+    it('should be a Quad', function () {
+      quad.should.be.an.instanceof(Quad);
+    });
+
+    it('should be a Term', function () {
+      quad.should.be.an.instanceof(Term);
+    });
+
+    it('should have the correct termType', function () {
+      quad.termType.should.equal('Quad');
+    });
+
+    it('should have the correct subject', function () {
+      quad.subject.should.equal(subject);
+    });
+
+    it('should have the correct predicate', function () {
+      quad.predicate.should.equal(predicate);
+    });
+
+    it('should have the correct object', function () {
+      quad.object.should.equal(object);
+    });
+
+    it('should have the default graph', function () {
+      quad.graph.should.equal(new DefaultGraph());
+    });
+
+    it('should equal a quad with the same components', function () {
+      quad.equals({
+        subject:   subject,
+        predicate: predicate,
+        object:    object,
+        graph:     new DefaultGraph(),
+      }).should.be.true;
+    });
+
+    it('should not equal a quad with a different subject', function () {
+      quad.equals({
+        termType: 'Quad',
+        value: '',
+        subject:   termFromId('x'),
+        predicate: predicate,
+        object:    object,
+        graph:     new DefaultGraph(),
+      }).should.be.false;
+    });
+
+    it('should not equal a quad with a different predicate', function () {
+      quad.equals({
+        termType: 'Quad',
+        value: '',
+        subject:   subject,
+        predicate: termFromId('x'),
+        object:    object,
+        graph:     new DefaultGraph(),
+      }).should.be.false;
+    });
+
+    it('should not equal a quad with a different object', function () {
+      quad.equals({
+        termType: 'Quad',
+        value: '',
+        subject:   subject,
+        predicate: predicate,
+        object:    termFromId('x'),
+        graph:     new DefaultGraph(),
+      }).should.be.false;
+    });
+
+    it('should not equal a quad with a different graph', function () {
+      quad.equals({
+        termType: 'Quad',
+        value: '',
+        subject:   subject,
+        predicate: predicate,
+        object:    object,
+        graph:     termFromId('x'),
+      }).should.be.false;
+    });
+
+    it('should provide a JSON representation', function () {
+      quad.toJSON().should.deep.equal({
+        subject:   termFromId('<<_:n3-123 ?var-a ?var-b _:n3-000>>').toJSON(),
+        predicate: { termType: 'NamedNode', value: 'p' },
+        object:    termFromId('<<http://ex.org/a http://ex.org/b http://ex.org/c>>').toJSON(),
+        graph:     { termType: 'DefaultGraph', value: '' },
       });
     });
   });

--- a/test/Term-test.js
+++ b/test/Term-test.js
@@ -10,7 +10,10 @@ import {
   termFromId,
 } from '../src/';
 
-import { escape, unescape } from '../src/N3DataFactory';
+import {
+  escapeQuotes,
+  unescapeQuotes,
+} from '../src/N3DataFactory';
 
 describe('Term', function () {
   describe('The Term module', function () {
@@ -474,40 +477,40 @@ describe('Term', function () {
     });
   });
 
-  describe('escape', function () {
+  describe('escaping', function () {
     it('should unescape an escaped string correctly', function () {
       let id = '"Hello ""World"""@en-us';
-      unescape(id).should.equal('"Hello "World""@en-us');
+      unescapeQuotes(id).should.equal('"Hello "World""@en-us');
     });
 
     it('should escape an unescaped string correctly', function () {
       let id = '"Hello "World""@en-us';
-      escape(id).should.equal('"Hello ""World"""@en-us');
+      escapeQuotes(id).should.equal('"Hello ""World"""@en-us');
     });
 
     it('should not change an unescaped string', function () {
       let id = '"Hello "World""@en-us';
-      unescape(id).should.equal(id);
+      unescapeQuotes(id).should.equal(id);
     });
 
     it('should not change a string without quotes', function () {
       let id = '"Hello World"@en-us';
-      escape(id).should.equal(id);
+      escapeQuotes(id).should.equal(id);
     });
 
     it('should not change a blank node', function () {
       let id = '_:b1';
-      escape(id).should.equal(id);
+      escapeQuotes(id).should.equal(id);
     });
 
     it('should not change a variable', function () {
       let id = '?v1';
-      escape(id).should.equal(id);
+      escapeQuotes(id).should.equal(id);
     });
 
     it('should not change the empty string', function () {
       let id = '';
-      escape(id).should.equal(id);
+      escapeQuotes(id).should.equal(id);
     });
   });
 });

--- a/test/Term-test.js
+++ b/test/Term-test.js
@@ -8,9 +8,9 @@ import {
   Quad,
   termToId,
   termFromId,
-  unescape,
-  escape,
 } from '../src/';
+
+import { escape, unescape } from '../src/N3DataFactory';
 
 describe('Term', function () {
   describe('The Term module', function () {


### PR DESCRIPTION
This PR implements RDF* on the data level. The changes include:
- Additional tests
- Make Quad extend Term
- Added the field 'value' to Quad which has the empty string as its value
- Added the field 'termtype' to Quad which has the value 'Quad'
- Updates to the termFromId and termToId methods that allow conversion from RDF* objects to string and back.