### PR TITLE
Extend writer for RDF* Quads

### DIFF
--- a/src/N3Writer.js
+++ b/src/N3Writer.js
@@ -130,12 +130,8 @@ export default class N3Writer {
 
   // ### `_encodeSubject` represents a subject
   _encodeSubject(entity) {
-    if (entity.termType === 'Quad') {
-      return `<<${this._encodeSubject(entity.subject)} ${this._encodePredicate(entity.predicate)} ${this._encodeObject(entity.object)}${isDefaultGraph(entity.graph) ? '' : ` ${this._encodeIriOrBlank(entity.graph)}`}>>`;
-    }
-    else {
-      return this._encodeIriOrBlank(entity);
-    }
+    return entity.termType === 'Quad' ?
+      this._encodeQuad(entity) : this._encodeIriOrBlank(entity);
   }
 
   // ### `_encodeIriOrBlank` represents an IRI or blank node
@@ -179,15 +175,23 @@ export default class N3Writer {
 
   // ### `_encodeObject` represents an object
   _encodeObject(object) {
-    if (object.termType === 'Quad') {
-      return `<<${this._encodeSubject(object.subject)} ${this._encodePredicate(object.predicate)} ${this._encodeObject(object.object)}${isDefaultGraph(object.graph) ? '' : ` ${this._encodeIriOrBlank(object.graph)}`}>>`;
-    }
-    else if (object.termType === 'Literal') {
+    switch (object.termType) {
+    case 'Quad':
+      return this._encodeQuad(object);
+    case 'Literal':
       return this._encodeLiteral(object);
-    }
-    else {
+    default:
       return this._encodeIriOrBlank(object);
     }
+  }
+
+  // ### `_encodeQuad` encodes an RDF* quad
+  _encodeQuad({ subject, predicate, object, graph }) {
+    return `<<${
+      this._encodeSubject(subject)} ${
+      this._encodePredicate(predicate)} ${
+      this._encodeObject(object)}${
+      isDefaultGraph(graph) ? '' : ` ${this._encodeIriOrBlank(graph)}`}>>`;
   }
 
   // ### `_blockedWrite` replaces `_write` after the writer has been closed

--- a/src/N3Writer.js
+++ b/src/N3Writer.js
@@ -99,7 +99,7 @@ export default class N3Writer {
       // Different subject; write the whole quad
       else
         this._write((this._subject === null ? '' : '.\n') +
-                    this._encodeIriOrBlank(this._subject = subject) + ' ' +
+                    this._encodeSubject(this._subject = subject) + ' ' +
                     this._encodePredicate(this._predicate = predicate) + ' ' +
                     this._encodeObject(object), done);
     }
@@ -115,7 +115,7 @@ export default class N3Writer {
 
   // ### `quadToString` serializes a quad as a string
   quadToString(subject, predicate, object, graph) {
-    return  this._encodeIriOrBlank(subject)   + ' ' +
+    return  this._encodeSubject(subject)   + ' ' +
             this._encodeIriOrBlank(predicate) + ' ' +
             this._encodeObject(object) +
             (graph && graph.value ? ' ' + this._encodeIriOrBlank(graph) + ' .\n' : ' .\n');
@@ -131,7 +131,7 @@ export default class N3Writer {
   // ### `_encodeSubject` represents a subject
   _encodeSubject(entity) {
     if (entity.termType === 'Quad') {
-      return `<<${this._encodeSubject(entity.subject)} ${this._encodeIriOrBlank(entity.predicate)} ${this._encodeObject(entity.object)}${isDefaultGraph(entity._graph) ? '' : ` ${this._encodeIriOrBlank(entity._graph)}`}>>`;
+      return `<<${this._encodeSubject(entity.subject)} ${this._encodePredicate(entity.predicate)} ${this._encodeObject(entity.object)}${isDefaultGraph(entity.graph) ? '' : ` ${this._encodeIriOrBlank(entity.graph)}`}>>`;
     }
     else {
       return this._encodeIriOrBlank(entity);
@@ -180,7 +180,7 @@ export default class N3Writer {
   // ### `_encodeObject` represents an object
   _encodeObject(object) {
     if (object.termType === 'Quad') {
-      return `<<${this._encodeSubject(object.subject)} ${this._encodeIriOrBlank(object.predicate)} ${this._encodeObject(object.object)}${isDefaultGraph(object._graph) ? '' : ` ${this._encodeIriOrBlank(object._graph)}`}>>`;
+      return `<<${this._encodeSubject(object.subject)} ${this._encodePredicate(object.predicate)} ${this._encodeObject(object.object)}${isDefaultGraph(object.graph) ? '' : ` ${this._encodeIriOrBlank(object.graph)}`}>>`;
     }
     else if (object.termType === 'Literal') {
       return this._encodeLiteral(object);

--- a/test/N3Writer-test.js
+++ b/test/N3Writer-test.js
@@ -570,15 +570,17 @@ describe('Writer', function () {
       });
     });
 
-    it('should serialize a triple with a triple as subject', function () {
+    it('should serialize a triple with a triple with mixed component types as subject', function () {
       var writer = new Writer();
       writer.quadToString(new Quad(new BlankNode('b1'), new NamedNode('b'), new Literal('l1')), new NamedNode('b'), new NamedNode('c')).should.equal('<<_:b1 <b> "l">> <b> <c> .\n');
     });
-    it('should serialize a triple with a triple as subject', function () {
+
+    it('should serialize a triple with a triple with iris as subject', function () {
       var writer = new Writer();
       writer.quadToString(new Quad(new NamedNode('a'), new NamedNode('b'), new NamedNode('c')), new NamedNode('b'), new NamedNode('c')).should.equal('<<<a> <b> <c>>> <b> <c> .\n');
     });
-    it('should serialize a triple with a triple as subject', function () {
+
+    it('should serialize a triple with a triple with blanknodes as subject', function () {
       var writer = new Writer();
       writer.quadToString(new Quad(new BlankNode('b1'), new BlankNode('b2'), new BlankNode('b3')), new NamedNode('b'), new NamedNode('c')).should.equal('<<_:b1 _:b2 _:b3>> <b> <c> .\n');
     });
@@ -587,16 +589,18 @@ describe('Writer', function () {
       var writer = new Writer();
       writer.quadToString(new NamedNode('a'), new NamedNode('b'), new Quad(new BlankNode('b1'), new NamedNode('b'), new Literal('l1'))).should.equal('<a> <b> <<_:b1 <b> "l">> .\n');
     });
-    it('should serialize a triple with a triple as object', function () {
+
+    it('should serialize a triple with a triple with iris as object', function () {
       var writer = new Writer();
       writer.quadToString(new NamedNode('a'), new NamedNode('b'), new Quad(new NamedNode('a'), new NamedNode('b'), new NamedNode('c'))).should.equal('<a> <b> <<<a> <b> <c>>> .\n');
     });
-    it('should serialize a triple with a triple as object', function () {
+
+    it('should serialize a triple with a triple with blanknodes as object', function () {
       var writer = new Writer();
       writer.quadToString(new NamedNode('a'), new NamedNode('b'), new Quad(new BlankNode('b1'), new BlankNode('b2'), new BlankNode('b3'))).should.equal('<a> <b> <<_:b1 _:b2 _:b3>> .\n');
     });
 
-    it('should serialize a quad with a triple as subject', function () {
+    it('should serialize a quad with a triple with mixed component types as subject', function () {
       var writer = new Writer();
       writer.quadToString(new Quad(new NamedNode('a'), new NamedNode('b'), new NamedNode('c')), new NamedNode('b'), new NamedNode('c'), new NamedNode('g')).should.equal('<<<a> <b> <c>>> <b> <c> <g> .\n');
     });

--- a/test/N3Writer-test.js
+++ b/test/N3Writer-test.js
@@ -494,7 +494,7 @@ describe('Writer', function () {
       writer.addQuad(new NamedNode('a3'), new NamedNode('b'), new BlankNode('m3'));
       writer.end(function (error, output) {
         output.should.equal('(<c> <d> <e>) <b> ("c" "d" "e").\n' +
-                            '<a3> <b> _:m3.\n');
+          '<a3> <b> _:m3.\n');
         done(error);
       });
     });
@@ -568,6 +568,62 @@ describe('Writer', function () {
         outputStream.should.have.property('ended', false);
         done();
       });
+    });
+
+    it('should serialize a triple with a triple as subject', function () {
+      var writer = new Writer();
+      writer.quadToString(new Quad(new BlankNode('b1'), new NamedNode('b'), new Literal('l1')), new NamedNode('b'), new NamedNode('c')).should.equal('<<_:b1 <b> "l">> <b> <c> .\n');
+    });
+    it('should serialize a triple with a triple as subject', function () {
+      var writer = new Writer();
+      writer.quadToString(new Quad(new NamedNode('a'), new NamedNode('b'), new NamedNode('c')), new NamedNode('b'), new NamedNode('c')).should.equal('<<<a> <b> <c>>> <b> <c> .\n');
+    });
+    it('should serialize a triple with a triple as subject', function () {
+      var writer = new Writer();
+      writer.quadToString(new Quad(new BlankNode('b1'), new BlankNode('b2'), new BlankNode('b3')), new NamedNode('b'), new NamedNode('c')).should.equal('<<_:b1 _:b2 _:b3>> <b> <c> .\n');
+    });
+
+    it('should serialize a triple with a triple as object', function () {
+      var writer = new Writer();
+      writer.quadToString(new NamedNode('a'), new NamedNode('b'), new Quad(new BlankNode('b1'), new NamedNode('b'), new Literal('l1'))).should.equal('<a> <b> <<_:b1 <b> "l">> .\n');
+    });
+    it('should serialize a triple with a triple as object', function () {
+      var writer = new Writer();
+      writer.quadToString(new NamedNode('a'), new NamedNode('b'), new Quad(new NamedNode('a'), new NamedNode('b'), new NamedNode('c'))).should.equal('<a> <b> <<<a> <b> <c>>> .\n');
+    });
+    it('should serialize a triple with a triple as object', function () {
+      var writer = new Writer();
+      writer.quadToString(new NamedNode('a'), new NamedNode('b'), new Quad(new BlankNode('b1'), new BlankNode('b2'), new BlankNode('b3'))).should.equal('<a> <b> <<_:b1 _:b2 _:b3>> .\n');
+    });
+
+    it('should serialize a quad with a triple as subject', function () {
+      var writer = new Writer();
+      writer.quadToString(new Quad(new NamedNode('a'), new NamedNode('b'), new NamedNode('c')), new NamedNode('b'), new NamedNode('c'), new NamedNode('g')).should.equal('<<<a> <b> <c>>> <b> <c> <g> .\n');
+    });
+
+    it('should serialize a quad with a triple as object', function () {
+      var writer = new Writer();
+      writer.quadToString(new NamedNode('a'), new NamedNode('b'), new Quad(new NamedNode('a'), new NamedNode('b'), new NamedNode('c')), new NamedNode('g')).should.equal('<a> <b> <<<a> <b> <c>>> <g> .\n');
+    });
+
+    it('should serialize a quad with a quad as subject', function () {
+      var writer = new Writer();
+      writer.quadToString(new Quad(new NamedNode('a'), new NamedNode('b'), new NamedNode('c'), new NamedNode('g')), new NamedNode('b'), new NamedNode('c'), new NamedNode('g')).should.equal('<<<a> <b> <c> <g>>> <b> <c> <g> .\n');
+    });
+
+    it('should serialize a quad with a quad as object', function () {
+      var writer = new Writer();
+      writer.quadToString(new NamedNode('a'), new NamedNode('b'), new Quad(new NamedNode('a'), new NamedNode('b'), new NamedNode('c'), new NamedNode('g')), new NamedNode('g')).should.equal('<a> <b> <<<a> <b> <c> <g>>> <g> .\n');
+    });
+
+    it('should serialize a triple with a quad as subject', function () {
+      var writer = new Writer();
+      writer.quadToString(new Quad(new NamedNode('a'), new NamedNode('b'), new NamedNode('c'), new NamedNode('g')), new NamedNode('b'), new NamedNode('c')).should.equal('<<<a> <b> <c> <g>>> <b> <c> .\n');
+    });
+
+    it('should serialize a triple with a quad as object', function () {
+      var writer = new Writer();
+      writer.quadToString(new NamedNode('a'), new NamedNode('b'), new Quad(new NamedNode('a'), new NamedNode('b'), new NamedNode('c'), new NamedNode('g'))).should.equal('<a> <b> <<<a> <b> <c> <g>>> .\n');
     });
   });
 });


### PR DESCRIPTION
This PR adds support for writing nested quads to the Writer component of N3. The changes include
* Added a check in the method that encodes objects
* Added a method for converting subjects
* Changed the Writer to handler Quads
* Added tests
