### PR TITLE
Add 'termType' property to Quad.toJSON() result

### DIFF
--- a/src/N3DataFactory.js
+++ b/src/N3DataFactory.js
@@ -272,6 +272,7 @@ export class Quad extends Term {
   // ### Returns a plain object representation of this quad
   toJSON() {
     return {
+      termType:  this.termType,
       subject:   this.subject.toJSON(),
       predicate: this.predicate.toJSON(),
       object:    this.object.toJSON(),

--- a/test/Quad-test.js
+++ b/test/Quad-test.js
@@ -100,6 +100,7 @@ describe('Quad', function () {
 
     it('should provide a JSON representation', function () {
       quad.toJSON().should.deep.equal({
+        termType:  'Quad',
         subject:   { termType: 'NamedNode', value: 's' },
         predicate: { termType: 'NamedNode', value: 'p' },
         object:    { termType: 'NamedNode', value: 'o' },
@@ -194,6 +195,7 @@ describe('Quad', function () {
 
     it('should provide a JSON representation', function () {
       quad.toJSON().should.deep.equal({
+        termType:  'Quad',
         subject:   { termType: 'NamedNode', value: 's' },
         predicate: { termType: 'NamedNode', value: 'p' },
         object:    { termType: 'NamedNode', value: 'o' },
@@ -295,6 +297,7 @@ describe('Quad', function () {
 
     it('should provide a JSON representation', function () {
       quad.toJSON().should.deep.equal({
+        termType:  'Quad',
         subject:   termFromId('<<_:n3-123 ?var-a ?var-b _:n3-000>>').toJSON(),
         predicate: { termType: 'NamedNode', value: 'p' },
         object:    termFromId('<<http://ex.org/a http://ex.org/b http://ex.org/c>>').toJSON(),


### PR DESCRIPTION
This allows to distinguish Quad `subject` (or `object`) value by looking at `termType` when serializing Quad to JSON.