### PR TITLE
Added parsing for RDF* syntax

### DIFF
--- a/src/N3Lexer.js
+++ b/src/N3Lexer.js
@@ -39,9 +39,9 @@ export default class N3Lexer {
     this._simpleApostropheString = /^'([^'\\\r\n]*)'(?=[^'])/;
     this._langcode = /^@([a-z]+(?:-[a-z0-9]+)*)(?=[^a-z0-9\-])/i;
     this._prefix = /^((?:[A-Za-z\xc0-\xd6\xd8-\xf6\xf8-\u02ff\u0370-\u037d\u037f-\u1fff\u200c\u200d\u2070-\u218f\u2c00-\u2fef\u3001-\ud7ff\uf900-\ufdcf\ufdf0-\ufffd]|[\ud800-\udb7f][\udc00-\udfff])(?:\.?[\-0-9A-Z_a-z\xb7\xc0-\xd6\xd8-\xf6\xf8-\u037d\u037f-\u1fff\u200c\u200d\u203f\u2040\u2070-\u218f\u2c00-\u2fef\u3001-\ud7ff\uf900-\ufdcf\ufdf0-\ufffd]|[\ud800-\udb7f][\udc00-\udfff])*)?:(?=[#\s<])/;
-    this._prefixed = /^((?:[A-Za-z\xc0-\xd6\xd8-\xf6\xf8-\u02ff\u0370-\u037d\u037f-\u1fff\u200c\u200d\u2070-\u218f\u2c00-\u2fef\u3001-\ud7ff\uf900-\ufdcf\ufdf0-\ufffd]|[\ud800-\udb7f][\udc00-\udfff])(?:\.?[\-0-9A-Z_a-z\xb7\xc0-\xd6\xd8-\xf6\xf8-\u037d\u037f-\u1fff\u200c\u200d\u203f\u2040\u2070-\u218f\u2c00-\u2fef\u3001-\ud7ff\uf900-\ufdcf\ufdf0-\ufffd]|[\ud800-\udb7f][\udc00-\udfff])*)?:((?:(?:[0-:A-Z_a-z\xc0-\xd6\xd8-\xf6\xf8-\u02ff\u0370-\u037d\u037f-\u1fff\u200c\u200d\u2070-\u218f\u2c00-\u2fef\u3001-\ud7ff\uf900-\ufdcf\ufdf0-\ufffd]|[\ud800-\udb7f][\udc00-\udfff]|%[0-9a-fA-F]{2}|\\[!#-\/;=?\-@_~])(?:(?:[\.\-0-:A-Z_a-z\xb7\xc0-\xd6\xd8-\xf6\xf8-\u037d\u037f-\u1fff\u200c\u200d\u203f\u2040\u2070-\u218f\u2c00-\u2fef\u3001-\ud7ff\uf900-\ufdcf\ufdf0-\ufffd]|[\ud800-\udb7f][\udc00-\udfff]|%[0-9a-fA-F]{2}|\\[!#-\/;=?\-@_~])*(?:[\-0-:A-Z_a-z\xb7\xc0-\xd6\xd8-\xf6\xf8-\u037d\u037f-\u1fff\u200c\u200d\u203f\u2040\u2070-\u218f\u2c00-\u2fef\u3001-\ud7ff\uf900-\ufdcf\ufdf0-\ufffd]|[\ud800-\udb7f][\udc00-\udfff]|%[0-9a-fA-F]{2}|\\[!#-\/;=?\-@_~]))?)?)(?:[ \t]+|(?=\.?[,;!\^\s#()\[\]\{\}"'<]))/;
+    this._prefixed = /^((?:[A-Za-z\xc0-\xd6\xd8-\xf6\xf8-\u02ff\u0370-\u037d\u037f-\u1fff\u200c\u200d\u2070-\u218f\u2c00-\u2fef\u3001-\ud7ff\uf900-\ufdcf\ufdf0-\ufffd]|[\ud800-\udb7f][\udc00-\udfff])(?:\.?[\-0-9A-Z_a-z\xb7\xc0-\xd6\xd8-\xf6\xf8-\u037d\u037f-\u1fff\u200c\u200d\u203f\u2040\u2070-\u218f\u2c00-\u2fef\u3001-\ud7ff\uf900-\ufdcf\ufdf0-\ufffd]|[\ud800-\udb7f][\udc00-\udfff])*)?:((?:(?:[0-:A-Z_a-z\xc0-\xd6\xd8-\xf6\xf8-\u02ff\u0370-\u037d\u037f-\u1fff\u200c\u200d\u2070-\u218f\u2c00-\u2fef\u3001-\ud7ff\uf900-\ufdcf\ufdf0-\ufffd]|[\ud800-\udb7f][\udc00-\udfff]|%[0-9a-fA-F]{2}|\\[!#-\/;=?\-@_~])(?:(?:[\.\-0-:A-Z_a-z\xb7\xc0-\xd6\xd8-\xf6\xf8-\u037d\u037f-\u1fff\u200c\u200d\u203f\u2040\u2070-\u218f\u2c00-\u2fef\u3001-\ud7ff\uf900-\ufdcf\ufdf0-\ufffd]|[\ud800-\udb7f][\udc00-\udfff]|%[0-9a-fA-F]{2}|\\[!#-\/;=?\-@_~])*(?:[\-0-:A-Z_a-z\xb7\xc0-\xd6\xd8-\xf6\xf8-\u037d\u037f-\u1fff\u200c\u200d\u203f\u2040\u2070-\u218f\u2c00-\u2fef\u3001-\ud7ff\uf900-\ufdcf\ufdf0-\ufffd]|[\ud800-\udb7f][\udc00-\udfff]|%[0-9a-fA-F]{2}|\\[!#-\/;=?\-@_~]))?)?)(?:[ \t]+|(?=\.?[,;!\^\s#()\[\]\{\}"'<>]))/;
     this._variable = /^\?(?:(?:[A-Z_a-z\xc0-\xd6\xd8-\xf6\xf8-\u02ff\u0370-\u037d\u037f-\u1fff\u200c\u200d\u2070-\u218f\u2c00-\u2fef\u3001-\ud7ff\uf900-\ufdcf\ufdf0-\ufffd]|[\ud800-\udb7f][\udc00-\udfff])(?:[\-0-:A-Z_a-z\xb7\xc0-\xd6\xd8-\xf6\xf8-\u037d\u037f-\u1fff\u200c\u200d\u203f\u2040\u2070-\u218f\u2c00-\u2fef\u3001-\ud7ff\uf900-\ufdcf\ufdf0-\ufffd]|[\ud800-\udb7f][\udc00-\udfff])*)(?=[.,;!\^\s#()\[\]\{\}"'<])/;
-    this._blank = /^_:((?:[0-9A-Z_a-z\xc0-\xd6\xd8-\xf6\xf8-\u02ff\u0370-\u037d\u037f-\u1fff\u200c\u200d\u2070-\u218f\u2c00-\u2fef\u3001-\ud7ff\uf900-\ufdcf\ufdf0-\ufffd]|[\ud800-\udb7f][\udc00-\udfff])(?:\.?[\-0-9A-Z_a-z\xb7\xc0-\xd6\xd8-\xf6\xf8-\u037d\u037f-\u1fff\u200c\u200d\u203f\u2040\u2070-\u218f\u2c00-\u2fef\u3001-\ud7ff\uf900-\ufdcf\ufdf0-\ufffd]|[\ud800-\udb7f][\udc00-\udfff])*)(?:[ \t]+|(?=\.?[,;:\s#()\[\]\{\}"'<]))/;
+    this._blank = /^_:((?:[0-9A-Z_a-z\xc0-\xd6\xd8-\xf6\xf8-\u02ff\u0370-\u037d\u037f-\u1fff\u200c\u200d\u2070-\u218f\u2c00-\u2fef\u3001-\ud7ff\uf900-\ufdcf\ufdf0-\ufffd]|[\ud800-\udb7f][\udc00-\udfff])(?:\.?[\-0-9A-Z_a-z\xb7\xc0-\xd6\xd8-\xf6\xf8-\u037d\u037f-\u1fff\u200c\u200d\u203f\u2040\u2070-\u218f\u2c00-\u2fef\u3001-\ud7ff\uf900-\ufdcf\ufdf0-\ufffd]|[\ud800-\udb7f][\udc00-\udfff])*)(?:[ \t]+|(?=\.?[,;:\s#()\[\]\{\}"'<>]))/;
     this._number = /^[\-+]?(?:(\d+\.\d*|\.?\d+)[eE][\-+]?|\d*(\.)?)\d+(?=\.?[,;:\s#()\[\]\{\}"'<])/;
     this._boolean = /^(?:true|false)(?=[.,;\s#()\[\]\{\}"'<])/;
     this._keyword = /^@[a-z]+(?=[\s#<:])/i;
@@ -143,9 +143,17 @@ export default class N3Lexer {
             return reportSyntaxError(this);
           type = 'IRI';
         }
+        // Try to find a nested triple
+        else if (input.length > 1 && input[1] === '<')
+          type = '<<', matchLength = 2;
         // Try to find a backwards implication arrow
         else if (this._n3Mode && input.length > 1 && input[1] === '=')
           type = 'inverse', matchLength = 2, value = '>';
+        break;
+
+      case '>':
+        if (input.length > 1 && input[1] === '>')
+          type = '>>', matchLength = 2;
         break;
 
       case '_':

--- a/src/N3Parser.js
+++ b/src/N3Parser.js
@@ -25,7 +25,9 @@ export default class N3Parser {
         isLineMode = isNTriples || isNQuads;
     if (!(this._supportsNamedGraphs = !(isTurtle || isN3)))
       this._readPredicateOrNamedGraph = this._readPredicate;
+    // Support triples in other graphs
     this._supportsQuads = !(isTurtle || isTriG || isNTriples || isN3);
+    // Support nesting of triples
     this._supportsRDFStar = format === '' || /star|\*$/.test(format);
     // Disable relative IRIs in N-Triples or N-Quads mode
     if (isLineMode)

--- a/src/N3Parser.js
+++ b/src/N3Parser.js
@@ -232,16 +232,11 @@ export default class N3Parser {
 
       break;
     case '<<':
-      if (!this._supportsRDFStar) {
-        this._error(`${token.type} is not allowed in this format`, token);
-      }
-      else {
-        // Start a new nested triple
-        this._saveContext('<<', this._graph, null, null, null);
-        this._graph = null;
-        // Read the subject
-        return this._readSubject;
-      }
+      if (!this._supportsRDFStar)
+        return this._error('Unexpected RDF* syntax', token);
+      this._saveContext('<<', this._graph, null, null, null);
+      this._graph = null;
+      return this._readSubject;
     default:
       // Read the subject entity
       if ((this._subject = this._readEntity(token)) === undefined)
@@ -319,16 +314,11 @@ export default class N3Parser {
                         this._graph = this._blankNode());
       return this._readSubject;
     case '<<':
-      if (!this._supportsRDFStar) {
-        this._error(`${token.type} is not allowed in this format`, token);
-      }
-      else {
-        // Start a new nested triple
-        this._saveContext('<<', this._graph, this._subject, this._predicate, null);
-        this._graph = null;
-        // Read the object
-        return this._readSubject;
-      }
+      if (!this._supportsRDFStar)
+        return this._error('Unexpected RDF* syntax', token);
+      this._saveContext('<<', this._graph, this._subject, this._predicate, null);
+      this._graph = null;
+      return this._readSubject;
     default:
       // Read the object entity
       if ((this._object = this._readEntity(token)) === undefined)
@@ -831,34 +821,29 @@ export default class N3Parser {
   _readRDFStarTailOrGraph(token) {
     if (token.type !== '>>') {
       // An entity means this is a quad (only allowed if not already inside a graph)
-      if (this._supportsQuads && this._graph === null && (this._graph = this._readEntity(token)) !== undefined) {
-        // continue by reading '>>'
+      if (this._supportsQuads && this._graph === null && (this._graph = this._readEntity(token)) !== undefined)
         return this._readRDFStarTail;
-      }
       return this._error('Expected >> to follow "' + this._object.id + '"', token);
     }
-    else {
-      return this._readRDFStarTail(token);
-    }
+    return this._readRDFStarTail(token);
   }
 
   // ### `_readRDFStarTail` reads the end of a nested RDF* triple
   _readRDFStarTail(token) {
     if (token.type !== '>>')
       return this._error(`Expected >> but got ${token.type}`, token);
-
-    // Get the triples value
-    let value = this._quad(this._subject, this._predicate, this._object, this._graph || this.DEFAULTGRAPH);
-    // Restore the parent context containing this formula
+    // Read the quad and restore the previous context
+    const quad = this._quad(this._subject, this._predicate, this._object,
+      this._graph || this.DEFAULTGRAPH);
     this._restoreContext();
     // If the triple was the subject, continue by reading the predicate.
     if (this._subject === null) {
-      this._subject = value;
+      this._subject = quad;
       return this._readPredicate;
     }
+    // If the triple was the object, read context end.
     else {
-      // If the triple was the object, read context end.
-      this._object = value;
+      this._object = quad;
       return this._getContextEndReader();
     }
   }

--- a/test/N3Parser-test.js
+++ b/test/N3Parser-test.js
@@ -941,7 +941,7 @@ describe('Parser', function () {
 
     it('should not parse nested RDF* statements that are partially closed',
       shouldNotParse('<d> <e> <<<<<a> <b> <c>>> <f> <g>.',
-        'Expected >> but got . on line 1.'
+        'Expected entity but got . on line 1.'
       ));
 
     it('should not parse partially closed nested RDF* statements',
@@ -983,6 +983,29 @@ describe('Parser', function () {
       shouldNotParse('<<<a> <b> <c>>>.',
         'Unexpected . on line 1.'
       ));
+
+    it('should parse an RDF* quad',
+      shouldParse('<<<a> <b> <c> <d>>> <a> <b> .',
+        [['a', 'b', 'c', 'd'], 'a', 'b']));
+
+    it('should not parse a malformed RDF* quad',
+      shouldNotParse('<<<a> <b> <c> <d> <e>>> <a> <b> .',
+        'Expected >> but got IRI on line 1.'));
+
+    it('should parse statements with a shared RDF* subject',
+      shouldParse('<<<a> <b> <c>>> <b> <c>;\n<d> <c>.',
+        [['a', 'b', 'c'], 'b', 'c'],
+        [['a', 'b', 'c'], 'd', 'c']));
+
+    it('should parse statements with a shared RDF* subject',
+      shouldParse('<<<a> <b> <c>>> <b> <c>;\n<d> <<<a> <b> <c>>>.',
+        [['a', 'b', 'c'], 'b', 'c'],
+        [['a', 'b', 'c'], 'd', ['a', 'b', 'c']]));
+
+    it('should put nested triples in the default graph',
+      shouldParse('<a> <b> <c> <g>.\n<<<a> <b> <c>>> <d> <e>.',
+          ['a', 'b', 'c', 'g'],
+          [['a', 'b', 'c'], 'd', 'e']));
   });
 
   describe('An Parser instance without document IRI', function () {
@@ -1158,6 +1181,10 @@ describe('Parser', function () {
     it('should not parse a literal as subject',
       shouldNotParse(parser, '1 <a> <b>.',
         'Unexpected literal on line 1.'));
+
+    it('should not parse nested quads',
+      shouldNotParse(parser, '<<<a> <b> <c> <d>>> <a> <b> .',
+        'Expected >> to follow "http://example.org/c" on line 1.'));
   });
 
   describe('A Parser instance for the TriG format', function () {
@@ -1198,6 +1225,10 @@ describe('Parser', function () {
 
     it('should not parse @forAll',
       shouldNotParse(parser, '@forAll <x>.', 'Unexpected "@forAll" on line 1.'));
+
+    it('should not parse nested quads',
+      shouldNotParse(parser, '<<<a> <b> <c> <d>>> <a> <b> .',
+        'Expected >> to follow "http://example.org/c" on line 1.'));
   });
 
   describe('A Parser instance for the N-Triples format', function () {
@@ -1249,6 +1280,10 @@ describe('Parser', function () {
 
     it('should not parse @forAll',
       shouldNotParse(parser, '@forAll <x>.', 'Unexpected "@forAll" on line 1.'));
+
+    it('should not parse nested quads',
+      shouldNotParse(parser, '<<_:a <http://ex.org/b> _:b <http://ex.org/b>>> <http://ex.org/b> "c" .',
+        'Expected >> to follow "_:b0_b" on line 1.'));
   });
 
   describe('A Parser instance for the N-Quads format', function () {
@@ -1619,6 +1654,10 @@ describe('Parser', function () {
             ['a', 'b', '_:b0'],
             ['"bonjour"@fr', 'sameAs', '"hello"@en', '_:b0']
         ));
+
+    it('should not parse nested quads',
+      shouldNotParse(parser, '<<<a> <b> <c> <d>>> <a> <b> .',
+        'Expected >> to follow "http://example.org/c" on line 1.'));
   });
 
   describe('A Parser instance for the N3 format with the explicitQuantifiers option', function () {

--- a/test/N3Parser-test.js
+++ b/test/N3Parser-test.js
@@ -1182,13 +1182,13 @@ describe('Parser', function () {
       shouldNotParse(parser, '1 <a> <b>.',
         'Unexpected literal on line 1.'));
 
-    it('should not parse RDF*',
+    it('should not parse RDF* in the subject position',
       shouldNotParse(parser, '<<<a> <b> <c>>> <a> <b> .',
-        '<< is not allowed in this format on line 1.'));
+        'Unexpected RDF* syntax on line 1.'));
 
-    it('should not parse RDF*',
+    it('should not parse RDF* in the object position',
       shouldNotParse(parser, '<a> <b> <<a> <b> <c>>>.',
-        '<< is not allowed in this format on line 1.'));
+        'Unexpected RDF* syntax on line 1.'));
   });
 
   describe('A Parser instance for the TurtleStar format', function () {
@@ -1243,13 +1243,13 @@ describe('Parser', function () {
     it('should not parse @forAll',
       shouldNotParse(parser, '@forAll <x>.', 'Unexpected "@forAll" on line 1.'));
 
-    it('should not parse RDF*',
+    it('should not parse RDF* in the subject position',
       shouldNotParse(parser, '<<<a> <b> <c>>> <a> <b> .',
-        '<< is not allowed in this format on line 1.'));
+        'Unexpected RDF* syntax on line 1.'));
 
-    it('should not parse RDF*',
+    it('should not parse RDF* in the object position',
       shouldNotParse(parser, '<a> <b> <<<a> <b> <c>>>.',
-        '<< is not allowed in this format on line 1.'));
+        'Unexpected RDF* syntax on line 1.'));
   });
 
   describe('A Parser instance for the TriGStar format', function () {
@@ -1314,13 +1314,13 @@ describe('Parser', function () {
     it('should not parse @forAll',
       shouldNotParse(parser, '@forAll <x>.', 'Unexpected "@forAll" on line 1.'));
 
-    it('should not parse RDF*',
+    it('should not parse RDF* in the subject position',
       shouldNotParse(parser, '<<<a> <b> <c>>> <a> <b> .',
-        '<< is not allowed in this format on line 1.'));
+        'Unexpected RDF* syntax on line 1.'));
 
-    it('should not parse RDF*',
+    it('should not parse RDF* in the object position',
       shouldNotParse(parser, '<http://ex.org/a> <http://ex.org/b> <<<a> <b> <c>>>.',
-        '<< is not allowed in this format on line 1.'));
+        'Unexpected RDF* syntax on line 1.'));
   });
 
   describe('A Parser instance for the N-TriplesStar format', function () {
@@ -1373,13 +1373,13 @@ describe('Parser', function () {
     it('should not parse @forAll',
       shouldNotParse(parser, '@forAll <x>.', 'Unexpected "@forAll" on line 1.'));
 
-    it('should not parse RDF*',
+    it('should not parse RDF* in the subject position',
       shouldNotParse(parser, '<<<a> <b> <c>>> <a> <b> .',
-        '<< is not allowed in this format on line 1.'));
+        'Unexpected RDF* syntax on line 1.'));
 
-    it('should not parse RDF*',
+    it('should not parse RDF* in the object position',
       shouldNotParse(parser, '_:a <http://ex.org/b> <<<a> <b> <c>>>.',
-        '<< is not allowed in this format on line 1.'));
+        'Unexpected RDF* syntax on line 1.'));
   });
 
   describe('A Parser instance for the N-QuadsStar format', function () {
@@ -1720,13 +1720,13 @@ describe('Parser', function () {
             ['"bonjour"@fr', 'sameAs', '"hello"@en', '_:b0']
         ));
 
-    it('should not parse RDF*',
+    it('should not parse RDF* in the subject position',
       shouldNotParse(parser, '<<<a> <b> <c>>> <a> <b> .',
-        '<< is not allowed in this format on line 1.'));
+        'Unexpected RDF* syntax on line 1.'));
 
-    it('should not parse RDF*',
+    it('should not parse RDF* in the object position',
       shouldNotParse(parser, '<a> <b> <<<a> <b> <c>>>.',
-        '<< is not allowed in this format on line 1.'));
+        'Unexpected RDF* syntax on line 1.'));
   });
 
   describe('A Parser instance for the N3Star format', function () {

--- a/test/N3Parser-test.js
+++ b/test/N3Parser-test.js
@@ -1182,9 +1182,26 @@ describe('Parser', function () {
       shouldNotParse(parser, '1 <a> <b>.',
         'Unexpected literal on line 1.'));
 
+    it('should not parse RDF*',
+      shouldNotParse(parser, '<<<a> <b> <c>>> <a> <b> .',
+        '<< is not allowed in this format on line 1.'));
+
+    it('should not parse RDF*',
+      shouldNotParse(parser, '<a> <b> <<a> <b> <c>>>.',
+        '<< is not allowed in this format on line 1.'));
+  });
+
+  describe('A Parser instance for the TurtleStar format', function () {
+    function parser() { return new Parser({ baseIRI: BASE_IRI, format: 'TurtleStar' }); }
+
+    it('should parse RDF*',
+      shouldParse(parser,
+        '<<<a> <b> <c>>> <b> <c> .',
+        [['a', 'b', 'c'], 'b', 'c']));
+
     it('should not parse nested quads',
-      shouldNotParse(parser, '<<<a> <b> <c> <d>>> <a> <b> .',
-        'Expected >> to follow "http://example.org/c" on line 1.'));
+      shouldNotParse(parser, '<<_:a <http://ex.org/b> _:b <http://ex.org/b>>> <http://ex.org/b> "c" .',
+        'Expected >> to follow "_:b0_b" on line 1.'));
   });
 
   describe('A Parser instance for the TriG format', function () {
@@ -1226,9 +1243,25 @@ describe('Parser', function () {
     it('should not parse @forAll',
       shouldNotParse(parser, '@forAll <x>.', 'Unexpected "@forAll" on line 1.'));
 
+    it('should not parse RDF*',
+      shouldNotParse(parser, '<<<a> <b> <c>>> <a> <b> .',
+        '<< is not allowed in this format on line 1.'));
+
+    it('should not parse RDF*',
+      shouldNotParse(parser, '<a> <b> <<<a> <b> <c>>>.',
+        '<< is not allowed in this format on line 1.'));
+  });
+
+  describe('A Parser instance for the TriGStar format', function () {
+    function parser() { return new Parser({ baseIRI: BASE_IRI, format: 'TriGStar' }); }
+
+    it('should parse RDF*',
+      shouldParse(parser, '<<<a> <b> <c>>> <a> <b> .',
+        [['a', 'b', 'c'], 'a', 'b']));
+
     it('should not parse nested quads',
-      shouldNotParse(parser, '<<<a> <b> <c> <d>>> <a> <b> .',
-        'Expected >> to follow "http://example.org/c" on line 1.'));
+      shouldNotParse(parser, '<<_:a <http://ex.org/b> _:b <http://ex.org/b>>> <http://ex.org/b> "c" .',
+        'Expected >> to follow "_:b0_b" on line 1.'));
   });
 
   describe('A Parser instance for the N-Triples format', function () {
@@ -1281,6 +1314,22 @@ describe('Parser', function () {
     it('should not parse @forAll',
       shouldNotParse(parser, '@forAll <x>.', 'Unexpected "@forAll" on line 1.'));
 
+    it('should not parse RDF*',
+      shouldNotParse(parser, '<<<a> <b> <c>>> <a> <b> .',
+        '<< is not allowed in this format on line 1.'));
+
+    it('should not parse RDF*',
+      shouldNotParse(parser, '<http://ex.org/a> <http://ex.org/b> <<<a> <b> <c>>>.',
+        '<< is not allowed in this format on line 1.'));
+  });
+
+  describe('A Parser instance for the N-TriplesStar format', function () {
+    function parser() { return new Parser({ baseIRI: BASE_IRI, format: 'N-TriplesStar' }); }
+
+    it('should parse RDF*',
+      shouldParse(parser, '<<_:a <http://example.org/b> _:c>> <http://example.org/a> _:b .',
+        [['_:b0_a', 'b', '_:b0_c'], 'a', '_:b0_b']));
+
     it('should not parse nested quads',
       shouldNotParse(parser, '<<_:a <http://ex.org/b> _:b <http://ex.org/b>>> <http://ex.org/b> "c" .',
         'Expected >> to follow "_:b0_b" on line 1.'));
@@ -1323,6 +1372,22 @@ describe('Parser', function () {
 
     it('should not parse @forAll',
       shouldNotParse(parser, '@forAll <x>.', 'Unexpected "@forAll" on line 1.'));
+
+    it('should not parse RDF*',
+      shouldNotParse(parser, '<<<a> <b> <c>>> <a> <b> .',
+        '<< is not allowed in this format on line 1.'));
+
+    it('should not parse RDF*',
+      shouldNotParse(parser, '_:a <http://ex.org/b> <<<a> <b> <c>>>.',
+        '<< is not allowed in this format on line 1.'));
+  });
+
+  describe('A Parser instance for the N-QuadsStar format', function () {
+    function parser() { return new Parser({ baseIRI: BASE_IRI, format: 'N-QuadsStar' }); }
+
+    it('should parse RDF*',
+      shouldParse(parser, '<<_:a <http://example.org/b> _:c>> <http://example.org/a> _:c .',
+        [['_:b0_a', 'b', '_:b0_c'], 'a', '_:b0_c']));
   });
 
   describe('A Parser instance for the N3 format', function () {
@@ -1655,9 +1720,25 @@ describe('Parser', function () {
             ['"bonjour"@fr', 'sameAs', '"hello"@en', '_:b0']
         ));
 
+    it('should not parse RDF*',
+      shouldNotParse(parser, '<<<a> <b> <c>>> <a> <b> .',
+        '<< is not allowed in this format on line 1.'));
+
+    it('should not parse RDF*',
+      shouldNotParse(parser, '<a> <b> <<<a> <b> <c>>>.',
+        '<< is not allowed in this format on line 1.'));
+  });
+
+  describe('A Parser instance for the N3Star format', function () {
+    function parser() { return new Parser({ baseIRI: BASE_IRI, format: 'N3Star' }); }
+
+    it('should parse RDF*',
+      shouldParse(parser, '<<<a> <b> <c>>> <a> <b> .',
+        [['a', 'b', 'c'], 'a', 'b']));
+
     it('should not parse nested quads',
-      shouldNotParse(parser, '<<<a> <b> <c> <d>>> <a> <b> .',
-        'Expected >> to follow "http://example.org/c" on line 1.'));
+      shouldNotParse(parser, '<<_:a <http://ex.org/b> _:b <http://ex.org/b>>> <http://ex.org/b> "c" .',
+        'Expected >> to follow "_:.b" on line 1.'));
   });
 
   describe('A Parser instance for the N3 format with the explicitQuantifiers option', function () {

--- a/test/N3Parser-test.js
+++ b/test/N3Parser-test.js
@@ -896,6 +896,93 @@ describe('Parser', function () {
       (function () { new Parser().parse('<a> <b> <c>'); })
       .should.throw('Expected entity but got eof on line 1');
     });
+
+    it('should parse an RDF* triple with a triple with iris as subject correctly', function () {
+      shouldParse('<<<a> <b> <c>>> <b> <c>.',
+        [['a', 'b', 'c'], 'b', 'c']);
+    });
+
+    it('should not parse an RDF* triple with a triple as predicate',
+      shouldNotParse('<a> <<<b> <c> <d>>> <e>',
+        'Expected entity but got << on line 1.'));
+
+    it('should parse an RDF* triple with a triple with blanknodes as subject correctly',
+      shouldParse('<<_:a <b> _:c>> <b> <c>.',
+        [['_:b0_a', 'b', '_:b0_c'], 'b', 'c']));
+
+    it('should parse an RDF* triple with a triple with blanknodes and literals as subject correctly',
+      shouldParse('<<_:a <b> "c"^^<d>>> <b> <c>.',
+        [['_:b0_a', 'b', '"c"^^http://example.org/d'], 'b', 'c']));
+
+    it('should parse an RDF* triple with a triple as object correctly',
+      shouldParse('<a> <b> <<<a> <b> <c>>>.',
+        ['a', 'b', ['a', 'b', 'c']]));
+
+    it('should parse an RDF* triple with a triple as object correctly',
+      shouldParse('<a> <b> <<_:a <b> _:c>>.',
+        ['a', 'b', ['_:b0_a', 'b', '_:b0_c']]));
+
+    it('should parse an RDF* triple with a triple as object correctly',
+      shouldParse('<a> <b> <<_:a <b> "c"^^<d>>>.',
+        ['a', 'b', ['_:b0_a', 'b', '"c"^^http://example.org/d']]));
+
+    it('should parse nested triples correctly',
+      shouldParse('<<<<<a> <b> <c>>> <f> <g>>> <d> <e>.',
+        [[['a', 'b', 'c'], 'f', 'g'], 'd', 'e']));
+    it('should parse nested triples correctly',
+      shouldParse('<d> <e> <<<f> <g> <<<a> <b> <c>>>>>.',
+        ['d', 'e', ['f', 'g', ['a', 'b', 'c']]]));
+    it('should parse nested triples correctly',
+      shouldParse('<<<f> <g> <<<a> <b> <c>>>>> <d> <e>.',
+        [['f', 'g', ['a', 'b', 'c']], 'd', 'e']));
+    it('should parse nested triples correctly',
+      shouldParse('<d> <e> <<<<<a> <b> <c>>> <f> <g>>>.',
+        ['d', 'e', [['a', 'b', 'c'], 'f', 'g']]));
+
+    it('should not parse nested RDF* statements that are partially closed',
+      shouldNotParse('<d> <e> <<<<<a> <b> <c>>> <f> <g>.',
+        'Expected >> but got . on line 1.'
+      ));
+
+    it('should not parse partially closed nested RDF* statements',
+      shouldNotParse('<d> <e> <<<<<a> <b> <c> <f> <g>>>.',
+        'Expected >> but got IRI on line 1.'
+      ));
+
+    it('should not parse nested RDF* statements with too many closing tags',
+      shouldNotParse('<d> <e> <<<<<a> <b> <c>>>>> <f> <g>>>.',
+        'Expected entity but got >> on line 1.'
+      ));
+
+    it('should not parse nested RDF* statements with too many closing tags',
+      shouldNotParse('<d> <e> <<<<<a> <b> <c>>> <f> <g>>>>>.',
+        'Expected entity but got >> on line 1.'
+      ));
+
+    it('should not parse RDF* statements with too many closing tags',
+      shouldNotParse('<a> <b> <c>>>.',
+        'Expected entity but got >> on line 1.'
+      ));
+
+    it('should not parse incomplete RDF* statements',
+      shouldNotParse('<d> <e> <<<a> <b>>>.',
+        'Expected entity but got >> on line 1.'
+      ));
+
+    it('should not parse incomplete RDF* statements',
+      shouldNotParse('<<<a> <b>>> <d> <e>.',
+        'Expected entity but got >> on line 1.'
+      ));
+
+    it('should not parse incorrectly nested RDF* statements',
+      shouldNotParse('>> <<',
+        'Expected entity but got >> on line 1.'
+      ));
+
+    it('should not parse a nested triple on its own',
+      shouldNotParse('<<<a> <b> <c>>>.',
+        'Unexpected . on line 1.'
+      ));
   });
 
   describe('An Parser instance without document IRI', function () {
@@ -2055,19 +2142,7 @@ function shouldParse(parser, input) {
 
   return function (done) {
     var results = [];
-    var items = expected.map(function (item) {
-      item = item.map(function (t) {
-        // don't touch if it's already an object
-        if (typeof t === 'object')
-          return t;
-
-        // Append base to relative IRIs
-        if (!/^$|^["?]|:/.test(t))
-          t = BASE_IRI + t;
-        return termFromId(t);
-      });
-      return new Quad(item[0], item[1], item[2], item[3]);
-    });
+    var items = expected.map(mapToQuad);
     new parser({ baseIRI: BASE_IRI }).parse(input, function (error, triple) {
       expect(error).not.to.exist;
       if (triple)
@@ -2076,6 +2151,23 @@ function shouldParse(parser, input) {
         toSortedJSON(results).should.equal(toSortedJSON(items)), done();
     });
   };
+}
+
+function mapToQuad(item) {
+  item = item.map(function (t) {
+    // recursively map content if it's an array
+    if (t instanceof Array)
+      t = mapToQuad(t);
+    // don't touch if it's already an object
+    if (typeof t === 'object')
+      return t;
+
+    // Append base to relative IRIs
+    if (!/^$|^["?]|:/.test(t))
+      t = BASE_IRI + t;
+    return termFromId(t);
+  });
+  return new Quad(item[0], item[1], item[2], item[3]);
 }
 
 function toSortedJSON(triples) {

--- a/test/N3Parser-test.js
+++ b/test/N3Parser-test.js
@@ -2155,15 +2155,12 @@ function shouldParse(parser, input) {
 
 function mapToQuad(item) {
   item = item.map(function (t) {
-    // recursively map content if it's an array
-    if (t instanceof Array)
-      t = mapToQuad(t);
     // don't touch if it's already an object
     if (typeof t === 'object')
-      return t;
-
+      // recursively map content if it's an array
+      return (t instanceof Array) ? mapToQuad(t) : t;
     // Append base to relative IRIs
-    if (!/^$|^["?]|:/.test(t))
+    else if (!/^$|^["?]|:/.test(t))
       t = BASE_IRI + t;
     return termFromId(t);
   });


### PR DESCRIPTION
- Added RDF* tests in N3Lexer-test.js
- Added RDF* tests in N3Parser-test.js
- Updated the lexer for RDF*
- Updated the parser for RDF*

This PR is based on the branch from PR #210, meaning that the changes from that PR are also listed as new changes. Those changes are:
- Additional tests for the data definitions
- Updates to the data definitions
- Updates to the termFromId and termToId methods that allow conversion from RDF* objects to string and back.

There are 2 use cases not covered by this implementation. I was not sure if they should be covered.
1)
Adding metadata over multiple triples like so:
`<<:bob foaf:age 23; foaf:knows "Mary">> creator "John" .`
2)
Quads within nested triples like so:
`<<:bob foaf:knows "Mary" graph_uri>> creator "John" .`
**Update:**
Added support for case 2: quads within nested triples. An example: `<<a b c d>> a b` will be parsed as well.