### PR TITLE
Adding documentation about RDF*

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,13 +339,13 @@ In addition, the N3.js parser also supports [Notation3 (N3)](https://www.w3.org/
 The N3.js parser and writer are also fully compatible with the RDF* variants 
 of the W3C specifications.
 
+The default mode is permissive
+and allows a mixture of different syntaxes, including RDF*.
 Pass a `format` option to the constructor with the name or MIME type of a format
 for strict, fault-intolerant behavior.
-
-In the default mode (i.e. no format provided), the parser will parse RDF*.
-Pass a MIME type containing `star` or `*`, e.g. `turtlestar` or `TriG*` to parse one format
-with its RDF* extension.
-
+If a format string contains `star` or `*`
+(e.g., `turtlestar` or `TriG*`),
+RDF* support for that format will be enabled.
 
 ### Interface specifications
 The N3.js submodules are compatible with the following [RDF.js](http://rdf.js.org) interfaces:

--- a/README.md
+++ b/README.md
@@ -12,12 +12,14 @@ It offers:
   [TriG](https://www.w3.org/TR/trig/),
   [N-Triples](https://www.w3.org/TR/n-triples/),
   [N-Quads](https://www.w3.org/TR/n-quads/),
+  [RDF*](https://blog.liu.se/olafhartig/2019/01/10/position-statement-rdf-star-and-sparql-star/)
   and [Notation3 (N3)](https://www.w3.org/TeamSubmission/n3/)
 - [**Writing**](#writing) triples/quads to
   [Turtle](https://www.w3.org/TR/turtle/),
   [TriG](https://www.w3.org/TR/trig/),
   [N-Triples](https://www.w3.org/TR/n-triples/),
-  and [N-Quads](https://www.w3.org/TR/n-quads/)
+  [N-Quads](https://www.w3.org/TR/n-quads/)
+  and [RDF*](https://blog.liu.se/olafhartig/2019/01/10/position-statement-rdf-star-and-sparql-star/)
 - [**Storage**](#storing) of triples/quads in memory
 
 Parsing and writing is:
@@ -60,6 +62,8 @@ const myQuad = quad(
   literal('Ruben', 'en'),
   defaultGraph(),
 );
+console.log(myQuad.termType);              // Quad
+console.log(myQuad.value);                 // ''
 console.log(myQuad.subject.value);         // https://ruben.verborgh.org/profile/#me
 console.log(myQuad.object.value);          // Ruben
 console.log(myQuad.object.datatype.value); // http://www.w3.org/1999/02/22-rdf-syntax-ns#langString
@@ -332,6 +336,9 @@ The N3.js parser and writer is fully compatible with the following W3C specifica
 
 In addition, the N3.js parser also supports [Notation3 (N3)](https://www.w3.org/TeamSubmission/n3/) (no official specification yet).
 
+The N3.js parser and writer are also fully compatible with the RDF* variants 
+of the W3C specifications.
+
 Pass a `format` option to the constructor with the name or MIME type of a format
 for strict, fault-intolerant behavior.
 
@@ -348,6 +355,7 @@ The N3.js submodules are compatible with the following [RDF.js](http://rdf.js.or
     [`Variable`](http://rdf.js.org/data-model-spec/#variable-interface),
     [`DefaultGraph`](http://rdf.js.org/data-model-spec/#defaultgraph-interface)
   - the triples/quads it creates implement
+    [`Term`](http://rdf.js.org/data-model-spec/#term-interface),
     [`Triple`](http://rdf.js.org/data-model-spec/#triple-interface)
     and
     [`Quad`](http://rdf.js.org/data-model-spec/#quad-interface)

--- a/README.md
+++ b/README.md
@@ -342,6 +342,11 @@ of the W3C specifications.
 Pass a `format` option to the constructor with the name or MIME type of a format
 for strict, fault-intolerant behavior.
 
+In the default mode (i.e. no format provided), the parser will parse RDF*.
+Pass a MIME type containing `star` or `*`, e.g. `turtlestar` or `TriG*` to parse one format
+with its RDF* extension.
+
+
 ### Interface specifications
 The N3.js submodules are compatible with the following [RDF.js](http://rdf.js.org) interfaces:
 


### PR DESCRIPTION
This PR aims to add documentation detailing the support of RDF* to the README file. This first version might be good but I'm open for suggestions.

There are some things I'm not sure about so I'll write them down quickly:
- As a link to RDF* I used [Olaf Hartig's position statement](https://blog.liu.se/olafhartig/2019/01/10/position-statement-rdf-star-and-sparql-star/), maybe another URL is necessary.
- I didn't mention the extensions we made to RDF* such as quads within `<< >>` yet because I was not sure where to put it, and maybe it's not necessary to mention this at all.