### PR TITLE
Switch to arrow functions

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -121,6 +121,7 @@
 
     // Stylistic Issues
     array-bracket-spacing: 2,
+    arrow-parens: [2, "as-needed"],
     block-spacing: 2,
     brace-style: [2, "stroustrup", { allowSingleLine: true }],
     camelcase: 2,
@@ -161,6 +162,7 @@
     operator-assignment: 2,
     operator-linebreak: [2, "after", { overrides: { ":": "ignore" } }],
     padded-blocks: [2, "never"],
+    prefer-arrow-callback: 2,
     quote-props: [2, "consistent-as-needed"],
     quotes: [2, "single", "avoid-escape"],
     semi-spacing: 2,

--- a/perf/N3Lexer-perf.js
+++ b/perf/N3Lexer-perf.js
@@ -14,7 +14,7 @@ var TEST = '- Lexing file ' + filename;
 console.time(TEST);
 
 var count = 0;
-new N3.Lexer().tokenize(fs.createReadStream(filename), function (error, token) {
+new N3.Lexer().tokenize(fs.createReadStream(filename), (error, token) => {
   assert(!error, error);
   count++;
   if (token.type === 'eof') {

--- a/perf/N3Parser-perf.js
+++ b/perf/N3Parser-perf.js
@@ -16,7 +16,7 @@ var TEST = '- Parsing file ' + filename;
 console.time(TEST);
 
 var count = 0;
-new N3.Parser({ baseIRI: base }).parse(fs.createReadStream(filename), function (error, quad) {
+new N3.Parser({ baseIRI: base }).parse(fs.createReadStream(filename), (error, quad) => {
   assert(!error, error);
   if (quad)
     count++;

--- a/src/N3Lexer.js
+++ b/src/N3Lexer.js
@@ -432,7 +432,6 @@ export default class N3Lexer {
   // ### `tokenize` starts the transformation of an N3 document into an array of tokens.
   // The input can be a string or a stream.
   tokenize(input, callback) {
-    var self = this;
     this._line = 1;
 
     // If the input is a string, continuously emit tokens through the callback until the end
@@ -440,11 +439,11 @@ export default class N3Lexer {
       this._input = input;
       // If a callback was passed, asynchronously call it
       if (typeof callback === 'function')
-        queueMicrotask(() => self._tokenizeToEnd(callback, true));
+        queueMicrotask(() => this._tokenizeToEnd(callback, true));
       // If no callback was passed, tokenize synchronously and return
       else {
         var tokens = [], error;
-        this._tokenizeToEnd(function (e, t) { e ? (error = e) : tokens.push(t); }, true);
+        this._tokenizeToEnd((e, t) => { e ? (error = e) : tokens.push(t); }, true);
         if (error) throw error;
         return tokens;
       }
@@ -456,28 +455,28 @@ export default class N3Lexer {
       if (typeof input.setEncoding === 'function')
         input.setEncoding('utf8');
       // Adds the data chunk to the buffer and parses as far as possible
-      input.on('data', function (data) {
-        if (self._input !== null && data.length !== 0) {
+      input.on('data', data => {
+        if (this._input !== null && data.length !== 0) {
           // Prepend any previous pending writes
-          if (self._pendingBuffer) {
-            data = Buffer.concat([self._pendingBuffer, data]);
-            self._pendingBuffer = null;
+          if (this._pendingBuffer) {
+            data = Buffer.concat([this._pendingBuffer, data]);
+            this._pendingBuffer = null;
           }
           // Hold if the buffer ends in an incomplete unicode sequence
           if (data[data.length - 1] & 0x80) {
-            self._pendingBuffer = data;
+            this._pendingBuffer = data;
           }
           // Otherwise, tokenize as far as possible
           else {
-            self._input += data;
-            self._tokenizeToEnd(callback, false);
+            this._input += data;
+            this._tokenizeToEnd(callback, false);
           }
         }
       });
       // Parses until the end
-      input.on('end', function () {
-        if (self._input !== null)
-          self._tokenizeToEnd(callback, true);
+      input.on('end', () => {
+        if (this._input !== null)
+          this._tokenizeToEnd(callback, true);
       });
       input.on('error', callback);
     }

--- a/src/N3Parser.js
+++ b/src/N3Parser.js
@@ -31,7 +31,7 @@ export default class N3Parser {
     this._supportsRDFStar = format === '' || /star|\*$/.test(format);
     // Disable relative IRIs in N-Triples or N-Quads mode
     if (isLineMode)
-      this._resolveRelativeIRI = function (iri) { return null; };
+      this._resolveRelativeIRI = iri => { return null; };
     this._blankNodePrefix = typeof options.blankNodePrefix !== 'string' ? '' :
                               options.blankNodePrefix.replace(/^(?!_:)/, '_:');
     this._lexer = options.lexer || new N3Lexer({ lineMode: isLineMode, n3: isN3 });
@@ -977,7 +977,6 @@ export default class N3Parser {
 
   // ### `parse` parses the N3 input and emits each parsed quad through the callback
   parse(input, quadCallback, prefixCallback) {
-    var self = this;
     // The read callback is the next function to be executed when a token arrives.
     // We start reading in the top context.
     this._readCallback = this._readInTopContext;
@@ -992,9 +991,9 @@ export default class N3Parser {
     // Parse synchronously if no quad callback is given
     if (!quadCallback) {
       var quads = [], error;
-      this._callback = function (e, t) { e ? (error = e) : t && quads.push(t); };
-      this._lexer.tokenize(input).every(function (token) {
-        return self._readCallback = self._readCallback(token);
+      this._callback = (e, t) => { e ? (error = e) : t && quads.push(t); };
+      this._lexer.tokenize(input).every(token => {
+        return this._readCallback = this._readCallback(token);
       });
       if (error) throw error;
       return quads;
@@ -1002,11 +1001,11 @@ export default class N3Parser {
 
     // Parse asynchronously otherwise, executing the read callback when a token arrives
     this._callback = quadCallback;
-    this._lexer.tokenize(input, function (error, token) {
+    this._lexer.tokenize(input, (error, token) => {
       if (error !== null)
-        self._callback(error), self._callback = noop;
-      else if (self._readCallback)
-        self._readCallback = self._readCallback(token);
+        this._callback(error), this._callback = noop;
+      else if (this._readCallback)
+        this._readCallback = this._readCallback(token);
     });
   }
 }

--- a/src/N3Store.js
+++ b/src/N3Store.js
@@ -259,8 +259,7 @@ export default class N3Store {
 
   // ### `import` adds a stream of quads to the store
   import(stream) {
-    var self = this;
-    stream.on('data', function (quad) { self.addQuad(quad); });
+    stream.on('data', quad => { this.addQuad(quad); });
     return stream;
   }
 
@@ -307,8 +306,7 @@ export default class N3Store {
 
   // ### `remove` removes a stream of quads from the store
   remove(stream) {
-    var self = this;
-    stream.on('data', function (quad) { self.removeQuad(quad); });
+    stream.on('data', quad => { this.removeQuad(quad); });
     return stream;
   }
 
@@ -433,7 +431,7 @@ export default class N3Store {
   // ### `forEach` executes the callback on all quads.
   // Setting any field to `undefined` or `null` indicates a wildcard.
   forEach(callback, subject, predicate, object, graph) {
-    this.some(function (quad) {
+    this.some(quad => {
       callback(quad);
       return false;
     }, subject, predicate, object, graph);
@@ -444,7 +442,7 @@ export default class N3Store {
   // Setting any field to `undefined` or `null` indicates a wildcard.
   every(callback, subject, predicate, object, graph) {
     var some = false;
-    var every = !this.some(function (quad) {
+    var every = !this.some(quad => {
       some = true;
       return !callback(quad);
     }, subject, predicate, object, graph);
@@ -516,7 +514,7 @@ export default class N3Store {
   // Setting any field to `undefined` or `null` indicates a wildcard.
   getSubjects(predicate, object, graph) {
     var results = [];
-    this.forSubjects(function (s) { results.push(s); }, predicate, object, graph);
+    this.forSubjects(s => { results.push(s); }, predicate, object, graph);
     return results;
   }
 
@@ -562,7 +560,7 @@ export default class N3Store {
   // Setting any field to `undefined` or `null` indicates a wildcard.
   getPredicates(subject, object, graph) {
     var results = [];
-    this.forPredicates(function (p) { results.push(p); }, subject, object, graph);
+    this.forPredicates(p => { results.push(p); }, subject, object, graph);
     return results;
   }
 
@@ -608,7 +606,7 @@ export default class N3Store {
   // Setting any field to `undefined` or `null` indicates a wildcard.
   getObjects(subject, predicate, graph) {
     var results = [];
-    this.forObjects(function (o) { results.push(o); }, subject, predicate, graph);
+    this.forObjects(o => { results.push(o); }, subject, predicate, graph);
     return results;
   }
 
@@ -654,7 +652,7 @@ export default class N3Store {
   // Setting any field to `undefined` or `null` indicates a wildcard.
   getGraphs(subject, predicate, object) {
     var results = [];
-    this.forGraphs(function (g) { results.push(g); }, subject, predicate, object);
+    this.forGraphs(g => { results.push(g); }, subject, predicate, object);
     return results;
   }
 
@@ -662,7 +660,7 @@ export default class N3Store {
   // Setting any field to `undefined` or `null` indicates a wildcard.
   forGraphs(callback, subject, predicate, object) {
     for (var graph in this._graphs) {
-      this.some(function (quad) {
+      this.some(quad => {
         callback(quad.graph);
         return true; // Halt iteration of some()
       }, subject, predicate, object, graph);

--- a/src/N3StreamParser.js
+++ b/src/N3StreamParser.js
@@ -9,9 +9,9 @@ export default class N3StreamParser extends Transform {
     this._readableState.objectMode = true;
 
     // Set up parser with dummy stream to obtain `data` and `end` callbacks
-    var self = this, parser = new N3Parser(options), onData, onEnd;
+    var parser = new N3Parser(options), onData, onEnd;
     parser.parse({
-      on: function (event, callback) {
+      on: (event, callback) => {
         switch (event) {
         case 'data': onData = callback; break;
         case 'end':   onEnd = callback; break;
@@ -19,22 +19,21 @@ export default class N3StreamParser extends Transform {
       },
     },
       // Handle quads by pushing them down the pipeline
-      function (error, quad) { error && self.emit('error', error) || quad && self.push(quad); },
+      (error, quad) => { error && this.emit('error', error) || quad && this.push(quad); },
       // Emit prefixes through the `prefix` event
-      function (prefix, uri) { self.emit('prefix', prefix, uri); }
+      (prefix, uri) => { this.emit('prefix', prefix, uri); }
     );
 
     // Implement Transform methods through parser callbacks
-    this._transform = function (chunk, encoding, done) { onData(chunk); done(); };
-    this._flush = function (done) { onEnd(); done(); };
+    this._transform = (chunk, encoding, done) => { onData(chunk); done(); };
+    this._flush = done => { onEnd(); done(); };
   }
 
   // ### Parses a stream of strings
   import(stream) {
-    var self = this;
-    stream.on('data',  function (chunk) { self.write(chunk); });
-    stream.on('end',   function ()      { self.end(); });
-    stream.on('error', function (error) { self.emit('error', error); });
+    stream.on('data',  chunk => { this.write(chunk); });
+    stream.on('end',   ()      => { this.end(); });
+    stream.on('error', error => { this.emit('error', error); });
     return this;
   }
 }

--- a/src/N3StreamWriter.js
+++ b/src/N3StreamWriter.js
@@ -9,24 +9,22 @@ export default class N3StreamWriter extends Transform {
     this._writableState.objectMode = true;
 
     // Set up writer with a dummy stream object
-    var self = this;
     var writer = this._writer = new N3Writer({
-      write: function (quad, encoding, callback) { self.push(quad); callback && callback(); },
-      end: function (callback) { self.push(null); callback && callback(); },
+      write: (quad, encoding, callback) => { this.push(quad); callback && callback(); },
+      end: callback => { this.push(null); callback && callback(); },
     }, options);
 
     // Implement Transform methods on top of writer
-    this._transform = function (quad, encoding, done) { writer.addQuad(quad, done); };
-    this._flush = function (done) { writer.end(done); };
+    this._transform = (quad, encoding, done) => { writer.addQuad(quad, done); };
+    this._flush = done => { writer.end(done); };
   }
 
 // ### Serializes a stream of quads
   import(stream) {
-    var self = this;
-    stream.on('data',   function (quad)  { self.write(quad); });
-    stream.on('end',    function ()      { self.end(); });
-    stream.on('error',  function (error) { self.emit('error', error); });
-    stream.on('prefix', function (prefix, iri) { self._writer.addPrefix(prefix, iri); });
+    stream.on('data',   quad => { this.write(quad); });
+    stream.on('end',    () => { this.end(); });
+    stream.on('error',  error => { this.emit('error', error); });
+    stream.on('prefix', (prefix, iri) => { this._writer.addPrefix(prefix, iri); });
     return this;
   }
 }

--- a/src/N3Util.js
+++ b/src/N3Util.js
@@ -53,7 +53,7 @@ export function prefixes(defaultPrefixes, factory) {
     if (typeof iri === 'string') {
       // Create a function that expands the prefix
       var cache = Object.create(null);
-      prefixes[prefix] = function (local) {
+      prefixes[prefix] = local => {
         return cache[local] || (cache[local] = factory.namedNode(iri + local));
       };
     }

--- a/src/N3Writer.js
+++ b/src/N3Writer.js
@@ -41,7 +41,7 @@ export default class N3Writer {
       var output = '';
       this._outputStream = {
         write(chunk, encoding, done) { output += chunk; done && done(); },
-        end:   function (done) { done && done(null, output); },
+        end: done => { done && done(null, output); },
       };
       this._endStream = true;
     }
@@ -123,9 +123,9 @@ export default class N3Writer {
 
   // ### `quadsToString` serializes an array of quads as a string
   quadsToString(quads) {
-    return quads.map(function (t) {
+    return quads.map(t => {
       return this.quadToString(t.subject, t.predicate, t.object, t.graph);
-    }, this).join('');
+    }).join('');
   }
 
   // ### `_encodeSubject` represents a subject
@@ -320,7 +320,7 @@ export default class N3Writer {
     this._write = this._blockedWrite;
 
     // Try to end the underlying stream, ensuring done is called exactly one time
-    var singleDone = done && function (error, result) { singleDone = null, done(error, result); };
+    var singleDone = done && ((error, result) => { singleDone = null, done(error, result); });
     if (this._endStream) {
       try { return this._outputStream.end(singleDone); }
       catch (error) { /* error closing stream */ }

--- a/test/BlankNode-test.js
+++ b/test/BlankNode-test.js
@@ -1,78 +1,78 @@
 import { BlankNode, Term } from '../src/';
 
-describe('BlankNode', function () {
-  describe('The BlankNode module', function () {
-    it('should be a function', function () {
+describe('BlankNode', () => {
+  describe('The BlankNode module', () => {
+    it('should be a function', () => {
       BlankNode.should.be.a('function');
     });
 
-    it('should be a BlankNode constructor', function () {
+    it('should be a BlankNode constructor', () => {
       new BlankNode().should.be.an.instanceof(BlankNode);
     });
 
-    it('should be a Term constructor', function () {
+    it('should be a Term constructor', () => {
       new BlankNode().should.be.an.instanceof(Term);
     });
   });
 
-  describe('A BlankNode instance created from a name', function () {
+  describe('A BlankNode instance created from a name', () => {
     var blankNode;
-    before(function () { blankNode = new BlankNode('b1'); });
+    before(() => { blankNode = new BlankNode('b1'); });
 
-    it('should be a BlankNode', function () {
+    it('should be a BlankNode', () => {
       blankNode.should.be.an.instanceof(BlankNode);
     });
 
-    it('should be a Term', function () {
+    it('should be a Term', () => {
       blankNode.should.be.an.instanceof(Term);
     });
 
-    it('should have term type "BlankNode"', function () {
+    it('should have term type "BlankNode"', () => {
       blankNode.termType.should.equal('BlankNode');
     });
 
-    it('should have the name as value', function () {
+    it('should have the name as value', () => {
       blankNode.should.have.property('value', 'b1');
     });
 
-    it('should have "_:name" as id', function () {
+    it('should have "_:name" as id', () => {
       blankNode.should.have.property('id', '_:b1');
     });
 
-    it('should equal a BlankNode instance with the same name', function () {
+    it('should equal a BlankNode instance with the same name', () => {
       blankNode.equals(new BlankNode('b1')).should.be.true;
     });
 
-    it('should equal an object with the same term type and value', function () {
+    it('should equal an object with the same term type and value', () => {
       blankNode.equals({
         termType: 'BlankNode',
         value: 'b1',
       }).should.be.true;
     });
 
-    it('should not equal a falsy object', function () {
+    it('should not equal a falsy object', () => {
       blankNode.equals(null).should.be.false;
     });
 
-    it('should not equal a BlankNode instance with another name', function () {
+    it('should not equal a BlankNode instance with another name', () => {
       blankNode.equals(new BlankNode('b2')).should.be.false;
     });
 
-    it('should not equal an object with the same term type but a different value', function () {
+    it('should not equal an object with the same term type but a different value', () => {
       blankNode.equals({
         termType: 'BlankNode',
         value: 'b2',
       }).should.be.false;
     });
 
-    it('should not equal an object with a different term type but the same value', function () {
+    it('should not equal an object with a different term type but the same value', () => {
       blankNode.equals({
         termType: 'NamedNode',
         value: 'b1',
       }).should.be.false;
     });
 
-    it('should provide a JSON representation', function () {
+    it('should provide a JSON representation', () => {
       blankNode.toJSON().should.deep.equal({
         termType: 'BlankNode',
         value: 'b1',

--- a/test/DefaultGraph-test.js
+++ b/test/DefaultGraph-test.js
@@ -1,65 +1,65 @@
 import { DefaultGraph, Term } from '../src/';
 
-describe('DefaultGraph', function () {
-  describe('The DefaultGraph module', function () {
-    it('should be a function', function () {
+describe('DefaultGraph', () => {
+  describe('The DefaultGraph module', () => {
+    it('should be a function', () => {
       DefaultGraph.should.be.a('function');
     });
 
-    it('should be a DefaultGraph constructor', function () {
+    it('should be a DefaultGraph constructor', () => {
       new DefaultGraph().should.be.an.instanceof(DefaultGraph);
     });
 
-    it('should be a Term constructor', function () {
+    it('should be a Term constructor', () => {
       new DefaultGraph().should.be.an.instanceof(Term);
     });
   });
 
-  describe('A DefaultGraph instance', function () {
+  describe('A DefaultGraph instance', () => {
     var defaultGraph;
-    before(function () { defaultGraph = new DefaultGraph(); });
+    before(() => { defaultGraph = new DefaultGraph(); });
 
-    it('should be a DefaultGraph', function () {
+    it('should be a DefaultGraph', () => {
       defaultGraph.should.be.an.instanceof(DefaultGraph);
     });
 
-    it('should be a Term', function () {
+    it('should be a Term', () => {
       defaultGraph.should.be.an.instanceof(Term);
     });
 
-    it('should have term type "DefaultGraph"', function () {
+    it('should have term type "DefaultGraph"', () => {
       defaultGraph.termType.should.equal('DefaultGraph');
     });
 
-    it('should have the empty string as value', function () {
+    it('should have the empty string as value', () => {
       defaultGraph.should.have.property('value', '');
     });
 
-    it('should have the empty string as id', function () {
+    it('should have the empty string as id', () => {
       defaultGraph.should.have.property('id', '');
     });
 
-    it('should equal another DefaultGraph instance', function () {
+    it('should equal another DefaultGraph instance', () => {
       defaultGraph.equals(new DefaultGraph()).should.be.true;
     });
 
-    it('should equal an object with the same term type', function () {
+    it('should equal an object with the same term type', () => {
       defaultGraph.equals({
         termType: 'DefaultGraph',
       }).should.be.true;
     });
 
-    it('should not equal a falsy object', function () {
+    it('should not equal a falsy object', () => {
       defaultGraph.equals(null).should.be.false;
     });
 
-    it('should not equal an object with a different term type', function () {
+    it('should not equal an object with a different term type', () => {
       defaultGraph.equals({
         termType: 'Literal',
       }).should.be.false;
     });
 
-    it('should provide a JSON representation', function () {
+    it('should provide a JSON representation', () => {
       defaultGraph.toJSON().should.deep.equal({
         termType: 'DefaultGraph',
         value: '',

--- a/test/Literal-test.js
+++ b/test/Literal-test.js
@@ -1,59 +1,59 @@
 import { Literal, NamedNode, Term } from '../src/';
 
-describe('Literal', function () {
-  describe('The Literal module', function () {
-    it('should be a function', function () {
+describe('Literal', () => {
+  describe('The Literal module', () => {
+    it('should be a function', () => {
       Literal.should.be.a('function');
     });
 
-    it('should be a Literal constructor', function () {
+    it('should be a Literal constructor', () => {
       new Literal().should.be.an.instanceof(Literal);
     });
 
-    it('should be a Term constructor', function () {
+    it('should be a Term constructor', () => {
       new Literal().should.be.an.instanceof(Term);
     });
   });
 
-  describe('A Literal instance created from the empty string without language or datatype', function () {
+  describe('A Literal instance created from the empty string without language or datatype', () => {
     var literal;
-    before(function () { literal = new Literal('""'); });
+    before(() => { literal = new Literal('""'); });
 
-    it('should be a Literal', function () {
+    it('should be a Literal', () => {
       literal.should.be.an.instanceof(Literal);
     });
 
-    it('should be a Term', function () {
+    it('should be a Term', () => {
       literal.should.be.an.instanceof(Term);
     });
 
-    it('should have term type "Literal"', function () {
+    it('should have term type "Literal"', () => {
       literal.termType.should.equal('Literal');
     });
 
-    it('should have the empty string as value', function () {
+    it('should have the empty string as value', () => {
       literal.should.have.property('value', '');
     });
 
-    it('should have the empty string as language', function () {
+    it('should have the empty string as language', () => {
       literal.should.have.property('language', '');
     });
 
-    it('should have xsd:string as datatype', function () {
+    it('should have xsd:string as datatype', () => {
       literal.should.have.property('datatype');
       literal.datatype.should.be.an.instanceof(NamedNode);
       literal.datatype.value.should.equal('http://www.w3.org/2001/XMLSchema#string');
     });
 
-    it('should have the quoted empty string as id', function () {
+    it('should have the quoted empty string as id', () => {
       literal.should.have.property('id', '""');
     });
 
-    it('should equal a Literal instance with the same value', function () {
+    it('should equal a Literal instance with the same value', () => {
       literal.equals(new Literal('""')).should.be.true;
     });
 
-    it('should equal an object with the same term type, value, language, and datatype', function () {
+    it('should equal an object with the same term type, value, language, and datatype', () => {
       literal.equals({
         termType: 'Literal',
         value: '',
@@ -62,15 +62,15 @@ describe('Literal', function () {
       }).should.be.true;
     });
 
-    it('should not equal a falsy object', function () {
+    it('should not equal a falsy object', () => {
       literal.equals(null).should.be.false;
     });
 
-    it('should not equal a Literal instance with a non-empty value', function () {
+    it('should not equal a Literal instance with a non-empty value', () => {
       literal.equals(new Literal('"x"')).should.be.false;
     });
 
-    it('should not equal an object with the same term type but a different value', function () {
+    it('should not equal an object with the same term type but a different value', () => {
       literal.equals({
         termType: 'Literal',
         value: 'x',
@@ -79,7 +79,7 @@ describe('Literal', function () {
       }).should.be.false;
     });
 
-    it('should not equal an object with the same term type but a different language', function () {
+    it('should not equal an object with the same term type but a different language', () => {
       literal.equals({
         termType: 'Literal',
         value: '',
@@ -88,7 +88,7 @@ describe('Literal', function () {
       }).should.be.false;
     });
 
-    it('should not equal an object with the same term type but a different datatype', function () {
+    it('should not equal an object with the same term type but a different datatype', () => {
       literal.equals({
         termType: 'Literal',
         value: '',
@@ -97,7 +97,7 @@ describe('Literal', function () {
       }).should.be.false;
     });
 
-    it('should not equal an object with a different term type', function () {
+    it('should not equal an object with a different term type', () => {
       literal.equals({
         termType: 'NamedNode',
         value: '',
@@ -106,7 +106,7 @@ describe('Literal', function () {
       }).should.be.false;
     });
 
-    it('should provide a JSON representation', function () {
+    it('should provide a JSON representation', () => {
       literal.toJSON().should.deep.equal({
         termType: 'Literal',
         value: '',
@@ -119,45 +119,45 @@ describe('Literal', function () {
     });
   });
 
-  describe('A Literal instance created from a string without language or datatype', function () {
+  describe('A Literal instance created from a string without language or datatype', () => {
     var literal;
-    before(function () { literal = new Literal('"my @^^ string"'); });
+    before(() => { literal = new Literal('"my @^^ string"'); });
 
-    it('should be a Literal', function () {
+    it('should be a Literal', () => {
       literal.should.be.an.instanceof(Literal);
     });
 
-    it('should be a Term', function () {
+    it('should be a Term', () => {
       literal.should.be.an.instanceof(Term);
     });
 
-    it('should have term type "Literal"', function () {
+    it('should have term type "Literal"', () => {
       literal.termType.should.equal('Literal');
     });
 
-    it('should have the text value as value', function () {
+    it('should have the text value as value', () => {
       literal.should.have.property('value', 'my @^^ string');
     });
 
-    it('should have the empty string as language', function () {
+    it('should have the empty string as language', () => {
       literal.should.have.property('language', '');
     });
 
-    it('should have xsd:string as datatype', function () {
+    it('should have xsd:string as datatype', () => {
       literal.should.have.property('datatype');
       literal.datatype.should.be.an.instanceof(NamedNode);
       literal.datatype.value.should.equal('http://www.w3.org/2001/XMLSchema#string');
     });
 
-    it('should have the quoted string as id', function () {
+    it('should have the quoted string as id', () => {
       literal.should.have.property('id', '"my @^^ string"');
     });
 
-    it('should equal a Literal instance with the same value', function () {
+    it('should equal a Literal instance with the same value', () => {
       literal.equals(new Literal('"my @^^ string"')).should.be.true;
     });
 
-    it('should equal an object with the same term type, value, language, and datatype', function () {
+    it('should equal an object with the same term type, value, language, and datatype', () => {
       literal.equals({
         termType: 'Literal',
         value: 'my @^^ string',
@@ -166,15 +166,15 @@ describe('Literal', function () {
       }).should.be.true;
     });
 
-    it('should not equal a falsy object', function () {
+    it('should not equal a falsy object', () => {
       literal.equals(null).should.be.false;
     });
 
-    it('should not equal a Literal instance with another value', function () {
+    it('should not equal a Literal instance with another value', () => {
       literal.equals(new Literal('"other string"')).should.be.false;
     });
 
-    it('should not equal an object with the same term type but a different value', function () {
+    it('should not equal an object with the same term type but a different value', () => {
       literal.equals({
         termType: 'Literal',
         value: 'other string',
@@ -183,7 +183,7 @@ describe('Literal', function () {
       }).should.be.false;
     });
 
-    it('should not equal an object with the same term type but a different language', function () {
+    it('should not equal an object with the same term type but a different language', () => {
       literal.equals({
         termType: 'Literal',
         value: 'my @^^ string',
@@ -192,7 +192,7 @@ describe('Literal', function () {
       }).should.be.false;
     });
 
-    it('should not equal an object with the same term type but a different datatype', function () {
+    it('should not equal an object with the same term type but a different datatype', () => {
       literal.equals({
         termType: 'Literal',
         value: 'my @^^ string',
@@ -201,7 +201,7 @@ describe('Literal', function () {
       }).should.be.false;
     });
 
-    it('should not equal an object with a different term type', function () {
+    it('should not equal an object with a different term type', () => {
       literal.equals({
         termType: 'NamedNode',
         value: 'my @^^ string',
@@ -210,7 +210,7 @@ describe('Literal', function () {
       }).should.be.false;
     });
 
-    it('should provide a JSON representation', function () {
+    it('should provide a JSON representation', () => {
       literal.toJSON().should.deep.equal({
         termType: 'Literal',
         value: 'my @^^ string',
@@ -223,45 +223,45 @@ describe('Literal', function () {
     });
   });
 
-  describe('A Literal instance created from the empty string with a language', function () {
+  describe('A Literal instance created from the empty string with a language', () => {
     var literal;
-    before(function () { literal = new Literal('""@en-us'); });
+    before(() => { literal = new Literal('""@en-us'); });
 
-    it('should be a Literal', function () {
+    it('should be a Literal', () => {
       literal.should.be.an.instanceof(Literal);
     });
 
-    it('should be a Term', function () {
+    it('should be a Term', () => {
       literal.should.be.an.instanceof(Term);
     });
 
-    it('should have term type "Literal"', function () {
+    it('should have term type "Literal"', () => {
       literal.termType.should.equal('Literal');
     });
 
-    it('should have the empty string as value', function () {
+    it('should have the empty string as value', () => {
       literal.should.have.property('value', '');
     });
 
-    it('should have the language tag as language', function () {
+    it('should have the language tag as language', () => {
       literal.should.have.property('language', 'en-us');
     });
 
-    it('should have rdf:langString as datatype', function () {
+    it('should have rdf:langString as datatype', () => {
       literal.should.have.property('datatype');
       literal.datatype.should.be.an.instanceof(NamedNode);
       literal.datatype.value.should.equal('http://www.w3.org/1999/02/22-rdf-syntax-ns#langString');
     });
 
-    it('should have the quoted empty string as id', function () {
+    it('should have the quoted empty string as id', () => {
       literal.should.have.property('id', '""@en-us');
     });
 
-    it('should equal a Literal instance with the same value', function () {
+    it('should equal a Literal instance with the same value', () => {
       literal.equals(new Literal('""@en-us')).should.be.true;
     });
 
-    it('should equal an object with the same term type, value, language, and datatype', function () {
+    it('should equal an object with the same term type, value, language, and datatype', () => {
       literal.equals({
         termType: 'Literal',
         value: '',
@@ -270,15 +270,15 @@ describe('Literal', function () {
       }).should.be.true;
     });
 
-    it('should not equal a falsy object', function () {
+    it('should not equal a falsy object', () => {
       literal.equals(null).should.be.false;
     });
 
-    it('should not equal a Literal instance with a non-empty value', function () {
+    it('should not equal a Literal instance with a non-empty value', () => {
       literal.equals(new Literal('"x"')).should.be.false;
     });
 
-    it('should not equal an object with the same term type but a different value', function () {
+    it('should not equal an object with the same term type but a different value', () => {
       literal.equals({
         termType: 'Literal',
         value: 'x',
@@ -287,7 +287,7 @@ describe('Literal', function () {
       }).should.be.false;
     });
 
-    it('should not equal an object with the same term type but a different language', function () {
+    it('should not equal an object with the same term type but a different language', () => {
       literal.equals({
         termType: 'Literal',
         value: '',
@@ -296,7 +296,7 @@ describe('Literal', function () {
       }).should.be.false;
     });
 
-    it('should not equal an object with the same term type but a different datatype', function () {
+    it('should not equal an object with the same term type but a different datatype', () => {
       literal.equals({
         termType: 'Literal',
         value: '',
@@ -305,7 +305,7 @@ describe('Literal', function () {
       }).should.be.false;
     });
 
-    it('should not equal an object with a different term type', function () {
+    it('should not equal an object with a different term type', () => {
       literal.equals({
         termType: 'NamedNode',
         value: '',
@@ -314,7 +314,7 @@ describe('Literal', function () {
       }).should.be.false;
     });
 
-    it('should provide a JSON representation', function () {
+    it('should provide a JSON representation', () => {
       literal.toJSON().should.deep.equal({
         termType: 'Literal',
         value: '',
@@ -327,45 +327,45 @@ describe('Literal', function () {
     });
   });
 
-  describe('A Literal instance created from a string without language or datatype', function () {
+  describe('A Literal instance created from a string without language or datatype', () => {
     var literal;
-    before(function () { literal = new Literal('"my @^^ string"@en-us'); });
+    before(() => { literal = new Literal('"my @^^ string"@en-us'); });
 
-    it('should be a Literal', function () {
+    it('should be a Literal', () => {
       literal.should.be.an.instanceof(Literal);
     });
 
-    it('should be a Term', function () {
+    it('should be a Term', () => {
       literal.should.be.an.instanceof(Term);
     });
 
-    it('should have term type "Literal"', function () {
+    it('should have term type "Literal"', () => {
       literal.termType.should.equal('Literal');
     });
 
-    it('should have the text value as value', function () {
+    it('should have the text value as value', () => {
       literal.should.have.property('value', 'my @^^ string');
     });
 
-    it('should have the language tag as language', function () {
+    it('should have the language tag as language', () => {
       literal.should.have.property('language', 'en-us');
     });
 
-    it('should have rdf:langString as datatype', function () {
+    it('should have rdf:langString as datatype', () => {
       literal.should.have.property('datatype');
       literal.datatype.should.be.an.instanceof(NamedNode);
       literal.datatype.value.should.equal('http://www.w3.org/1999/02/22-rdf-syntax-ns#langString');
     });
 
-    it('should have the quoted string as id', function () {
+    it('should have the quoted string as id', () => {
       literal.should.have.property('id', '"my @^^ string"@en-us');
     });
 
-    it('should equal a Literal instance with the same value', function () {
+    it('should equal a Literal instance with the same value', () => {
       literal.equals(new Literal('"my @^^ string"@en-us')).should.be.true;
     });
 
-    it('should equal an object with the same term type, value, language, and datatype', function () {
+    it('should equal an object with the same term type, value, language, and datatype', () => {
       literal.equals({
         termType: 'Literal',
         value: 'my @^^ string',
@@ -374,15 +374,15 @@ describe('Literal', function () {
       }).should.be.true;
     });
 
-    it('should not equal a falsy object', function () {
+    it('should not equal a falsy object', () => {
       literal.equals(null).should.be.false;
     });
 
-    it('should not equal a Literal instance with another value', function () {
+    it('should not equal a Literal instance with another value', () => {
       literal.equals(new Literal('"other string"')).should.be.false;
     });
 
-    it('should not equal an object with the same term type but a different value', function () {
+    it('should not equal an object with the same term type but a different value', () => {
       literal.equals({
         termType: 'Literal',
         value: 'other string',
@@ -391,7 +391,7 @@ describe('Literal', function () {
       }).should.be.false;
     });
 
-    it('should not equal an object with the same term type but a different language', function () {
+    it('should not equal an object with the same term type but a different language', () => {
       literal.equals({
         termType: 'Literal',
         value: 'my @^^ string',
@@ -400,7 +400,7 @@ describe('Literal', function () {
       }).should.be.false;
     });
 
-    it('should not equal an object with the same term type but a different datatype', function () {
+    it('should not equal an object with the same term type but a different datatype', () => {
       literal.equals({
         termType: 'Literal',
         value: 'my @^^ string',
@@ -409,7 +409,7 @@ describe('Literal', function () {
       }).should.be.false;
     });
 
-    it('should not equal an object with a different term type', function () {
+    it('should not equal an object with a different term type', () => {
       literal.equals({
         termType: 'NamedNode',
         value: 'my @^^ string',
@@ -418,7 +418,7 @@ describe('Literal', function () {
       }).should.be.false;
     });
 
-    it('should provide a JSON representation', function () {
+    it('should provide a JSON representation', () => {
       literal.toJSON().should.deep.equal({
         termType: 'Literal',
         value: 'my @^^ string',
@@ -431,45 +431,45 @@ describe('Literal', function () {
     });
   });
 
-  describe('A Literal instance created from the empty string with a datatype', function () {
+  describe('A Literal instance created from the empty string with a datatype', () => {
     var literal;
-    before(function () { literal = new Literal('""^^http://example.org/types#type'); });
+    before(() => { literal = new Literal('""^^http://example.org/types#type'); });
 
-    it('should be a Literal', function () {
+    it('should be a Literal', () => {
       literal.should.be.an.instanceof(Literal);
     });
 
-    it('should be a Term', function () {
+    it('should be a Term', () => {
       literal.should.be.an.instanceof(Term);
     });
 
-    it('should have term type "Literal"', function () {
+    it('should have term type "Literal"', () => {
       literal.termType.should.equal('Literal');
     });
 
-    it('should have the empty string as value', function () {
+    it('should have the empty string as value', () => {
       literal.should.have.property('value', '');
     });
 
-    it('should have the empty string as language', function () {
+    it('should have the empty string as language', () => {
       literal.should.have.property('language', '');
     });
 
-    it('should have the datatype', function () {
+    it('should have the datatype', () => {
       literal.should.have.property('datatype');
       literal.datatype.should.be.an.instanceof(NamedNode);
       literal.datatype.value.should.equal('http://example.org/types#type');
     });
 
-    it('should have the quoted empty string as id', function () {
+    it('should have the quoted empty string as id', () => {
       literal.should.have.property('id', '""^^http://example.org/types#type');
     });
 
-    it('should equal a Literal instance with the same value', function () {
+    it('should equal a Literal instance with the same value', () => {
       literal.equals(new Literal('""^^http://example.org/types#type')).should.be.true;
     });
 
-    it('should equal an object with the same term type, value, language, and datatype', function () {
+    it('should equal an object with the same term type, value, language, and datatype', () => {
       literal.equals({
         termType: 'Literal',
         value: '',
@@ -478,15 +478,15 @@ describe('Literal', function () {
       }).should.be.true;
     });
 
-    it('should not equal a falsy object', function () {
+    it('should not equal a falsy object', () => {
       literal.equals(null).should.be.false;
     });
 
-    it('should not equal a Literal instance with a non-empty value', function () {
+    it('should not equal a Literal instance with a non-empty value', () => {
       literal.equals(new Literal('"x"^^http://example.org/types#type')).should.be.false;
     });
 
-    it('should not equal an object with the same term type but a different value', function () {
+    it('should not equal an object with the same term type but a different value', () => {
       literal.equals({
         termType: 'Literal',
         value: 'x',
@@ -495,7 +495,7 @@ describe('Literal', function () {
       }).should.be.false;
     });
 
-    it('should not equal an object with the same term type but a different language', function () {
+    it('should not equal an object with the same term type but a different language', () => {
       literal.equals({
         termType: 'Literal',
         value: '',
@@ -504,7 +504,7 @@ describe('Literal', function () {
       }).should.be.false;
     });
 
-    it('should not equal an object with the same term type but a different datatype', function () {
+    it('should not equal an object with the same term type but a different datatype', () => {
       literal.equals({
         termType: 'Literal',
         value: '',
@@ -513,7 +513,7 @@ describe('Literal', function () {
       }).should.be.false;
     });
 
-    it('should not equal an object with a different term type', function () {
+    it('should not equal an object with a different term type', () => {
       literal.equals({
         termType: 'NamedNode',
         value: '',
@@ -522,7 +522,7 @@ describe('Literal', function () {
       }).should.be.false;
     });
 
-    it('should provide a JSON representation', function () {
+    it('should provide a JSON representation', () => {
       literal.toJSON().should.deep.equal({
         termType: 'Literal',
         value: '',
@@ -535,45 +535,45 @@ describe('Literal', function () {
     });
   });
 
-  describe('A Literal instance created from a string with a datatype', function () {
+  describe('A Literal instance created from a string with a datatype', () => {
     var literal;
-    before(function () { literal = new Literal('"my @^^ string"^^http://example.org/types#type'); });
+    before(() => { literal = new Literal('"my @^^ string"^^http://example.org/types#type'); });
 
-    it('should be a Literal', function () {
+    it('should be a Literal', () => {
       literal.should.be.an.instanceof(Literal);
     });
 
-    it('should be a Term', function () {
+    it('should be a Term', () => {
       literal.should.be.an.instanceof(Term);
     });
 
-    it('should have term type "Literal"', function () {
+    it('should have term type "Literal"', () => {
       literal.termType.should.equal('Literal');
     });
 
-    it('should have the text value as value', function () {
+    it('should have the text value as value', () => {
       literal.should.have.property('value', 'my @^^ string');
     });
 
-    it('should have the empty string as language', function () {
+    it('should have the empty string as language', () => {
       literal.should.have.property('language', '');
     });
 
-    it('should have the datatype', function () {
+    it('should have the datatype', () => {
       literal.should.have.property('datatype');
       literal.datatype.should.be.an.instanceof(NamedNode);
       literal.datatype.value.should.equal('http://example.org/types#type');
     });
 
-    it('should have the quoted string as id', function () {
+    it('should have the quoted string as id', () => {
       literal.should.have.property('id', '"my @^^ string"^^http://example.org/types#type');
     });
 
-    it('should equal a Literal instance with the same value', function () {
+    it('should equal a Literal instance with the same value', () => {
       literal.equals(new Literal('"my @^^ string"^^http://example.org/types#type')).should.be.true;
     });
 
-    it('should equal an object with the same term type, value, language, and datatype', function () {
+    it('should equal an object with the same term type, value, language, and datatype', () => {
       literal.equals({
         termType: 'Literal',
         value: 'my @^^ string',
@@ -582,15 +582,15 @@ describe('Literal', function () {
       }).should.be.true;
     });
 
-    it('should not equal a falsy object', function () {
+    it('should not equal a falsy object', () => {
       literal.equals(null).should.be.false;
     });
 
-    it('should not equal a Literal instance with another value', function () {
+    it('should not equal a Literal instance with another value', () => {
       literal.equals(new Literal('"other string"^^http://example.org/types#type')).should.be.false;
     });
 
-    it('should not equal an object with the same term type but a different value', function () {
+    it('should not equal an object with the same term type but a different value', () => {
       literal.equals({
         termType: 'Literal',
         value: 'other string',
@@ -599,7 +599,7 @@ describe('Literal', function () {
       }).should.be.false;
     });
 
-    it('should not equal an object with the same term type but a different language', function () {
+    it('should not equal an object with the same term type but a different language', () => {
       literal.equals({
         termType: 'Literal',
         value: 'my @^^ string',
@@ -608,7 +608,7 @@ describe('Literal', function () {
       }).should.be.false;
     });
 
-    it('should not equal an object with the same term type but a different datatype', function () {
+    it('should not equal an object with the same term type but a different datatype', () => {
       literal.equals({
         termType: 'Literal',
         value: 'my @^^ string',
@@ -617,7 +617,7 @@ describe('Literal', function () {
       }).should.be.false;
     });
 
-    it('should not equal an object with a different term type', function () {
+    it('should not equal an object with a different term type', () => {
       literal.equals({
         termType: 'NamedNode',
         value: 'my @^^ string',
@@ -626,7 +626,7 @@ describe('Literal', function () {
       }).should.be.false;
     });
 
-    it('should provide a JSON representation', function () {
+    it('should provide a JSON representation', () => {
       literal.toJSON().should.deep.equal({
         termType: 'Literal',
         value: 'my @^^ string',

--- a/test/N3DataFactory-test.js
+++ b/test/N3DataFactory-test.js
@@ -8,100 +8,100 @@ import {
   Quad,
 } from '../src/';
 
-describe('DataFactory', function () {
-  describe('namedNode', function () {
-    it('converts a plain IRI', function () {
+describe('DataFactory', () => {
+  describe('namedNode', () => {
+    it('converts a plain IRI', () => {
       DataFactory.namedNode('http://ex.org/foo#bar').should.deep.equal(new NamedNode('http://ex.org/foo#bar'));
     });
   });
 
-  describe('blankNode', function () {
-    it('converts a label', function () {
+  describe('blankNode', () => {
+    it('converts a label', () => {
       DataFactory.blankNode('abc').should.deep.equal(new BlankNode('abc'));
     });
 
-    it('creates an anonymous blank node', function () {
+    it('creates an anonymous blank node', () => {
       DataFactory.blankNode().should.deep.equal(new BlankNode('n3-0'));
       DataFactory.blankNode().should.deep.equal(new BlankNode('n3-1'));
     });
 
-    it('does not create two equal anonymous blank nodes', function () {
+    it('does not create two equal anonymous blank nodes', () => {
       DataFactory.blankNode().should.not.deep.equal(DataFactory.blankNode());
     });
   });
 
-  describe('literal', function () {
-    it('converts the empty string', function () {
+  describe('literal', () => {
+    it('converts the empty string', () => {
       DataFactory.literal('').should.deep.equal(new Literal('""'));
     });
 
-    it('converts the empty string with a language', function () {
+    it('converts the empty string with a language', () => {
       DataFactory.literal('', 'en-GB').should.deep.equal(new Literal('""@en-gb'));
     });
 
-    it('converts the empty string with a named node type', function () {
+    it('converts the empty string with a named node type', () => {
       DataFactory.literal('', new NamedNode('http://ex.org/type')).should.deep.equal(new Literal('""^^http://ex.org/type'));
     });
 
-    it('converts a non-empty string', function () {
+    it('converts a non-empty string', () => {
       DataFactory.literal('abc').should.deep.equal(new Literal('"abc"'));
     });
 
-    it('converts a non-empty string with a language', function () {
+    it('converts a non-empty string with a language', () => {
       DataFactory.literal('abc', 'en-GB').should.deep.equal(new Literal('"abc"@en-gb'));
     });
 
-    it('converts a non-empty string with a named node type', function () {
+    it('converts a non-empty string with a named node type', () => {
       DataFactory.literal('abc', new NamedNode('http://ex.org/type')).should.deep.equal(new Literal('"abc"^^http://ex.org/type'));
     });
 
-    it('converts a non-empty string with an xsd:string type', function () {
+    it('converts a non-empty string with an xsd:string type', () => {
       DataFactory.literal('abc', new NamedNode('http://www.w3.org/2001/XMLSchema#string')).should.deep.equal(new Literal('"abc"'));
     });
 
-    it('converts an integer', function () {
+    it('converts an integer', () => {
       DataFactory.literal(123).should.deep.equal(new Literal('"123"^^http://www.w3.org/2001/XMLSchema#integer'));
     });
 
-    it('converts a double', function () {
+    it('converts a double', () => {
       DataFactory.literal(2.3).should.deep.equal(new Literal('"2.3"^^http://www.w3.org/2001/XMLSchema#double'));
     });
 
-    it('converts Infinity', function () {
+    it('converts Infinity', () => {
       DataFactory.literal(Infinity).should.deep.equal(new Literal('"INF"^^http://www.w3.org/2001/XMLSchema#double'));
     });
 
-    it('converts -Infinity', function () {
+    it('converts -Infinity', () => {
       DataFactory.literal(-Infinity).should.deep.equal(new Literal('"-INF"^^http://www.w3.org/2001/XMLSchema#double'));
     });
 
-    it('converts NaN', function () {
+    it('converts NaN', () => {
       DataFactory.literal(NaN).should.deep.equal(new Literal('"NaN"^^http://www.w3.org/2001/XMLSchema#double'));
     });
 
-    it('converts false', function () {
+    it('converts false', () => {
       DataFactory.literal(false).should.deep.equal(new Literal('"false"^^http://www.w3.org/2001/XMLSchema#boolean'));
     });
 
-    it('converts true', function () {
+    it('converts true', () => {
       DataFactory.literal(true).should.deep.equal(new Literal('"true"^^http://www.w3.org/2001/XMLSchema#boolean'));
     });
   });
 
-  describe('variable', function () {
-    it('converts a label', function () {
+  describe('variable', () => {
+    it('converts a label', () => {
       DataFactory.variable('abc').should.deep.equal(new Variable('abc'));
     });
   });
 
-  describe('defaultGraph', function () {
-    it('returns the default graph', function () {
+  describe('defaultGraph', () => {
+    it('returns the default graph', () => {
       DataFactory.defaultGraph().should.deep.equal(new DefaultGraph());
     });
   });
 
-  describe('triple', function () {
-    it('returns a quad in the default graph', function () {
+  describe('triple', () => {
+    it('returns a quad in the default graph', () => {
       DataFactory.triple(
         new NamedNode('http://ex.org/a'),
         new NamedNode('http://ex.org/b'),
@@ -115,8 +115,8 @@ describe('DataFactory', function () {
     });
   });
 
-  describe('quad', function () {
-    it('returns a quad', function () {
+  describe('quad', () => {
+    it('returns a quad', () => {
       DataFactory.quad(
         new NamedNode('http://ex.org/a'),
         new NamedNode('http://ex.org/b'),
@@ -130,7 +130,7 @@ describe('DataFactory', function () {
       ));
     });
 
-    it('should return a nested quad', function () {
+    it('should return a nested quad', () => {
       DataFactory.quad(
         new Quad(
           new NamedNode('http://ex.org/a'),
@@ -154,7 +154,7 @@ describe('DataFactory', function () {
       ));
     });
 
-    it('should return a nested quad', function () {
+    it('should return a nested quad', () => {
       DataFactory.quad(
         new NamedNode('http://ex.org/a'),
         new NamedNode('http://ex.org/b'),
@@ -178,7 +178,7 @@ describe('DataFactory', function () {
       ));
     });
 
-    it('without graph parameter returns a quad in the default graph', function () {
+    it('without graph parameter returns a quad in the default graph', () => {
       DataFactory.quad(
         new NamedNode('http://ex.org/a'),
         new NamedNode('http://ex.org/b'),

--- a/test/N3Lexer-test.js
+++ b/test/N3Lexer-test.js
@@ -3,18 +3,18 @@ import queueMicrotask from 'queue-microtask';
 
 import { EventEmitter } from 'events';
 
-describe('Lexer', function () {
-  describe('The Lexer export', function () {
-    it('should be a function', function () {
+describe('Lexer', () => {
+  describe('The Lexer export', () => {
+    it('should be a function', () => {
       Lexer.should.be.a('function');
     });
 
-    it('should be an Lexer constructor', function () {
+    it('should be an Lexer constructor', () => {
       new Lexer().should.be.an.instanceof(Lexer);
     });
   });
 
-  describe('A Lexer instance', function () {
+  describe('A Lexer instance', () => {
     it('should tokenize the empty string',
       shouldTokenize('',
                      { type: 'eof', line: 1 }));
@@ -53,9 +53,9 @@ describe('Lexer', function () {
       shouldNotTokenize('<http://ex.org/bla\\uXYZZxyzzfoo>',
                         'Unexpected "<http://ex.org/bla\\uXYZZxyzzfoo>" on line 1.'));
 
-    it('should not tokenize an IRI with a non-numeric 4-digit unicode escapes', function (done) {
+    it('should not tokenize an IRI with a non-numeric 4-digit unicode escapes', done => {
       var stream = new EventEmitter(), lexer = new Lexer();
-      lexer.tokenize(stream, function (error, token) {
+      lexer.tokenize(stream, (error, token) => {
         error.should.be.an.instanceof(Error);
         error.message.should.equal('Unexpected "<\\uz234>" on line 1.');
         done(token);
@@ -63,9 +63,9 @@ describe('Lexer', function () {
       stream.emit('data', '<\\uz234>');
     });
 
-    it('should not tokenize an IRI with a non-numeric 8-digit unicode escapes', function (done) {
+    it('should not tokenize an IRI with a non-numeric 8-digit unicode escapes', done => {
       var stream = new EventEmitter(), lexer = new Lexer();
-      lexer.tokenize(stream, function (error, token) {
+      lexer.tokenize(stream, (error, token) => {
         error.should.be.an.instanceof(Error);
         error.message.should.equal('Unexpected "<\\Uz2345678>" on line 1.');
         done(token);
@@ -820,7 +820,7 @@ describe('Lexer', function () {
     it('should not tokenize an invalid document',
       shouldNotTokenize(' \n @!', 'Unexpected "@!" on line 2.'));
 
-    it('does not call setEncoding if not available', function () {
+    it('does not call setEncoding if not available', () => {
       new Lexer().tokenize({ on: function () {} });
     });
 
@@ -1078,11 +1078,11 @@ describe('Lexer', function () {
         { type: 'eof', line: 1 }));
 
 
-    describe('passing data after the stream has been finished', function () {
+    describe('passing data after the stream has been finished', () => {
       var tokens = [], error;
-      before(function () {
+      before(() => {
         var stream = new EventEmitter(), lexer = new Lexer();
-        lexer.tokenize(stream, function (err, token) {
+        lexer.tokenize(stream, (err, token) => {
           if (err)
             error = err;
           else
@@ -1094,20 +1094,20 @@ describe('Lexer', function () {
         stream.emit('end');
       });
 
-      it('parses only the first chunk (plus EOF)', function () {
+      it('parses only the first chunk (plus EOF)', () => {
         tokens.should.have.length(2);
       });
 
-      it('does not emit an error', function () {
+      it('does not emit an error', () => {
         expect(error).to.not.exist;
       });
     });
 
-    describe('passing data after a syntax error', function () {
+    describe('passing data after a syntax error', () => {
       var tokens = [], error;
-      before(function () {
+      before(() => {
         var stream = new EventEmitter(), lexer = new Lexer();
-        lexer.tokenize(stream, function (err, token) {
+        lexer.tokenize(stream, (err, token) => {
           if (err)
             error = err;
           else
@@ -1120,21 +1120,21 @@ describe('Lexer', function () {
         stream.emit('end');
       });
 
-      it('parses only the first chunk', function () {
+      it('parses only the first chunk', () => {
         tokens.should.have.length(1);
       });
 
-      it('emits the error', function () {
+      it('emits the error', () => {
         expect(error).to.exist;
         expect(error).to.have.property('message', 'Unexpected "error" on line 1.');
       });
     });
 
-    describe('when the stream errors', function () {
+    describe('when the stream errors', () => {
       var tokens = [], error;
-      before(function () {
+      before(() => {
         var stream = new EventEmitter(), lexer = new Lexer();
-        lexer.tokenize(stream, function (err, token) {
+        lexer.tokenize(stream, (err, token) => {
           if (err)
             error = err;
           else
@@ -1143,17 +1143,17 @@ describe('Lexer', function () {
         stream.emit('error', new Error('my error'));
       });
 
-      it('passes the error', function () {
+      it('passes the error', () => {
         expect(error).to.exist;
         expect(error).to.have.property('message', 'my error');
       });
     });
 
-    describe('called with a string and without callback', function () {
+    describe('called with a string and without callback', () => {
       var lexer = new Lexer(),
           tokens = lexer.tokenize('<a> <b> <c>.');
 
-      it('returns all tokens synchronously', function () {
+      it('returns all tokens synchronously', () => {
         tokens.should.deep.equal([
           { line: 1, type: 'IRI', value: 'a', prefix: '' },
           { line: 1, type: 'IRI', value: 'b', prefix: '' },
@@ -1164,10 +1164,10 @@ describe('Lexer', function () {
       });
     });
 
-    describe('called with an erroneous string and without callback', function () {
+    describe('called with an erroneous string and without callback', () => {
       var lexer = new Lexer();
 
-      it('throws an error', function () {
+      it('throws an error', () => {
         (function () { lexer.tokenize('<a> bar'); })
         .should.throw('Unexpected "bar" on line 1.');
       });
@@ -1175,7 +1175,7 @@ describe('Lexer', function () {
   });
 });
 
-describe('A Lexer instance with the n3 option set to false', function () {
+describe('A Lexer instance with the n3 option set to false', () => {
   function createLexer() { return new Lexer({ n3: false }); }
 
   it('should not tokenize a variable',
@@ -1197,7 +1197,7 @@ describe('A Lexer instance with the n3 option set to false', function () {
     shouldNotTokenize(createLexer(), ':joe^fam:father', 'Unexpected "^fam:father" on line 1.'));
 });
 
-describe('A Lexer instance with the comment option set to true', function () {
+describe('A Lexer instance with the comment option set to true', () => {
   function createLexer() { return new Lexer({ comments: true }); }
 
   it('should tokenize a single comment',

--- a/test/N3Parser-test.js
+++ b/test/N3Parser-test.js
@@ -10,18 +10,18 @@ beforeEach(() => {
 });
 Parser.prototype._blankNode = name => new BlankNode(name || `b${blankId++}`);
 
-describe('Parser', function () {
-  describe('The Parser export', function () {
-    it('should be a function', function () {
+describe('Parser', () => {
+  describe('The Parser export', () => {
+    it('should be a function', () => {
       Parser.should.be.a('function');
     });
 
-    it('should be a Parser constructor', function () {
+    it('should be a Parser constructor', () => {
       new Parser().should.be.an.instanceof(Parser);
     });
   });
 
-  describe('A Parser instance', function () {
+  describe('A Parser instance', () => {
     it('should parse the empty string',
       shouldParse(''
                   /* no triples */));
@@ -819,11 +819,11 @@ describe('Parser', function () {
                        line: 1,
                      });
 
-    it('should not error if there is no triple callback', function () {
+    it('should not error if there is no triple callback', () => {
       new Parser().parse('');
     });
 
-    it('should return prefixes through a callback', function (done) {
+    it('should return prefixes through a callback', done => {
       var prefixes = {};
       new Parser().parse('@prefix a: <http://a.org/#>. a:a a:b a:c. @prefix b: <http://b.org/#>.',
                            tripleCallback, prefixCallback);
@@ -847,7 +847,7 @@ describe('Parser', function () {
       }
     });
 
-    it('should return prefixes through a callback without triple callback', function (done) {
+    it('should return prefixes through a callback without triple callback', done => {
       var prefixes = {};
       new Parser().parse('@prefix a: <IRIa>. a:a a:b a:c. @prefix b: <IRIb>.',
                            null, prefixCallback);
@@ -861,7 +861,7 @@ describe('Parser', function () {
       }
     });
 
-    it('should return prefixes at the last triple callback', function (done) {
+    it('should return prefixes at the last triple callback', done => {
       new Parser({ baseIRI: BASE_IRI })
         .parse('@prefix a: <IRIa>. a:a a:b a:c. @prefix b: <IRIb>.', tripleCallback);
 
@@ -879,7 +879,7 @@ describe('Parser', function () {
       }
     });
 
-    it('should parse a string synchronously if no callback is given', function () {
+    it('should parse a string synchronously if no callback is given', () => {
       var triples = new Parser().parse('@prefix a: <urn:a:>. a:a a:b a:c.');
       triples.should.deep.equal([
         new Quad(termFromId('urn:a:a'), termFromId('urn:a:b'),
@@ -887,17 +887,17 @@ describe('Parser', function () {
       ]);
     });
 
-    it('should throw on syntax errors if no callback is given', function () {
+    it('should throw on syntax errors if no callback is given', () => {
       (function () { new Parser().parse('<a> bar <c>'); })
       .should.throw('Unexpected "bar" on line 1.').with.property('context').with.property('line', 1);
     });
 
-    it('should throw on grammar errors if no callback is given', function () {
+    it('should throw on grammar errors if no callback is given', () => {
       (function () { new Parser().parse('<a> <b> <c>'); })
       .should.throw('Expected entity but got eof on line 1');
     });
 
-    it('should parse an RDF* triple with a triple with iris as subject correctly', function () {
+    it('should parse an RDF* triple with a triple with iris as subject correctly', () => {
       shouldParse('<<<a> <b> <c>>> <b> <c>.',
         [['a', 'b', 'c'], 'b', 'c']);
     });
@@ -1008,7 +1008,7 @@ describe('Parser', function () {
           [['a', 'b', 'c'], 'd', 'e']));
   });
 
-  describe('An Parser instance without document IRI', function () {
+  describe('An Parser instance without document IRI', () => {
     function parser() { return new Parser(); }
 
     it('should keep relative IRIs',
@@ -1028,7 +1028,7 @@ describe('Parser', function () {
         [new NamedNode(''), new NamedNode(''), new NamedNode(''), new NamedNode('')]));
   });
 
-  describe('An Parser instance with a document IRI', function () {
+  describe('An Parser instance with a document IRI', () => {
     function parser() { return new Parser({ baseIRI: 'http://ex.org/x/yy/zzz/f.ttl' }); }
 
     it('should resolve IRIs against the document IRI',
@@ -1107,7 +1107,7 @@ describe('Parser', function () {
                   ['http://ex.org/e/k', 'http://ex.org/e/l', 'http://ex.org/e/m']));
   });
 
-  describe('A Parser instance with a blank node prefix', function () {
+  describe('A Parser instance with a blank node prefix', () => {
     function parser() { return new Parser({ baseIRI: BASE_IRI, blankNodePrefix: '_:blank' }); }
 
     it('should use the given prefix for blank nodes',
@@ -1116,7 +1116,7 @@ describe('Parser', function () {
                   ['_:blanka', 'b', '_:blankc']));
   });
 
-  describe('A Parser instance with an empty blank node prefix', function () {
+  describe('A Parser instance with an empty blank node prefix', () => {
     function parser() { return new Parser({ baseIRI: BASE_IRI, blankNodePrefix: '' }); }
 
     it('should not use a prefix for blank nodes',
@@ -1125,7 +1125,7 @@ describe('Parser', function () {
                   ['_:a', 'b', '_:c']));
   });
 
-  describe('A Parser instance with a non-string format', function () {
+  describe('A Parser instance with a non-string format', () => {
     function parser() { return new Parser({ baseIRI: BASE_IRI, format: 1 }); }
 
     it('should parse a single triple',
@@ -1135,7 +1135,7 @@ describe('Parser', function () {
       shouldParse(parser, '{<a> <b> <c>}', ['a', 'b', 'c']));
   });
 
-  describe('A Parser instance for the Turtle format', function () {
+  describe('A Parser instance for the Turtle format', () => {
     function parser() { return new Parser({ baseIRI: BASE_IRI, format: 'Turtle' }); }
 
     it('should parse a single triple',
@@ -1191,7 +1191,7 @@ describe('Parser', function () {
         'Unexpected RDF* syntax on line 1.'));
   });
 
-  describe('A Parser instance for the TurtleStar format', function () {
+  describe('A Parser instance for the TurtleStar format', () => {
     function parser() { return new Parser({ baseIRI: BASE_IRI, format: 'TurtleStar' }); }
 
     it('should parse RDF*',
@@ -1204,7 +1204,7 @@ describe('Parser', function () {
         'Expected >> to follow "_:b0_b" on line 1.'));
   });
 
-  describe('A Parser instance for the TriG format', function () {
+  describe('A Parser instance for the TriG format', () => {
     function parser() { return new Parser({ baseIRI: BASE_IRI, format: 'TriG' }); }
 
     it('should parse a single triple',
@@ -1252,7 +1252,7 @@ describe('Parser', function () {
         'Unexpected RDF* syntax on line 1.'));
   });
 
-  describe('A Parser instance for the TriGStar format', function () {
+  describe('A Parser instance for the TriGStar format', () => {
     function parser() { return new Parser({ baseIRI: BASE_IRI, format: 'TriGStar' }); }
 
     it('should parse RDF*',
@@ -1264,7 +1264,7 @@ describe('Parser', function () {
         'Expected >> to follow "_:b0_b" on line 1.'));
   });
 
-  describe('A Parser instance for the N-Triples format', function () {
+  describe('A Parser instance for the N-Triples format', () => {
     function parser() { return new Parser({ baseIRI: BASE_IRI, format: 'N-Triples' }); }
 
     it('should parse a single triple',
@@ -1323,7 +1323,7 @@ describe('Parser', function () {
         'Unexpected RDF* syntax on line 1.'));
   });
 
-  describe('A Parser instance for the N-TriplesStar format', function () {
+  describe('A Parser instance for the N-TriplesStar format', () => {
     function parser() { return new Parser({ baseIRI: BASE_IRI, format: 'N-TriplesStar' }); }
 
     it('should parse RDF*',
@@ -1335,7 +1335,7 @@ describe('Parser', function () {
         'Expected >> to follow "_:b0_b" on line 1.'));
   });
 
-  describe('A Parser instance for the N-Quads format', function () {
+  describe('A Parser instance for the N-Quads format', () => {
     function parser() { return new Parser({ baseIRI: BASE_IRI, format: 'N-Quads' }); }
 
     it('should parse a single triple',
@@ -1382,7 +1382,7 @@ describe('Parser', function () {
         'Unexpected RDF* syntax on line 1.'));
   });
 
-  describe('A Parser instance for the N-QuadsStar format', function () {
+  describe('A Parser instance for the N-QuadsStar format', () => {
     function parser() { return new Parser({ baseIRI: BASE_IRI, format: 'N-QuadsStar' }); }
 
     it('should parse RDF*',
@@ -1390,7 +1390,7 @@ describe('Parser', function () {
         [['_:b0_a', 'b', '_:b0_c'], 'a', '_:b0_c']));
   });
 
-  describe('A Parser instance for the N3 format', function () {
+  describe('A Parser instance for the N3 format', () => {
     function parser() { return new Parser({ baseIRI: BASE_IRI, format: 'N3' }); }
 
     it('should parse a single triple',
@@ -1729,7 +1729,7 @@ describe('Parser', function () {
         'Unexpected RDF* syntax on line 1.'));
   });
 
-  describe('A Parser instance for the N3Star format', function () {
+  describe('A Parser instance for the N3Star format', () => {
     function parser() { return new Parser({ baseIRI: BASE_IRI, format: 'N3Star' }); }
 
     it('should parse RDF*',
@@ -1741,7 +1741,7 @@ describe('Parser', function () {
         'Expected >> to follow "_:.b" on line 1.'));
   });
 
-  describe('A Parser instance for the N3 format with the explicitQuantifiers option', function () {
+  describe('A Parser instance for the N3 format with the explicitQuantifiers option', () => {
     function parser() { return new Parser({ baseIRI: BASE_IRI, format: 'N3', explicitQuantifiers: true }); }
 
     it('should parse a @forSome statement',
@@ -1805,17 +1805,17 @@ describe('Parser', function () {
                   ['x', 'x', 'x']));
   });
 
-  describe('A Parser instance with a custom DataFactory', function () {
+  describe('A Parser instance with a custom DataFactory', () => {
     var parser, factory = {};
-    before(function () {
+    before(() => {
       factory.quad = function (s, p, o, g) { return { s: s, p: p, o: o, g: g }; };
-      ['namedNode', 'blankNode', 'literal', 'variable', 'defaultGraph'].forEach(function (f) {
+      ['namedNode', 'blankNode', 'literal', 'variable', 'defaultGraph'].forEach(f => {
         factory[f] = function (n) { return n ? f[0] + '-' + n : f; };
       });
       parser = new Parser({ baseIRI: BASE_IRI, format: 'n3', factory: factory });
     });
 
-    it('should use the custom factory', function () {
+    it('should use the custom factory', () => {
       parser.parse('<a> ?b 1, _:d.').should.deep.equal([
         { s: 'n-http://example.org/a', p: 'v-b', o: 'l-1',    g: 'defaultGraph' },
         { s: 'n-http://example.org/a', p: 'v-b', o: 'b-b0_d', g: 'defaultGraph' },
@@ -1823,8 +1823,8 @@ describe('Parser', function () {
     });
   });
 
-  describe('IRI resolution', function () {
-    describe('RFC3986 normal examples', function () {
+  describe('IRI resolution', () => {
+    describe('RFC3986 normal examples', () => {
       itShouldResolve('http://a/bb/ccc/d;p?q', 'g:h',     'g:h');
       itShouldResolve('http://a/bb/ccc/d;p?q', 'g',       'http://a/bb/ccc/g');
       itShouldResolve('http://a/bb/ccc/d;p?q', './g',     'http://a/bb/ccc/g');
@@ -1850,7 +1850,7 @@ describe('Parser', function () {
       itShouldResolve('http://a/bb/ccc/d;p?q', '../../g', 'http://a/g');
     });
 
-    describe('RFC3986 abnormal examples', function () {
+    describe('RFC3986 abnormal examples', () => {
       itShouldResolve('http://a/bb/ccc/d;p?q', '../../../g',    'http://a/g');
       itShouldResolve('http://a/bb/ccc/d;p?q', '../../../../g', 'http://a/g');
       itShouldResolve('http://a/bb/ccc/d;p?q', '/./g',          'http://a/g');
@@ -1872,7 +1872,7 @@ describe('Parser', function () {
       itShouldResolve('http://a/bb/ccc/d;p?q', 'http:g',        'http:g');
     });
 
-    describe('RFC3986 normal examples with trailing slash in base IRI', function () {
+    describe('RFC3986 normal examples with trailing slash in base IRI', () => {
       itShouldResolve('http://a/bb/ccc/d/', 'g:h',     'g:h');
       itShouldResolve('http://a/bb/ccc/d/', 'g',       'http://a/bb/ccc/d/g');
       itShouldResolve('http://a/bb/ccc/d/', './g',     'http://a/bb/ccc/d/g');
@@ -1898,7 +1898,7 @@ describe('Parser', function () {
       itShouldResolve('http://a/bb/ccc/d/', '../../g', 'http://a/bb/g');
     });
 
-    describe('RFC3986 abnormal examples with trailing slash in base IRI', function () {
+    describe('RFC3986 abnormal examples with trailing slash in base IRI', () => {
       itShouldResolve('http://a/bb/ccc/d/', '../../../g',    'http://a/g');
       itShouldResolve('http://a/bb/ccc/d/', '../../../../g', 'http://a/g');
       itShouldResolve('http://a/bb/ccc/d/', '/./g',          'http://a/g');
@@ -1920,7 +1920,7 @@ describe('Parser', function () {
       itShouldResolve('http://a/bb/ccc/d/', 'http:g',        'http:g');
     });
 
-    describe('RFC3986 normal examples with /. in the base IRI', function () {
+    describe('RFC3986 normal examples with /. in the base IRI', () => {
       itShouldResolve('http://a/bb/ccc/./d;p?q', 'g:h',     'g:h');
       itShouldResolve('http://a/bb/ccc/./d;p?q', 'g',       'http://a/bb/ccc/g');
       itShouldResolve('http://a/bb/ccc/./d;p?q', './g',     'http://a/bb/ccc/g');
@@ -1946,7 +1946,7 @@ describe('Parser', function () {
       itShouldResolve('http://a/bb/ccc/./d;p?q', '../../g', 'http://a/g');
     });
 
-    describe('RFC3986 abnormal examples with /. in the base IRI', function () {
+    describe('RFC3986 abnormal examples with /. in the base IRI', () => {
       itShouldResolve('http://a/bb/ccc/./d;p?q', '../../../g',    'http://a/g');
       itShouldResolve('http://a/bb/ccc/./d;p?q', '../../../../g', 'http://a/g');
       itShouldResolve('http://a/bb/ccc/./d;p?q', '/./g',          'http://a/g');
@@ -1968,7 +1968,7 @@ describe('Parser', function () {
       itShouldResolve('http://a/bb/ccc/./d;p?q', 'http:g',        'http:g');
     });
 
-    describe('RFC3986 normal examples with /.. in the base IRI', function () {
+    describe('RFC3986 normal examples with /.. in the base IRI', () => {
       itShouldResolve('http://a/bb/ccc/../d;p?q', 'g:h',     'g:h');
       itShouldResolve('http://a/bb/ccc/../d;p?q', 'g',       'http://a/bb/g');
       itShouldResolve('http://a/bb/ccc/../d;p?q', './g',     'http://a/bb/g');
@@ -1994,7 +1994,7 @@ describe('Parser', function () {
       itShouldResolve('http://a/bb/ccc/../d;p?q', '../../g', 'http://a/g');
     });
 
-    describe('RFC3986 abnormal examples with /.. in the base IRI', function () {
+    describe('RFC3986 abnormal examples with /.. in the base IRI', () => {
       itShouldResolve('http://a/bb/ccc/../d;p?q', '../../../g',    'http://a/g');
       itShouldResolve('http://a/bb/ccc/../d;p?q', '../../../../g', 'http://a/g');
       itShouldResolve('http://a/bb/ccc/../d;p?q', '/./g',          'http://a/g');
@@ -2016,7 +2016,7 @@ describe('Parser', function () {
       itShouldResolve('http://a/bb/ccc/../d;p?q', 'http:g',        'http:g');
     });
 
-    describe('RFC3986 normal examples with trailing /. in the base IRI', function () {
+    describe('RFC3986 normal examples with trailing /. in the base IRI', () => {
       itShouldResolve('http://a/bb/ccc/.', 'g:h',     'g:h');
       itShouldResolve('http://a/bb/ccc/.', 'g',       'http://a/bb/ccc/g');
       itShouldResolve('http://a/bb/ccc/.', './g',     'http://a/bb/ccc/g');
@@ -2042,7 +2042,7 @@ describe('Parser', function () {
       itShouldResolve('http://a/bb/ccc/.', '../../g', 'http://a/g');
     });
 
-    describe('RFC3986 abnormal examples with trailing /. in the base IRI', function () {
+    describe('RFC3986 abnormal examples with trailing /. in the base IRI', () => {
       itShouldResolve('http://a/bb/ccc/.', '../../../g',    'http://a/g');
       itShouldResolve('http://a/bb/ccc/.', '../../../../g', 'http://a/g');
       itShouldResolve('http://a/bb/ccc/.', '/./g',          'http://a/g');
@@ -2064,7 +2064,7 @@ describe('Parser', function () {
       itShouldResolve('http://a/bb/ccc/.', 'http:g',        'http:g');
     });
 
-    describe('RFC3986 normal examples with trailing /.. in the base IRI', function () {
+    describe('RFC3986 normal examples with trailing /.. in the base IRI', () => {
       itShouldResolve('http://a/bb/ccc/..', 'g:h',     'g:h');
       itShouldResolve('http://a/bb/ccc/..', 'g',       'http://a/bb/ccc/g');
       itShouldResolve('http://a/bb/ccc/..', './g',     'http://a/bb/ccc/g');
@@ -2090,7 +2090,7 @@ describe('Parser', function () {
       itShouldResolve('http://a/bb/ccc/..', '../../g', 'http://a/g');
     });
 
-    describe('RFC3986 abnormal examples with trailing /.. in the base IRI', function () {
+    describe('RFC3986 abnormal examples with trailing /.. in the base IRI', () => {
       itShouldResolve('http://a/bb/ccc/..', '../../../g',    'http://a/g');
       itShouldResolve('http://a/bb/ccc/..', '../../../../g', 'http://a/g');
       itShouldResolve('http://a/bb/ccc/..', '/./g',          'http://a/g');
@@ -2112,7 +2112,7 @@ describe('Parser', function () {
       itShouldResolve('http://a/bb/ccc/..', 'http:g',        'http:g');
     });
 
-    describe('RFC3986 normal examples with fragment in base IRI', function () {
+    describe('RFC3986 normal examples with fragment in base IRI', () => {
       itShouldResolve('http://a/bb/ccc/d;p?q#f', 'g:h',     'g:h');
       itShouldResolve('http://a/bb/ccc/d;p?q#f', 'g',       'http://a/bb/ccc/g');
       itShouldResolve('http://a/bb/ccc/d;p?q#f', './g',     'http://a/bb/ccc/g');
@@ -2138,7 +2138,7 @@ describe('Parser', function () {
       itShouldResolve('http://a/bb/ccc/d;p?q#f', '../../g', 'http://a/g');
     });
 
-    describe('RFC3986 abnormal examples with fragment in base IRI', function () {
+    describe('RFC3986 abnormal examples with fragment in base IRI', () => {
       itShouldResolve('http://a/bb/ccc/d;p?q#f', '../../../g',    'http://a/g');
       itShouldResolve('http://a/bb/ccc/d;p?q#f', '../../../../g', 'http://a/g');
       itShouldResolve('http://a/bb/ccc/d;p?q#f', '/./g',          'http://a/g');
@@ -2160,7 +2160,7 @@ describe('Parser', function () {
       itShouldResolve('http://a/bb/ccc/d;p?q#f', 'http:g',        'http:g');
     });
 
-    describe('RFC3986 normal examples with file path', function () {
+    describe('RFC3986 normal examples with file path', () => {
       itShouldResolve('file:///a/bb/ccc/d;p?q', 'g:h',     'g:h');
       itShouldResolve('file:///a/bb/ccc/d;p?q', 'g',       'file:///a/bb/ccc/g');
       itShouldResolve('file:///a/bb/ccc/d;p?q', './g',     'file:///a/bb/ccc/g');
@@ -2186,7 +2186,7 @@ describe('Parser', function () {
       itShouldResolve('file:///a/bb/ccc/d;p?q', '../../g', 'file:///a/g');
     });
 
-    describe('RFC3986 abnormal examples with file path', function () {
+    describe('RFC3986 abnormal examples with file path', () => {
       itShouldResolve('file:///a/bb/ccc/d;p?q', '../../../g',    'file:///g');
       itShouldResolve('file:///a/bb/ccc/d;p?q', '../../../../g', 'file:///g');
       itShouldResolve('file:///a/bb/ccc/d;p?q', '/./g',          'file:///g');
@@ -2208,7 +2208,7 @@ describe('Parser', function () {
       itShouldResolve('file:///a/bb/ccc/d;p?q', 'http:g',        'http:g');
     });
 
-    describe('additional cases', function () {
+    describe('additional cases', () => {
       // relative paths ending with '.'
       itShouldResolve('http://abc/',        '.',      'http://abc/');
       itShouldResolve('http://abc/def/ghi', '.',      'http://abc/def/');
@@ -2263,7 +2263,7 @@ function shouldParse(parser, input) {
   return function (done) {
     var results = [];
     var items = expected.map(mapToQuad);
-    new parser({ baseIRI: BASE_IRI }).parse(input, function (error, triple) {
+    new parser({ baseIRI: BASE_IRI }).parse(input, (error, triple) => {
       expect(error).not.to.exist;
       if (triple)
         results.push(triple);
@@ -2274,7 +2274,7 @@ function shouldParse(parser, input) {
 }
 
 function mapToQuad(item) {
-  item = item.map(function (t) {
+  item = item.map(t => {
     // don't touch if it's already an object
     if (typeof t === 'object')
       // recursively map content if it's an array
@@ -2288,7 +2288,7 @@ function mapToQuad(item) {
 }
 
 function toSortedJSON(triples) {
-  triples = triples.map(function (t) {
+  triples = triples.map(t => {
     return JSON.stringify([
       t.subject.toJSON(), t.predicate.toJSON(), t.object.toJSON(), t.graph.toJSON(),
     ]);
@@ -2303,7 +2303,7 @@ function shouldNotParse(parser, input, expectedError, expectedContext) {
     expectedContext = expectedError, expectedError = input, input = parser, parser = Parser;
 
   return function (done) {
-    new parser({ baseIRI: BASE_IRI }).parse(input, function (error, triple) {
+    new parser({ baseIRI: BASE_IRI }).parse(input, (error, triple) => {
       if (error) {
         expect(triple).not.to.exist;
         error.should.be.an.instanceof(Error);
@@ -2319,11 +2319,11 @@ function shouldNotParse(parser, input, expectedError, expectedContext) {
 
 function itShouldResolve(baseIri, relativeIri, expected) {
   var result;
-  describe('resolving <' + relativeIri + '> against <' + baseIri + '>', function () {
-    before(function (done) {
+  describe('resolving <' + relativeIri + '> against <' + baseIri + '>', () => {
+    before(done => {
       try {
         var doc = '<urn:ex:s> <urn:ex:p> <' + relativeIri + '>.';
-        new Parser({ baseIRI: baseIri }).parse(doc, function (error, triple) {
+        new Parser({ baseIRI: baseIri }).parse(doc, (error, triple) => {
           if (done)
             result = triple, done(error);
           done = null;
@@ -2331,7 +2331,7 @@ function itShouldResolve(baseIri, relativeIri, expected) {
       }
       catch (error) { done(error); }
     });
-    it('should result in ' + expected, function () {
+    it('should result in ' + expected, () => {
       expect(result.object.value).to.equal(expected);
     });
   });

--- a/test/N3Store-test.js
+++ b/test/N3Store-test.js
@@ -10,30 +10,30 @@ import namespaces from '../src/IRIs';
 import { Readable } from 'readable-stream';
 import arrayifyStream from 'arrayify-stream';
 
-describe('Store', function () {
-  describe('The Store export', function () {
-    it('should be a function', function () {
+describe('Store', () => {
+  describe('The Store export', () => {
+    it('should be a function', () => {
       Store.should.be.a('function');
     });
 
-    it('should be an Store constructor', function () {
+    it('should be an Store constructor', () => {
       new Store().should.be.an.instanceof(Store);
     });
   });
 
-  describe('An empty Store', function () {
+  describe('An empty Store', () => {
     var store = new Store({});
 
-    it('should have size 0', function () {
+    it('should have size 0', () => {
       expect(store.size).to.eql(0);
     });
 
-    it('should be empty', function () {
+    it('should be empty', () => {
       store.getQuads().should.be.empty;
     });
 
-    describe('when importing a stream of 2 quads', function () {
-      before(function (done) {
+    describe('when importing a stream of 2 quads', () => {
+      before(done => {
         var stream = new ArrayReader([
           new Quad(new NamedNode('s1'), new NamedNode('p2'), new NamedNode('o2')),
           new Quad(new NamedNode('s1'), new NamedNode('p1'), new NamedNode('o1')),
@@ -42,11 +42,11 @@ describe('Store', function () {
         events.on('end', done);
       });
 
-      it('should have size 2', function () { store.size.should.eql(2); });
+      it('should have size 2', () => { store.size.should.eql(2); });
     });
 
-    describe('when removing a stream of 2 quads', function () {
-      before(function (done) {
+    describe('when removing a stream of 2 quads', () => {
+      before(done => {
         var stream = new ArrayReader([
           new Quad(new NamedNode('s1'), new NamedNode('p2'), new NamedNode('o2')),
           new Quad(new NamedNode('s1'), new NamedNode('p1'), new NamedNode('o1')),
@@ -55,11 +55,11 @@ describe('Store', function () {
         events.on('end', done);
       });
 
-      it('should have size 0', function () { store.size.should.eql(0); });
+      it('should have size 0', () => { store.size.should.eql(0); });
     });
 
-    describe('when importing a stream of 2 nested quads', function () {
-      before(function (done) {
+    describe('when importing a stream of 2 nested quads', () => {
+      before(done => {
         var stream = new ArrayReader([
           new Quad(new Quad(new NamedNode('s1'), new NamedNode('p2'), new NamedNode('o2')), new NamedNode('p2'), new NamedNode('o2')),
           new Quad(new NamedNode('s1'), new NamedNode('p1'), new Quad(new NamedNode('s1'), new NamedNode('p2'), new NamedNode('o2'))),
@@ -68,11 +68,11 @@ describe('Store', function () {
         events.on('end', done);
       });
 
-      it('should have size 2', function () { store.size.should.eql(2); });
+      it('should have size 2', () => { store.size.should.eql(2); });
     });
 
-    describe('when removing a stream of 2 nested quads', function () {
-      before(function (done) {
+    describe('when removing a stream of 2 nested quads', () => {
+      before(done => {
         var stream = new ArrayReader([
           new Quad(new Quad(new NamedNode('s1'), new NamedNode('p2'), new NamedNode('o2')), new NamedNode('p2'), new NamedNode('o2')),
           new Quad(new NamedNode('s1'), new NamedNode('p1'), new Quad(new NamedNode('s1'), new NamedNode('p2'), new NamedNode('o2'))),
@@ -81,43 +81,43 @@ describe('Store', function () {
         events.on('end', done);
       });
 
-      it('should have size 0', function () { store.size.should.eql(0); });
+      it('should have size 0', () => { store.size.should.eql(0); });
     });
 
-    describe('every', function () {
-      describe('with no parameters and a callback always returning true', function () {
-        it('should return false', function () {
+    describe('every', () => {
+      describe('with no parameters and a callback always returning true', () => {
+        it('should return false', () => {
           store.every(alwaysTrue, null, null, null, null).should.be.false;
         });
       });
-      describe('with no parameters and a callback always returning false', function () {
-        it('should return false', function () {
+      describe('with no parameters and a callback always returning false', () => {
+        it('should return false', () => {
           store.every(alwaysFalse, null, null, null, null).should.be.false;
         });
       });
     });
 
-    describe('some', function () {
-      describe('with no parameters and a callback always returning true', function () {
-        it('should return false', function () {
+    describe('some', () => {
+      describe('with no parameters and a callback always returning true', () => {
+        it('should return false', () => {
           store.some(alwaysTrue, null, null, null, null).should.be.false;
         });
       });
-      describe('with no parameters and a callback always returning false', function () {
-        it('should return false', function () {
+      describe('with no parameters and a callback always returning false', () => {
+        it('should return false', () => {
           store.some(alwaysFalse, null, null, null, null).should.be.false;
         });
       });
     });
 
-    it('should still have size 0 (instead of null) after adding and removing a triple', function () {
+    it('should still have size 0 (instead of null) after adding and removing a triple', () => {
       expect(store.size).to.eql(0);
       store.addQuad(new NamedNode('a'), new NamedNode('b'), new NamedNode('c')).should.be.true;
       store.removeQuad(new NamedNode('a'), new NamedNode('b'), new NamedNode('c')).should.be.true;
       expect(store.size).to.eql(0);
     });
 
-    it('should be able to generate unnamed blank nodes', function () {
+    it('should be able to generate unnamed blank nodes', () => {
       store.createBlankNode().value.should.eql('b0');
       store.createBlankNode().value.should.eql('b1');
 
@@ -126,20 +126,20 @@ describe('Store', function () {
       store.removeQuads(store.getQuads());
     });
 
-    it('should be able to generate named blank nodes', function () {
+    it('should be able to generate named blank nodes', () => {
       store.createBlankNode('blank').value.should.eql('blank');
       store.createBlankNode('blank').value.should.eql('blank1');
       store.createBlankNode('blank').value.should.eql('blank2');
     });
 
-    it('should be able to store triples with generated blank nodes', function () {
+    it('should be able to store triples with generated blank nodes', () => {
       store.addQuad(store.createBlankNode('x'), new NamedNode('b'), new NamedNode('c')).should.be.true;
       shouldIncludeAll(store.getQuads(null, new NamedNode('b')), ['_:x', 'b', 'c'])();
       store.removeQuads(store.getQuads());
     });
   });
 
-  describe('A Store with initialized with 5 elements', function () {
+  describe('A Store with initialized with 5 elements', () => {
     var store = new Store([
       new Quad(new Quad(new NamedNode('s1'), new NamedNode('p1'), new NamedNode('o1')), new NamedNode('p1'), new NamedNode('o1')),
       new Quad(new NamedNode('s1'), new NamedNode('p1'), new NamedNode('o1')),
@@ -148,106 +148,106 @@ describe('Store', function () {
       new Quad(new NamedNode('s2'), new NamedNode('p2'), new NamedNode('o2'), new NamedNode('g1')),
     ]);
 
-    it('should have size 5', function () {
+    it('should have size 5', () => {
       store.size.should.eql(5);
     });
 
-    describe('adding a triple that already exists', function () {
-      it('should return false', function () {
+    describe('adding a triple that already exists', () => {
+      it('should return false', () => {
         store.addQuad('s1', 'p1', 'o1').should.be.false;
       });
 
-      it('should not increase the size', function () {
+      it('should not increase the size', () => {
         store.size.should.eql(5);
       });
 
-      it('should return false', function () {
+      it('should return false', () => {
         store.addQuad(new Quad('s1', 'p1', 'o1'), 'p1', 'o1').should.be.false;
       });
 
-      it('should not increase the size', function () {
+      it('should not increase the size', () => {
         store.size.should.eql(5);
       });
     });
 
-    describe('adding a triple that did not exist yet', function () {
-      it('should return true', function () {
+    describe('adding a triple that did not exist yet', () => {
+      it('should return true', () => {
         store.addQuad('s1', 'p1', 'o4').should.be.true;
       });
 
-      it('should increase the size', function () {
+      it('should increase the size', () => {
         store.size.should.eql(6);
       });
 
-      it('should return true', function () {
+      it('should return true', () => {
         store.addQuad(new Quad(new NamedNode('s1'), new NamedNode('p1'), new NamedNode('o1')), 'p1', 'o4').should.be.true;
       });
 
-      it('should increase the size', function () {
+      it('should increase the size', () => {
         store.size.should.eql(7);
       });
     });
 
-    describe('removing an existing triple', function () {
-      it('should return true', function () {
+    describe('removing an existing triple', () => {
+      it('should return true', () => {
         store.removeQuad('s1', 'p1', 'o4').should.be.true;
       });
 
-      it('should decrease the size', function () {
+      it('should decrease the size', () => {
         store.size.should.eql(6);
       });
 
-      it('should return true', function () {
+      it('should return true', () => {
         store.removeQuad(new Quad(new NamedNode('s1'), new NamedNode('p1'), new NamedNode('o1')), 'p1', 'o4').should.be.true;
       });
 
-      it('should decrease the size', function () {
+      it('should decrease the size', () => {
         store.size.should.eql(5);
       });
     });
 
-    describe('removing a non-existing triple', function () {
-      it('should return false', function () {
+    describe('removing a non-existing triple', () => {
+      it('should return false', () => {
         store.removeQuad('s1', 'p1', 'o5').should.be.false;
       });
 
-      it('should not decrease the size', function () {
+      it('should not decrease the size', () => {
         store.size.should.eql(5);
       });
 
-      it('should return false', function () {
+      it('should return false', () => {
         store.removeQuad(new Quad(new NamedNode('s1'), new NamedNode('p1'), new NamedNode('o4')), 'p1', 'o1').should.be.false;
       });
 
-      it('should not decrease the size', function () {
+      it('should not decrease the size', () => {
         store.size.should.eql(5);
       });
     });
 
-    describe('removing matching quads', function () {
+    describe('removing matching quads', () => {
       it('should return the removed quads',
-        forResultStream(shouldIncludeAll, function () { return store.removeMatches('s1', 'p1'); },
+        forResultStream(shouldIncludeAll, () => { return store.removeMatches('s1', 'p1'); },
           ['s1', 'p1', 'o1'],
           ['s1', 'p1', 'o2'],
           ['s1', 'p1', 'o3']));
 
-      it('should decrease the size', function () {
+      it('should decrease the size', () => {
         store.size.should.eql(2);
       });
     });
 
-    describe('removing a graph', function () {
+    describe('removing a graph', () => {
       it('should return the removed quads',
-        forResultStream(shouldIncludeAll, function () { return store.deleteGraph('g1'); },
+        forResultStream(shouldIncludeAll, () => { return store.deleteGraph('g1'); },
           ['s2', 'p2', 'o2', 'g1']));
 
-      it('should decrease the size', function () {
+      it('should decrease the size', () => {
         store.size.should.eql(1);
       });
     });
   });
 
-  describe('removing matching quads for RDF*', function () {
+  describe('removing matching quads for RDF*', () => {
     let store;
     beforeEach(() => {
       store = new Store([
@@ -260,14 +260,14 @@ describe('Store', function () {
     });
 
     it('should return the removed quads',
-      forResultStream(shouldIncludeAll, function () { return store.removeMatches(null, 'p2', 'o2'); },
+      forResultStream(shouldIncludeAll, () => { return store.removeMatches(null, 'p2', 'o2'); },
         [termToId(new Quad(new NamedNode('s1'), new NamedNode('p1'), new NamedNode('o1'))), 'p2', 'o2']));
 
-    it('should decrease the size', function () {
+    it('should decrease the size', () => {
       store.size.should.eql(5);
     });
 
-    it('should match RDF* and normal quads at the same time', function (done) {
+    it('should match RDF* and normal quads at the same time', done => {
       let stream = store.removeMatches(null, 'p1', 'o2');
       stream.on('end', () => {
         store.size.should.eql(3);
@@ -275,7 +275,7 @@ describe('Store', function () {
       });
     });
 
-    it('should allow matching using a quad', function (done) {
+    it('should allow matching using a quad', done => {
       let stream = store.removeMatches(termToId(new Quad(new NamedNode('s1'), new NamedNode('p1'), new NamedNode('o1'))));
       stream.on('end', () => {
         store.size.should.eql(1);
@@ -285,7 +285,7 @@ describe('Store', function () {
   });
 
 
-  describe('A Store with 5 elements', function () {
+  describe('A Store with 5 elements', () => {
     var store = new Store();
     store.addQuad('s1', 'p1', 'o1').should.be.true;
     store.addQuad({ subject: 's1', predicate: 'p1', object: 'o2' }).should.be.true;
@@ -296,11 +296,11 @@ describe('Store', function () {
     store.addQuad('s1', 'p1', 'o1', 'c4').should.be.true;
     store.addQuad(new Quad('s2', 'p2', 'o2'), 'p1', 'o3');
 
-    it('should have size 6', function () {
+    it('should have size 6', () => {
       store.size.should.eql(6);
     });
 
-    describe('when searched without parameters', function () {
+    describe('when searched without parameters', () => {
       it('should return all items',
         shouldIncludeAll(store.getQuads(),
                          ['s1', 'p1', 'o1'],
@@ -311,7 +311,7 @@ describe('Store', function () {
                          [termToId(new Quad('s2', 'p2', 'o2')), 'p1', 'o3']));
     });
 
-    describe('when searched with an existing subject parameter', function () {
+    describe('when searched with an existing subject parameter', () => {
       it('should return all items with this subject in all graphs',
         shouldIncludeAll(store.getQuads(new NamedNode('s1'), null, null),
                          ['s1', 'p1', 'o1'],
@@ -320,15 +320,15 @@ describe('Store', function () {
                          ['s1', 'p1', 'o1', 'c4']));
     });
 
-    describe('when searched with a non-existing subject parameter', function () {
+    describe('when searched with a non-existing subject parameter', () => {
       itShouldBeEmpty(store.getQuads(new NamedNode('s3'), null, null));
     });
 
-    describe('when searched with a non-existing subject parameter that exists elsewhere', function () {
+    describe('when searched with a non-existing subject parameter that exists elsewhere', () => {
       itShouldBeEmpty(store.getQuads(new NamedNode('p1'), null, null));
     });
 
-    describe('when searched with an existing predicate parameter', function () {
+    describe('when searched with an existing predicate parameter', () => {
       it('should return all items with this predicate in all graphs',
         shouldIncludeAll(store.getQuads(null, new NamedNode('p1'), null),
                          ['s1', 'p1', 'o1'],
@@ -338,11 +338,11 @@ describe('Store', function () {
                          [termToId(new Quad('s2', 'p2', 'o2')), 'p1', 'o3']));
     });
 
-    describe('when searched with a non-existing predicate parameter', function () {
+    describe('when searched with a non-existing predicate parameter', () => {
       itShouldBeEmpty(store.getQuads(null, new NamedNode('p3'), null));
     });
 
-    describe('when searched with an existing object parameter', function () {
+    describe('when searched with an existing object parameter', () => {
       it('should return all items with this object in all graphs',
         shouldIncludeAll(store.getQuads(null, null, new NamedNode('o1')),
                          ['s1', 'p1', 'o1'],
@@ -350,11 +350,11 @@ describe('Store', function () {
                          ['s1', 'p1', 'o1', 'c4']));
     });
 
-    describe('when searched with a non-existing object parameter', function () {
+    describe('when searched with a non-existing object parameter', () => {
       itShouldBeEmpty(store.getQuads(null, null, new NamedNode('o4')));
     });
 
-    describe('when searched with existing subject and predicate parameters', function () {
+    describe('when searched with existing subject and predicate parameters', () => {
       it('should return all items with this subject and predicate in all graphs',
         shouldIncludeAll(store.getQuads(new NamedNode('s1'), new NamedNode('p1'), null),
                          ['s1', 'p1', 'o1'],
@@ -362,22 +362,22 @@ describe('Store', function () {
                          ['s1', 'p1', 'o1', 'c4']));
     });
 
-    describe('when searched with non-existing subject and predicate parameters', function () {
+    describe('when searched with non-existing subject and predicate parameters', () => {
       itShouldBeEmpty(store.getQuads(new NamedNode('s2'), new NamedNode('p2'), null));
     });
 
-    describe('when searched with existing subject and object parameters', function () {
+    describe('when searched with existing subject and object parameters', () => {
       it('should return all items with this subject and object in all graphs',
         shouldIncludeAll(store.getQuads(new NamedNode('s1'), null, new NamedNode('o1')),
                          ['s1', 'p1', 'o1'],
                          ['s1', 'p1', 'o1', 'c4']));
     });
 
-    describe('when searched with non-existing subject and object parameters', function () {
+    describe('when searched with non-existing subject and object parameters', () => {
       itShouldBeEmpty(store.getQuads(new NamedNode('s2'), new NamedNode('p2'), null));
     });
 
-    describe('when searched with existing predicate and object parameters', function () {
+    describe('when searched with existing predicate and object parameters', () => {
       it('should return all items with this predicate and object in all graphs',
         shouldIncludeAll(store.getQuads(null, new NamedNode('p1'), new NamedNode('o1')),
                          ['s1', 'p1', 'o1'],
@@ -385,22 +385,22 @@ describe('Store', function () {
                          ['s1', 'p1', 'o1', 'c4']));
     });
 
-    describe('when searched with non-existing predicate and object parameters in the default graph', function () {
+    describe('when searched with non-existing predicate and object parameters in the default graph', () => {
       itShouldBeEmpty(store.getQuads(null, new NamedNode('p2'), new NamedNode('o3'), new DefaultGraph()));
     });
 
-    describe('when searched with existing subject, predicate, and object parameters', function () {
+    describe('when searched with existing subject, predicate, and object parameters', () => {
       it('should return all items with this subject, predicate, and object in all graphs',
         shouldIncludeAll(store.getQuads(new NamedNode('s1'), new NamedNode('p1'), new NamedNode('o1')),
                          ['s1', 'p1', 'o1'],
                          ['s1', 'p1', 'o1', 'c4']));
     });
 
-    describe('when searched with a non-existing triple', function () {
+    describe('when searched with a non-existing triple', () => {
       itShouldBeEmpty(store.getQuads(new NamedNode('s2'), new NamedNode('p2'), new NamedNode('o1')));
     });
 
-    describe('when searched with the default graph parameter', function () {
+    describe('when searched with the default graph parameter', () => {
       it('should return all items in the default graph',
         shouldIncludeAll(store.getQuads(null, null, null, new DefaultGraph()),
                          ['s1', 'p1', 'o1'],
@@ -410,18 +410,18 @@ describe('Store', function () {
                          [termToId(new Quad('s2', 'p2', 'o2')), 'p1', 'o3']));
     });
 
-    describe('when searched with an existing named graph parameter', function () {
+    describe('when searched with an existing named graph parameter', () => {
       it('should return all items in that graph',
         shouldIncludeAll(store.getQuads(null, null, null, new NamedNode('c4')),
                          ['s1', 'p1', 'o1', 'c4']));
     });
 
-    describe('when searched with a non-existing named graph parameter', function () {
+    describe('when searched with a non-existing named graph parameter', () => {
       itShouldBeEmpty(store.getQuads(null, null, null, new NamedNode('c5')));
     });
 
-    describe('match', function () {
-      describe('without parameters', function () {
+    describe('match', () => {
+      describe('without parameters', () => {
         it('should return all items',
           forResultStream(shouldIncludeAll, store.match(),
             ['s1', 'p1', 'o1'],
@@ -432,7 +432,7 @@ describe('Store', function () {
             [termToId(new Quad('s2', 'p2', 'o2')), 'p1', 'o3']));
       });
 
-      describe('with an existing subject parameter', function () {
+      describe('with an existing subject parameter', () => {
         it('should return all items with this subject in all graphs',
           forResultStream(shouldIncludeAll, store.match(new NamedNode('s1'), null, null),
             ['s1', 'p1', 'o1'],
@@ -441,246 +441,246 @@ describe('Store', function () {
             ['s1', 'p1', 'o1', 'c4']));
       });
 
-      describe('with non-existing predicate and object parameters in the default graph', function () {
+      describe('with non-existing predicate and object parameters in the default graph', () => {
         forResultStream(itShouldBeEmpty, store.match(null, new NamedNode('p2'), new NamedNode('o3'), new DefaultGraph()));
       });
     });
 
-    describe('getSubjects', function () {
-      describe('with existing predicate, object and graph parameters', function () {
-        it('should return all subjects with this predicate, object and graph', function () {
+    describe('getSubjects', () => {
+      describe('with existing predicate, object and graph parameters', () => {
+        it('should return all subjects with this predicate, object and graph', () => {
           store.getSubjects(new NamedNode('p1'), new NamedNode('o1'), new NamedNode('c4')).should.have.deep.members([new NamedNode('s1')]);
         });
       });
 
-      describe('with existing predicate and object parameters', function () {
-        it('should return all subjects with this predicate and object', function () {
+      describe('with existing predicate and object parameters', () => {
+        it('should return all subjects with this predicate and object', () => {
           store.getSubjects(new NamedNode('p2'), new NamedNode('o2'), null).should.have.deep.members([new NamedNode('s1')]);
         });
       });
 
-      describe('with existing predicate and graph parameters', function () {
-        it('should return all subjects with this predicate and graph', function () {
+      describe('with existing predicate and graph parameters', () => {
+        it('should return all subjects with this predicate and graph', () => {
           store.getSubjects(new NamedNode('p1'), null, new DefaultGraph()).should.have.deep.members([new NamedNode('s1'), new NamedNode('s2'), new Quad(new NamedNode('s2'), new NamedNode('p2'), new NamedNode('o2'))]);
         });
       });
 
-      describe('with existing object and graph parameters', function () {
-        it('should return all subjects with this object and graph', function () {
+      describe('with existing object and graph parameters', () => {
+        it('should return all subjects with this object and graph', () => {
           store.getSubjects(null, new NamedNode('o1'), new DefaultGraph()).should.have.deep.members([new NamedNode('s1'), new NamedNode('s2')]);
         });
       });
 
-      describe('with an existing predicate parameter', function () {
-        it('should return all subjects with this predicate', function () {
+      describe('with an existing predicate parameter', () => {
+        it('should return all subjects with this predicate', () => {
           store.getSubjects(new NamedNode('p1'), null, null).should.have.deep.members([new NamedNode('s1'), new NamedNode('s2'),  new Quad(new NamedNode('s2'), new NamedNode('p2'), new NamedNode('o2'))]);
         });
       });
 
-      describe('with an existing object parameter', function () {
-        it('should return all subjects with this object', function () {
+      describe('with an existing object parameter', () => {
+        it('should return all subjects with this object', () => {
           store.getSubjects(null, new NamedNode('o1'), null).should.have.deep.members([new NamedNode('s1'), new NamedNode('s2')]);
         });
       });
 
-      describe('with an existing graph parameter', function () {
-        it('should return all subjects in the graph', function () {
+      describe('with an existing graph parameter', () => {
+        it('should return all subjects in the graph', () => {
           store.getSubjects(null, null, new NamedNode('c4')).should.have.deep.members([new NamedNode('s1')]);
         });
       });
 
-      describe('with no parameters', function () {
-        it('should return all subjects', function () {
+      describe('with no parameters', () => {
+        it('should return all subjects', () => {
           store.getSubjects(null, null, null).should.have.deep.members([new NamedNode('s1'), new NamedNode('s2'),  new Quad(new NamedNode('s2'), new NamedNode('p2'), new NamedNode('o2'))]);
         });
       });
     });
 
-    describe('getPredicates', function () {
-      describe('with existing subject, object and graph parameters', function () {
-        it('should return all predicates with this subject, object and graph', function () {
+    describe('getPredicates', () => {
+      describe('with existing subject, object and graph parameters', () => {
+        it('should return all predicates with this subject, object and graph', () => {
           store.getPredicates(new NamedNode('s1'), new NamedNode('o1'), new NamedNode('c4')).should.have.deep.members([new NamedNode('p1')]);
         });
       });
 
-      describe('with existing subject and object parameters', function () {
-        it('should return all predicates with this subject and object', function () {
+      describe('with existing subject and object parameters', () => {
+        it('should return all predicates with this subject and object', () => {
           store.getPredicates(new NamedNode('s1'), new NamedNode('o2'), null).should.have.deep.members([new NamedNode('p1'), new NamedNode('p2')]);
         });
       });
 
-      describe('with existing subject and graph parameters', function () {
-        it('should return all predicates with this subject and graph', function () {
+      describe('with existing subject and graph parameters', () => {
+        it('should return all predicates with this subject and graph', () => {
           store.getPredicates(new NamedNode('s1'), null, new DefaultGraph()).should.have.deep.members([new NamedNode('p1'), new NamedNode('p2')]);
         });
       });
 
-      describe('with existing object and graph parameters', function () {
-        it('should return all predicates with this object and graph', function () {
+      describe('with existing object and graph parameters', () => {
+        it('should return all predicates with this object and graph', () => {
           store.getPredicates(null, new NamedNode('o1'), new DefaultGraph()).should.have.deep.members([new NamedNode('p1')]);
         });
       });
 
-      describe('with an existing subject parameter', function () {
-        it('should return all predicates with this subject', function () {
+      describe('with an existing subject parameter', () => {
+        it('should return all predicates with this subject', () => {
           store.getPredicates(new NamedNode('s2'), null, null).should.have.deep.members([new NamedNode('p1')]);
         });
       });
 
-      describe('with an existing object parameter', function () {
-        it('should return all predicates with this object', function () {
+      describe('with an existing object parameter', () => {
+        it('should return all predicates with this object', () => {
           store.getPredicates(null, new NamedNode('o1'), null).should.have.deep.members([new NamedNode('p1')]);
         });
       });
 
-      describe('with an existing graph parameter', function () {
-        it('should return all predicates in the graph', function () {
+      describe('with an existing graph parameter', () => {
+        it('should return all predicates in the graph', () => {
           store.getPredicates(null, null, new NamedNode('c4')).should.have.deep.members([new NamedNode('p1')]);
         });
       });
 
-      describe('with no parameters', function () {
-        it('should return all predicates', function () {
+      describe('with no parameters', () => {
+        it('should return all predicates', () => {
           store.getPredicates(null, null, null).should.have.deep.members([new NamedNode('p1'), new NamedNode('p2')]);
         });
       });
     });
 
-    describe('getObjects', function () {
-      describe('with existing subject, predicate and graph parameters', function () {
-        it('should return all objects with this subject, predicate and graph', function () {
+    describe('getObjects', () => {
+      describe('with existing subject, predicate and graph parameters', () => {
+        it('should return all objects with this subject, predicate and graph', () => {
           store.getObjects(new NamedNode('s1'), new NamedNode('p1'), new DefaultGraph()).should.have.deep.members([new NamedNode('o1'), new NamedNode('o2')]);
         });
       });
 
-      describe('with existing subject and predicate parameters', function () {
-        it('should return all objects with this subject and predicate', function () {
+      describe('with existing subject and predicate parameters', () => {
+        it('should return all objects with this subject and predicate', () => {
           store.getObjects(new NamedNode('s1'), new NamedNode('p1'), null).should.have.deep.members([new NamedNode('o1'), new NamedNode('o2')]);
         });
       });
 
-      describe('with existing subject and graph parameters', function () {
-        it('should return all objects with this subject and graph', function () {
+      describe('with existing subject and graph parameters', () => {
+        it('should return all objects with this subject and graph', () => {
           store.getObjects(new NamedNode('s1'), null, new DefaultGraph()).should.have.deep.members([new NamedNode('o1'), new NamedNode('o2')]);
         });
       });
 
-      describe('with existing predicate and graph parameters', function () {
-        it('should return all objects with this predicate and graph', function () {
+      describe('with existing predicate and graph parameters', () => {
+        it('should return all objects with this predicate and graph', () => {
           store.getObjects(null, new NamedNode('p1'), new DefaultGraph()).should.have.deep.members([new NamedNode('o1'), new NamedNode('o2'), new NamedNode('o3')]);
         });
       });
 
-      describe('with an existing subject parameter', function () {
-        it('should return all objects with this subject', function () {
+      describe('with an existing subject parameter', () => {
+        it('should return all objects with this subject', () => {
           store.getObjects(new NamedNode('s1'), null, null).should.have.deep.members([new NamedNode('o1'), new NamedNode('o2')]);
         });
       });
 
-      describe('with an existing predicate parameter', function () {
-        it('should return all objects with this predicate', function () {
+      describe('with an existing predicate parameter', () => {
+        it('should return all objects with this predicate', () => {
           store.getObjects(null, new NamedNode('p1'), null).should.have.deep.members([new NamedNode('o1'), new NamedNode('o2'),  new NamedNode('o3')]);
         });
       });
 
-      describe('with an existing graph parameter', function () {
-        it('should return all objects in the graph', function () {
+      describe('with an existing graph parameter', () => {
+        it('should return all objects in the graph', () => {
           store.getObjects(null, null, new NamedNode('c4')).should.have.deep.members([new NamedNode('o1')]);
         });
       });
 
-      describe('with no parameters', function () {
-        it('should return all objects', function () {
+      describe('with no parameters', () => {
+        it('should return all objects', () => {
           store.getObjects(null, null, null).should.have.deep.members([new NamedNode('o1'), new NamedNode('o2'), new NamedNode('o3')]);
         });
       });
     });
 
-    describe('getGraphs', function () {
-      describe('with existing subject, predicate and object parameters', function () {
-        it('should return all graphs with this subject, predicate and object', function () {
+    describe('getGraphs', () => {
+      describe('with existing subject, predicate and object parameters', () => {
+        it('should return all graphs with this subject, predicate and object', () => {
           store.getGraphs(new NamedNode('s1'), new NamedNode('p1'), new NamedNode('o1')).should.have.deep.members([new NamedNode('c4'), new DefaultGraph()]);
         });
       });
 
-      describe('with existing subject and predicate parameters', function () {
-        it('should return all graphs with this subject and predicate', function () {
+      describe('with existing subject and predicate parameters', () => {
+        it('should return all graphs with this subject and predicate', () => {
           store.getGraphs(new NamedNode('s1'), new NamedNode('p1'), null).should.have.deep.members([new NamedNode('c4'),  new DefaultGraph()]);
         });
       });
 
-      describe('with existing subject and object parameters', function () {
-        it('should return all graphs with this subject and object', function () {
+      describe('with existing subject and object parameters', () => {
+        it('should return all graphs with this subject and object', () => {
           store.getGraphs(new NamedNode('s1'), null, new NamedNode('o2')).should.have.deep.members([new DefaultGraph()]);
         });
       });
 
-      describe('with existing predicate and object parameters', function () {
-        it('should return all graphs with this predicate and object', function () {
+      describe('with existing predicate and object parameters', () => {
+        it('should return all graphs with this predicate and object', () => {
           store.getGraphs(null, new NamedNode('p1'), new NamedNode('o1')).should.have.deep.members([new DefaultGraph(), new NamedNode('c4')]);
         });
       });
 
-      describe('with an existing subject parameter', function () {
-        it('should return all graphs with this subject', function () {
+      describe('with an existing subject parameter', () => {
+        it('should return all graphs with this subject', () => {
           store.getGraphs(new NamedNode('s1'), null, null).should.have.deep.members([new NamedNode('c4'), new DefaultGraph()]);
         });
       });
 
-      describe('with an existing predicate parameter', function () {
-        it('should return all graphs with this predicate', function () {
+      describe('with an existing predicate parameter', () => {
+        it('should return all graphs with this predicate', () => {
           store.getGraphs(null, new NamedNode('p1'), null).should.have.deep.members([new NamedNode('c4'), new DefaultGraph()]);
         });
       });
 
-      describe('with an existing object parameter', function () {
-        it('should return all graphs with this object', function () {
+      describe('with an existing object parameter', () => {
+        it('should return all graphs with this object', () => {
           store.getGraphs(null, null, new NamedNode('o2')).should.have.deep.members([new DefaultGraph()]);
         });
       });
 
-      describe('with no parameters', function () {
-        it('should return all graphs', function () {
+      describe('with no parameters', () => {
+        it('should return all graphs', () => {
           store.getGraphs(null, null, null).should.have.deep.members([new NamedNode('c4'), new DefaultGraph()]);
         });
       });
     });
 
-    describe('forEach', function () {
-      describe('with existing subject, predicate, object and graph parameters', function () {
+    describe('forEach', () => {
+      describe('with existing subject, predicate, object and graph parameters', () => {
         it('should have iterated all items with this subject, predicate, object and graph',
           shouldIncludeAll(collect(store, 'forEach', 's1', 'p1', 'o2', ''),
                            ['s1', 'p1', 'o2', '']));
       });
 
-      describe('with existing subject, predicate and object parameters', function () {
+      describe('with existing subject, predicate and object parameters', () => {
         it('should have iterated all items with this subject, predicate and object',
           shouldIncludeAll(collect(store, 'forEach', 's1', 'p2', 'o2', null),
                            ['s1', 'p2', 'o2', '']));
       });
 
-      describe('with existing subject, predicate and graph parameters', function () {
+      describe('with existing subject, predicate and graph parameters', () => {
         it('should have iterated all items with this subject, predicate and graph',
           shouldIncludeAll(collect(store, 'forEach', 's1', 'p1', null, ''),
                            ['s1', 'p1', 'o1', ''],
                            ['s1', 'p1', 'o2', '']));
       });
 
-      describe('with existing subject, object and graph parameters', function () {
+      describe('with existing subject, object and graph parameters', () => {
         it('should have iterated all items with this subject, object and graph',
           shouldIncludeAll(collect(store, 'forEach', 's1', null, 'o2', ''),
                            ['s1', 'p1', 'o2', ''],
                            ['s1', 'p2', 'o2', '']));
       });
 
-      describe('with existing predicate, object and graph parameters', function () {
+      describe('with existing predicate, object and graph parameters', () => {
         it('should have iterated all items with this predicate, object and graph',
           shouldIncludeAll(collect(store, 'forEach', null, 'p1', 'o1', ''),
                            ['s1', 'p1', 'o1', ''],
                            ['s2', 'p1', 'o1', '']));
       });
 
-      describe('with existing subject and predicate parameters', function () {
+      describe('with existing subject and predicate parameters', () => {
         it('should iterate all items with this subject and predicate',
           shouldIncludeAll(collect(store, 'forEach', 's1', 'p1', null, null),
                            ['s1', 'p1', 'o1', ''],
@@ -688,20 +688,20 @@ describe('Store', function () {
                            ['s1', 'p1', 'o1', 'c4']));
       });
 
-      describe('with existing subject and object parameters', function () {
+      describe('with existing subject and object parameters', () => {
         it('should iterate all items with this subject and predicate',
           shouldIncludeAll(collect(store, 'forEach', 's1', null, 'o2', null),
                            ['s1', 'p1', 'o2', ''],
                            ['s1', 'p2', 'o2', '']));
       });
 
-      describe('with existing subject and graph parameters', function () {
+      describe('with existing subject and graph parameters', () => {
         it('should iterate all items with this subject and graph',
           shouldIncludeAll(collect(store, 'forEach', 's1', null, null, 'c4'),
                          ['s1', 'p1', 'o1', 'c4']));
       });
 
-      describe('with existing predicate and object parameters', function () {
+      describe('with existing predicate and object parameters', () => {
         it('should iterate all items with this predicate and object',
           shouldIncludeAll(collect(store, 'forEach', null, 'p1', 'o1', null),
                            ['s1', 'p1', 'o1', ''],
@@ -709,7 +709,7 @@ describe('Store', function () {
                            ['s1', 'p1', 'o1', 'c4']));
       });
 
-      describe('with existing predicate and graph parameters', function () {
+      describe('with existing predicate and graph parameters', () => {
         it('should iterate all items with this predicate and graph',
         shouldIncludeAll(collect(store, 'forEach', null, 'p1', null, ''),
                            ['s1', 'p1', 'o1', ''],
@@ -718,20 +718,20 @@ describe('Store', function () {
                            [termToId(new Quad('s2', 'p2', 'o2')), 'p1', 'o3', '']));
       });
 
-      describe('with existing object and graph parameters', function () {
+      describe('with existing object and graph parameters', () => {
         it('should iterate all items with this object and graph',
           shouldIncludeAll(collect(store, 'forEach', null, null, 'o1', ''),
                            ['s1', 'p1', 'o1', ''],
                            ['s2', 'p1', 'o1', '']));
       });
 
-      describe('with an existing subject parameter', function () {
+      describe('with an existing subject parameter', () => {
         it('should iterate all items with this subject',
           shouldIncludeAll(collect(store, 'forEach', 's2', null, null, null),
                          ['s2', 'p1', 'o1', '']));
       });
 
-      describe('with an existing predicate parameter', function () {
+      describe('with an existing predicate parameter', () => {
         it('should iterate all items with this predicate',
           shouldIncludeAll(collect(store, 'forEach', null, 'p1', null, null),
                            ['s1', 'p1', 'o1', ''],
@@ -741,7 +741,7 @@ describe('Store', function () {
                            [termToId(new Quad('s2', 'p2', 'o2')), 'p1', 'o3', '']));
       });
 
-      describe('with an existing object parameter', function () {
+      describe('with an existing object parameter', () => {
         it('should iterate all items with this object',
           shouldIncludeAll(collect(store, 'forEach', null, null, 'o1', null),
                            ['s1', 'p1', 'o1', ''],
@@ -749,7 +749,7 @@ describe('Store', function () {
                            ['s1', 'p1', 'o1', 'c4']));
       });
 
-      describe('with an existing graph parameter', function () {
+      describe('with an existing graph parameter', () => {
         it('should iterate all items with this graph',
           shouldIncludeAll(collect(store, 'forEach', null, null, null, ''),
                            ['s1', 'p1', 'o1'],
@@ -759,7 +759,7 @@ describe('Store', function () {
                            [termToId(new Quad('s2', 'p2', 'o2')), 'p1', 'o3', '']));
       });
 
-      describe('with no parameters', function () {
+      describe('with no parameters', () => {
         it('should iterate all items',
           shouldIncludeAll(collect(store, 'forEach', null, null, null, null),
                            ['s1', 'p1', 'o1'],
@@ -771,326 +771,326 @@ describe('Store', function () {
       });
     });
 
-    describe('forSubjects', function () {
-      describe('with existing predicate, object and graph parameters', function () {
-        it('should iterate all subjects with this predicate, object and graph', function () {
+    describe('forSubjects', () => {
+      describe('with existing predicate, object and graph parameters', () => {
+        it('should iterate all subjects with this predicate, object and graph', () => {
           collect(store, 'forSubjects', 'p1', 'o1', '').should.have.deep.members([new NamedNode('s1'), new NamedNode('s2')]);
         });
       });
-      describe('with a non-existing predicate', function () {
-        it('should be empty', function () {
+      describe('with a non-existing predicate', () => {
+        it('should be empty', () => {
           collect(store, 'forSubjects', 'p3', null, null).should.be.empty;
         });
       });
-      describe('with a non-existing object', function () {
-        it('should be empty', function () {
+      describe('with a non-existing object', () => {
+        it('should be empty', () => {
           collect(store, 'forSubjects', null, 'o4', null).should.be.empty;
         });
       });
-      describe('with a non-existing graph', function () {
-        it('should be empty', function () {
+      describe('with a non-existing graph', () => {
+        it('should be empty', () => {
           collect(store, 'forSubjects', null, null, 'g2').should.be.empty;
         });
       });
     });
 
-    describe('forPredicates', function () {
-      describe('with existing subject, object and graph parameters', function () {
-        it('should iterate all predicates with this subject, object and graph', function () {
+    describe('forPredicates', () => {
+      describe('with existing subject, object and graph parameters', () => {
+        it('should iterate all predicates with this subject, object and graph', () => {
           collect(store, 'forPredicates', 's1', 'o2', '').should.have.deep.members([new NamedNode('p1'), new NamedNode('p2')]);
         });
       });
-      describe('with a non-existing subject', function () {
-        it('should be empty', function () {
+      describe('with a non-existing subject', () => {
+        it('should be empty', () => {
           collect(store, 'forPredicates', 's3', null, null).should.be.empty;
         });
       });
-      describe('with a non-existing object', function () {
-        it('should be empty', function () {
+      describe('with a non-existing object', () => {
+        it('should be empty', () => {
           collect(store, 'forPredicates', null, 'o4', null).should.be.empty;
         });
       });
-      describe('with a non-existing graph', function () {
-        it('should be empty', function () {
+      describe('with a non-existing graph', () => {
+        it('should be empty', () => {
           collect(store, 'forPredicates', null, null, 'g2').should.be.empty;
         });
       });
     });
 
-    describe('forObjects', function () {
-      describe('with existing subject, predicate and graph parameters', function () {
-        it('should iterate all objects with this subject, predicate and graph', function () {
+    describe('forObjects', () => {
+      describe('with existing subject, predicate and graph parameters', () => {
+        it('should iterate all objects with this subject, predicate and graph', () => {
           collect(store, 'forObjects', 's1', 'p1', '').should.have.deep.members([new NamedNode('o1'), new NamedNode('o2')]);
         });
       });
-      describe('with a non-existing subject', function () {
-        it('should be empty', function () {
+      describe('with a non-existing subject', () => {
+        it('should be empty', () => {
           collect(store, 'forObjects', 's3', null, null).should.be.empty;
         });
       });
-      describe('with a non-existing predicate', function () {
-        it('should be empty', function () {
+      describe('with a non-existing predicate', () => {
+        it('should be empty', () => {
           collect(store, 'forObjects', null, 'p3', null).should.be.empty;
         });
       });
-      describe('with a non-existing graph', function () {
-        it('should be empty', function () {
+      describe('with a non-existing graph', () => {
+        it('should be empty', () => {
           collect(store, 'forObjects', null, null, 'g2').should.be.empty;
         });
       });
     });
 
-    describe('forGraphs', function () {
-      describe('with existing subject, predicate and object parameters', function () {
-        it('should iterate all graphs with this subject, predicate and object', function () {
+    describe('forGraphs', () => {
+      describe('with existing subject, predicate and object parameters', () => {
+        it('should iterate all graphs with this subject, predicate and object', () => {
           collect(store, 'forGraphs', 's1', 'p1', 'o1').should.have.deep.members([new DefaultGraph(), new NamedNode('c4')]);
         });
       });
-      describe('with a non-existing subject', function () {
-        it('should be empty', function () {
+      describe('with a non-existing subject', () => {
+        it('should be empty', () => {
           collect(store, 'forObjects', 's3', null, null).should.be.empty;
         });
       });
-      describe('with a non-existing predicate', function () {
-        it('should be empty', function () {
+      describe('with a non-existing predicate', () => {
+        it('should be empty', () => {
           collect(store, 'forObjects', null, 'p3', null).should.be.empty;
         });
       });
-      describe('with a non-existing graph', function () {
-        it('should be empty', function () {
+      describe('with a non-existing graph', () => {
+        it('should be empty', () => {
           collect(store, 'forPredicates', null, null, 'g2').should.be.empty;
         });
       });
     });
 
-    describe('every', function () {
+    describe('every', () => {
       var count = 3;
       function thirdTimeFalse() { return count-- === 0; }
 
-      describe('with no parameters and a callback always returning true', function () {
-        it('should return true', function () {
+      describe('with no parameters and a callback always returning true', () => {
+        it('should return true', () => {
           store.every(alwaysTrue, null, null, null, null).should.be.true;
         });
       });
-      describe('with no parameters and a callback always returning false', function () {
-        it('should return false', function () {
+      describe('with no parameters and a callback always returning false', () => {
+        it('should return false', () => {
           store.every(alwaysFalse, null, null, null, null).should.be.false;
         });
       });
-      describe('with no parameters and a callback that returns false after 3 calls', function () {
-        it('should return false', function () {
+      describe('with no parameters and a callback that returns false after 3 calls', () => {
+        it('should return false', () => {
           store.every(thirdTimeFalse, null, null, null, null).should.be.false;
         });
       });
     });
 
-    describe('some', function () {
+    describe('some', () => {
       var count = 3;
       function thirdTimeFalse() { return count-- !== 0; }
 
-      describe('with no parameters and a callback always returning true', function () {
-        it('should return true', function () {
+      describe('with no parameters and a callback always returning true', () => {
+        it('should return true', () => {
           store.some(alwaysTrue, null, null, null, null).should.be.true;
         });
       });
-      describe('with no parameters and a callback always returning false', function () {
-        it('should return false', function () {
+      describe('with no parameters and a callback always returning false', () => {
+        it('should return false', () => {
           store.some(alwaysFalse, null, null, null, null).should.be.false;
         });
       });
-      describe('with no parameters and a callback that returns true after 3 calls', function () {
-        it('should return false', function () {
+      describe('with no parameters and a callback that returns true after 3 calls', () => {
+        it('should return false', () => {
           store.some(thirdTimeFalse, null, null, null, null).should.be.true;
         });
       });
-      describe('with a non-existing subject', function () {
-        it('should return true', function () {
+      describe('with a non-existing subject', () => {
+        it('should return true', () => {
           store.some(null, new NamedNode('s3'), null, null, null).should.be.false;
         });
       });
-      describe('with a non-existing predicate', function () {
-        it('should return false', function () {
+      describe('with a non-existing predicate', () => {
+        it('should return false', () => {
           store.some(null, null, new NamedNode('p3'), null, null).should.be.false;
         });
       });
-      describe('with a non-existing object', function () {
-        it('should return false', function () {
+      describe('with a non-existing object', () => {
+        it('should return false', () => {
           store.some(null, null, null, new NamedNode('o4'), null).should.be.false;
         });
       });
-      describe('with a non-existing graph', function () {
-        it('should return false', function () {
+      describe('with a non-existing graph', () => {
+        it('should return false', () => {
           store.some(null, null, null, null, new NamedNode('g2')).should.be.false;
         });
       });
     });
 
-    describe('when counted without parameters', function () {
-      it('should count all items in all graphs', function () {
+    describe('when counted without parameters', () => {
+      it('should count all items in all graphs', () => {
         store.countQuads().should.equal(6);
       });
     });
 
-    describe('when counted with an existing subject parameter', function () {
-      it('should count all items with this subject in all graphs', function () {
+    describe('when counted with an existing subject parameter', () => {
+      it('should count all items with this subject in all graphs', () => {
         store.countQuads(new NamedNode('s1'), null, null).should.equal(4);
       });
     });
 
-    describe('when counted with a non-existing subject parameter', function () {
-      it('should be empty', function () {
+    describe('when counted with a non-existing subject parameter', () => {
+      it('should be empty', () => {
         store.countQuads(new NamedNode('s3'), null, null).should.equal(0);
       });
     });
 
-    describe('when counted with a non-existing subject parameter that exists elsewhere', function () {
-      it('should be empty', function () {
+    describe('when counted with a non-existing subject parameter that exists elsewhere', () => {
+      it('should be empty', () => {
         store.countQuads(new NamedNode('p1'), null, null).should.equal(0);
       });
     });
 
-    describe('when counted with an existing predicate parameter', function () {
-      it('should count all items with this predicate in all graphs', function () {
+    describe('when counted with an existing predicate parameter', () => {
+      it('should count all items with this predicate in all graphs', () => {
         store.countQuads(null, new NamedNode('p1'), null).should.equal(5);
       });
     });
 
-    describe('when counted with a non-existing predicate parameter', function () {
-      it('should be empty', function () {
+    describe('when counted with a non-existing predicate parameter', () => {
+      it('should be empty', () => {
         store.countQuads(null, new NamedNode('p3'), null).should.equal(0);
       });
     });
 
-    describe('when counted with an existing object parameter', function () {
-      it('should count all items with this object in all graphs', function () {
+    describe('when counted with an existing object parameter', () => {
+      it('should count all items with this object in all graphs', () => {
         store.countQuads(null, null, 'o1').should.equal(3);
       });
     });
 
-    describe('when counted with a non-existing object parameter', function () {
-      it('should be empty', function () {
+    describe('when counted with a non-existing object parameter', () => {
+      it('should be empty', () => {
         store.countQuads(null, null, 'o4').should.equal(0);
       });
     });
 
-    describe('when counted with existing subject and predicate parameters', function () {
-      it('should count all items with this subject and predicate in all graphs', function () {
+    describe('when counted with existing subject and predicate parameters', () => {
+      it('should count all items with this subject and predicate in all graphs', () => {
         store.countQuads('s1', 'p1', null).should.equal(3);
       });
     });
 
-    describe('when counted with non-existing subject and predicate parameters', function () {
-      it('should be empty', function () {
+    describe('when counted with non-existing subject and predicate parameters', () => {
+      it('should be empty', () => {
         store.countQuads('s2', 'p2', null).should.equal(0);
       });
     });
 
-    describe('when counted with existing subject and object parameters', function () {
-      it('should count all items with this subject and object in all graphs', function () {
+    describe('when counted with existing subject and object parameters', () => {
+      it('should count all items with this subject and object in all graphs', () => {
         store.countQuads('s1', null, 'o1').should.equal(2);
       });
     });
 
-    describe('when counted with non-existing subject and object parameters', function () {
-      it('should be empty', function () {
+    describe('when counted with non-existing subject and object parameters', () => {
+      it('should be empty', () => {
         store.countQuads('s2', 'p2', null).should.equal(0);
       });
     });
 
-    describe('when counted with existing predicate and object parameters', function () {
-      it('should count all items with this predicate and object in all graphs', function () {
+    describe('when counted with existing predicate and object parameters', () => {
+      it('should count all items with this predicate and object in all graphs', () => {
         store.countQuads(null, 'p1', 'o1').should.equal(3);
       });
     });
 
-    describe('when counted with non-existing predicate and object parameters', function () {
-      it('should be empty', function () {
+    describe('when counted with non-existing predicate and object parameters', () => {
+      it('should be empty', () => {
         store.countQuads(null, 'p2', 'o3').should.equal(0);
       });
     });
 
-    describe('when counted with existing subject, predicate, and object parameters', function () {
-      it('should count all items with this subject, predicate, and object in all graphs', function () {
+    describe('when counted with existing subject, predicate, and object parameters', () => {
+      it('should count all items with this subject, predicate, and object in all graphs', () => {
         store.countQuads('s1', 'p1', 'o1').should.equal(2);
       });
     });
 
-    describe('when counted with a non-existing triple', function () {
-      it('should be empty', function () {
+    describe('when counted with a non-existing triple', () => {
+      it('should be empty', () => {
         store.countQuads('s2', 'p2', 'o1').should.equal(0);
       });
     });
 
-    describe('when counted with the default graph parameter', function () {
-      it('should count all items in the default graph', function () {
+    describe('when counted with the default graph parameter', () => {
+      it('should count all items in the default graph', () => {
         store.countQuads(null, null, null, new DefaultGraph()).should.equal(5);
       });
     });
 
-    describe('when counted with an existing named graph parameter', function () {
-      it('should count all items in that graph', function () {
+    describe('when counted with an existing named graph parameter', () => {
+      it('should count all items in that graph', () => {
         store.countQuads(null, null, null, 'c4').should.equal(1);
       });
     });
 
-    describe('when counted with a non-existing named graph parameter', function () {
-      it('should be empty', function () {
+    describe('when counted with a non-existing named graph parameter', () => {
+      it('should be empty', () => {
         store.countQuads(null, null, null, 'c5').should.equal(0);
       });
     });
 
-    describe('when trying to remove a triple with a non-existing subject', function () {
-      before(function () { store.removeQuad(new NamedNode('s0'), new NamedNode('p1'), new NamedNode('o1')).should.be.false; });
-      it('should still have size 6', function () { store.size.should.eql(6); });
+    describe('when trying to remove a triple with a non-existing subject', () => {
+      before(() => { store.removeQuad(new NamedNode('s0'), new NamedNode('p1'), new NamedNode('o1')).should.be.false; });
+      it('should still have size 6', () => { store.size.should.eql(6); });
     });
 
-    describe('when trying to remove a triple with a non-existing predicate', function () {
-      before(function () { store.removeQuad(new NamedNode('s1'), new NamedNode('p0'), new NamedNode('o1')).should.be.false; });
-      it('should still have size 6', function () { store.size.should.eql(6); });
+    describe('when trying to remove a triple with a non-existing predicate', () => {
+      before(() => { store.removeQuad(new NamedNode('s1'), new NamedNode('p0'), new NamedNode('o1')).should.be.false; });
+      it('should still have size 6', () => { store.size.should.eql(6); });
     });
 
-    describe('when trying to remove a triple with a non-existing object', function () {
-      before(function () { store.removeQuad(new NamedNode('s1'), new NamedNode('p1'), new NamedNode('o0')).should.be.false; });
-      it('should still have size 6', function () { store.size.should.eql(6); });
+    describe('when trying to remove a triple with a non-existing object', () => {
+      before(() => { store.removeQuad(new NamedNode('s1'), new NamedNode('p1'), new NamedNode('o0')).should.be.false; });
+      it('should still have size 6', () => { store.size.should.eql(6); });
     });
 
-    describe('when trying to remove a triple for which no subjects exist', function () {
-      before(function () { store.removeQuad(new NamedNode('o1'), new NamedNode('p1'), new NamedNode('o1')).should.be.false; });
-      it('should still have size 6', function () { store.size.should.eql(6); });
+    describe('when trying to remove a triple for which no subjects exist', () => {
+      before(() => { store.removeQuad(new NamedNode('o1'), new NamedNode('p1'), new NamedNode('o1')).should.be.false; });
+      it('should still have size 6', () => { store.size.should.eql(6); });
     });
 
-    describe('when trying to remove a triple for which no predicates exist', function () {
-      before(function () { store.removeQuad(new NamedNode('s1'), new NamedNode('s1'), new NamedNode('o1')).should.be.false; });
-      it('should still have size 6', function () { store.size.should.eql(6); });
+    describe('when trying to remove a triple for which no predicates exist', () => {
+      before(() => { store.removeQuad(new NamedNode('s1'), new NamedNode('s1'), new NamedNode('o1')).should.be.false; });
+      it('should still have size 6', () => { store.size.should.eql(6); });
     });
 
-    describe('when trying to remove a triple for which no objects exist', function () {
-      before(function () { store.removeQuad(new NamedNode('s1'), new NamedNode('p1'), new NamedNode('s1')).should.be.false; });
-      it('should still have size 6', function () { store.size.should.eql(6); });
+    describe('when trying to remove a triple for which no objects exist', () => {
+      before(() => { store.removeQuad(new NamedNode('s1'), new NamedNode('p1'), new NamedNode('s1')).should.be.false; });
+      it('should still have size 6', () => { store.size.should.eql(6); });
     });
 
-    describe('when trying to remove a triple that does not exist', function () {
-      before(function () { store.removeQuad(new NamedNode('s1'), new NamedNode('p2'), new NamedNode('o1')).should.be.false; });
-      it('should still have size 6', function () { store.size.should.eql(6); });
+    describe('when trying to remove a triple that does not exist', () => {
+      before(() => { store.removeQuad(new NamedNode('s1'), new NamedNode('p2'), new NamedNode('o1')).should.be.false; });
+      it('should still have size 6', () => { store.size.should.eql(6); });
     });
 
-    describe('when trying to remove an incomplete triple', function () {
-      before(function () { store.removeQuad(new NamedNode('s1'), null, null).should.be.false; });
-      it('should still have size 6', function () { store.size.should.eql(6); });
+    describe('when trying to remove an incomplete triple', () => {
+      before(() => { store.removeQuad(new NamedNode('s1'), null, null).should.be.false; });
+      it('should still have size 6', () => { store.size.should.eql(6); });
     });
 
-    describe('when trying to remove a triple with a non-existing graph', function () {
-      before(function () { store.removeQuad(new NamedNode('s1'), new NamedNode('p1'), new NamedNode('o1'), new NamedNode('c0')).should.be.false; });
-      it('should still have size 6', function () { store.size.should.eql(6); });
+    describe('when trying to remove a triple with a non-existing graph', () => {
+      before(() => { store.removeQuad(new NamedNode('s1'), new NamedNode('p1'), new NamedNode('o1'), new NamedNode('c0')).should.be.false; });
+      it('should still have size 6', () => { store.size.should.eql(6); });
     });
 
-    describe('when removing an existing triple', function () {
-      before(function () { store.removeQuad(new NamedNode('s1'), new NamedNode('p1'), new NamedNode('o1')).should.be.true; });
+    describe('when removing an existing triple', () => {
+      before(() => { store.removeQuad(new NamedNode('s1'), new NamedNode('p1'), new NamedNode('o1')).should.be.true; });
 
-      it('should have size 5', function () { store.size.should.eql(5); });
+      it('should have size 5', () => { store.size.should.eql(5); });
 
       it('should not contain that triple anymore',
-        shouldIncludeAll(function () { return store.getQuads(); },
+        shouldIncludeAll(() => { return store.getQuads(); },
                          ['s1', 'p1', 'o2'],
                          ['s1', 'p2', 'o2'],
                          ['s2', 'p1', 'o1'],
@@ -1098,63 +1098,63 @@ describe('Store', function () {
                          [termToId(new Quad('s2', 'p2', 'o2')), 'p1', 'o3', '']));
     });
 
-    describe('when removing an existing triple from a named graph', function () {
-      before(function () { store.removeQuad(new NamedNode('s1'), new NamedNode('p1'), new NamedNode('o1'), new NamedNode('c4')).should.be.true; });
+    describe('when removing an existing triple from a named graph', () => {
+      before(() => { store.removeQuad(new NamedNode('s1'), new NamedNode('p1'), new NamedNode('o1'), new NamedNode('c4')).should.be.true; });
 
-      it('should have size 4', function () { store.size.should.eql(4); });
+      it('should have size 4', () => { store.size.should.eql(4); });
 
-      itShouldBeEmpty(function () { return store.getQuads(null, null, null, 'c4'); });
+      itShouldBeEmpty(() => { return store.getQuads(null, null, null, 'c4'); });
     });
 
-    describe('when removing multiple triples', function () {
-      before(function () {
+    describe('when removing multiple triples', () => {
+      before(() => {
         store.removeQuads([
           new Quad(new NamedNode('s1'), new NamedNode('p2'), new NamedNode('o2')),
           new Quad(new NamedNode('s2'), new NamedNode('p1'), new NamedNode('o1')),
         ]);
       });
 
-      it('should have size 2', function () { store.size.should.eql(2); });
+      it('should have size 2', () => { store.size.should.eql(2); });
 
       it('should not contain those triples anymore',
-        shouldIncludeAll(function () { return store.getQuads(); },
+        shouldIncludeAll(() => { return store.getQuads(); },
                          ['s1', 'p1', 'o2'],
                          [termToId(new Quad('s2', 'p2', 'o2')), 'p1', 'o3', '']));
     });
 
-    describe('when adding and removing a triple', function () {
-      before(function () {
+    describe('when adding and removing a triple', () => {
+      before(() => {
         store.addQuad(new NamedNode('a'), new NamedNode('b'), new NamedNode('c')).should.be.true;
         store.removeQuad(new NamedNode('a'), new NamedNode('b'), new NamedNode('c')).should.be.true;
       });
 
-      it('should have an unchanged size', function () { store.size.should.eql(2); });
+      it('should have an unchanged size', () => { store.size.should.eql(2); });
     });
   });
 
-  describe('A Store containing a blank node', function () {
+  describe('A Store containing a blank node', () => {
     var store = new Store();
     var b1 = store.createBlankNode();
     store.addQuad(new NamedNode('s1'), new NamedNode('p1'), b1).should.be.true;
 
-    describe('when searched with more than one variable', function () {
+    describe('when searched with more than one variable', () => {
       it('should return a triple with the blank node as an object',
         shouldIncludeAll(store.getQuads(),
                          ['s1', 'p1', '_:' + b1.value]));
     });
 
-    describe('when searched with one variable', function () {
+    describe('when searched with one variable', () => {
       it('should return a triple with the blank node as an object',
         shouldIncludeAll(store.getQuads('s1', 'p1'),
                          ['s1', 'p1', '_:' + b1.value]));
     });
   });
 
-  describe('A Store with a custom DataFactory', function () {
+  describe('A Store with a custom DataFactory', () => {
     var store, factory = {};
-    before(function () {
+    before(() => {
       factory.quad = function (s, p, o, g) { return { s: s, p: p, o: o, g: g }; };
-      ['namedNode', 'blankNode', 'literal', 'variable', 'defaultGraph'].forEach(function (f) {
+      ['namedNode', 'blankNode', 'literal', 'variable', 'defaultGraph'].forEach(f => {
         factory[f] = function (n) { return n ? f[0] + '-' + n : f; };
       });
 
@@ -1168,7 +1168,7 @@ describe('Store', function () {
       store.addQuad('s1', 'p1', 'o1', 'c4').should.be.true;
     });
 
-    it('should use the factory when returning quads', function () {
+    it('should use the factory when returning quads', () => {
       store.getQuads().should.deep.equal([
         { s: 'n-s1', p: 'n-p1', o: 'n-o1', g: 'defaultGraph' },
         { s: 'n-s1', p: 'n-p1', o: 'n-o2', g: 'defaultGraph' },
@@ -1179,24 +1179,24 @@ describe('Store', function () {
     });
   });
 
-  describe('A Store', function () {
+  describe('A Store', () => {
     var store = new Store();
 
     // Test inspired by http://www.devthought.com/2012/01/18/an-object-is-not-a-hash/.
     // The value `__proto__` is not supported however – fixing it introduces too much overhead.
-    it('should be able to contain entities with JavaScript object property names', function () {
+    it('should be able to contain entities with JavaScript object property names', () => {
       store.addQuad('toString', 'valueOf', 'toLocaleString', 'hasOwnProperty').should.be.true;
       shouldIncludeAll(store.getQuads(null, null, null, 'hasOwnProperty'),
                        ['toString', 'valueOf', 'toLocaleString', 'hasOwnProperty'])();
     });
 
-    it('should be able to contain entities named "null"', function () {
+    it('should be able to contain entities named "null"', () => {
       store.addQuad('null', 'null', 'null', 'null').should.be.true;
       shouldIncludeAll(store.getQuads(null, null, null, 'null'), ['null', 'null', 'null', 'null'])();
     });
   });
 
-  describe('A Store containing a well-formed rdf:Collection as subject', function () {
+  describe('A Store containing a well-formed rdf:Collection as subject', () => {
     var store = new Store();
     var listElements = addList(store, new NamedNode('element1'), new Literal('"element2"'));
     store.addQuad(listElements[0], new NamedNode('p1'), new NamedNode('o1')).should.be.true;
@@ -1208,7 +1208,7 @@ describe('Store', function () {
       ],
     };
 
-    describe('extractLists without remove', function () {
+    describe('extractLists without remove', () => {
       var lists = store.extractLists();
       it('should not delete triples',
         shouldIncludeAll(store.getQuads(),
@@ -1218,23 +1218,23 @@ describe('Store', function () {
           ['_:' + listElements[1].value, namespaces.rdf.first, '"element2"'],
           ['_:' + listElements[1].value, namespaces.rdf.rest, namespaces.rdf.nil]
         ));
-      it('should generate a list of Collections', function () {
+      it('should generate a list of Collections', () => {
         expect(listsToJSON(lists)).to.deep.equal(listItemsJSON);
       });
     });
 
-    describe('extractLists with remove', function () {
+    describe('extractLists with remove', () => {
       var lists = store.extractLists({ remove: true });
       it('should remove the first/rest triples and return the list members',
         shouldIncludeAll(store.getQuads(),
                          ['_:' + listElements[0].value, 'p1', 'o1']));
-      it('should generate a list of Collections', function () {
+      it('should generate a list of Collections', () => {
         expect(listsToJSON(lists)).to.deep.equal(listItemsJSON);
       });
     });
   });
 
-  describe('A Store containing a well-formed rdf:Collection as object', function () {
+  describe('A Store containing a well-formed rdf:Collection as object', () => {
     var store = new Store();
     var listElements = addList(store, new NamedNode('element1'), new Literal('"element2"'));
     store.addQuad(new NamedNode('s1'), new NamedNode('p1'), listElements[0]).should.be.true;
@@ -1246,7 +1246,7 @@ describe('Store', function () {
       ],
     };
 
-    describe('extractLists without remove', function () {
+    describe('extractLists without remove', () => {
       var lists = store.extractLists();
       it('should not delete triples',
         shouldIncludeAll(store.getQuads(),
@@ -1256,28 +1256,28 @@ describe('Store', function () {
           ['_:' + listElements[1].value, namespaces.rdf.first, '"element2"'],
           ['_:' + listElements[1].value, namespaces.rdf.rest, namespaces.rdf.nil]
         ));
-      it('should generate a list of Collections', function () {
+      it('should generate a list of Collections', () => {
         expect(listsToJSON(lists)).to.deep.equal(listItemsJSON);
       });
     });
 
-    describe('extractLists with remove', function () {
+    describe('extractLists with remove', () => {
       var lists = store.extractLists({ remove: true });
       it('should remove the first/rest triples and return the list members',
         shouldIncludeAll(store.getQuads(),
                          ['s1', 'p1', '_:' + listElements[0].value]));
-      it('should generate a list of Collections', function () {
+      it('should generate a list of Collections', () => {
         expect(listsToJSON(lists)).to.deep.equal(listItemsJSON);
       });
     });
   });
 
-  describe('A Store containing a well-formed rdf:Collection that is not attached', function () {
+  describe('A Store containing a well-formed rdf:Collection that is not attached', () => {
     var store = new Store();
     var listElements = addList(store, new NamedNode('element1'), new Literal('"element2"'));
     store.addQuad(new NamedNode('s1'), new NamedNode('p1'), new NamedNode('o1'));
 
-    describe('extractLists without remove', function () {
+    describe('extractLists without remove', () => {
       var lists = store.extractLists();
       it('should not delete triples',
         shouldIncludeAll(store.getQuads(),
@@ -1287,115 +1287,115 @@ describe('Store', function () {
           ['_:' + listElements[1].value, namespaces.rdf.first, '"element2"'],
           ['_:' + listElements[1].value, namespaces.rdf.rest, namespaces.rdf.nil]
         ));
-      it('should generate a list of Collections', function () {
+      it('should generate a list of Collections', () => {
         expect(listsToJSON(lists)).to.deep.equal({});
       });
     });
 
-    describe('extractLists with remove', function () {
+    describe('extractLists with remove', () => {
       var lists = store.extractLists({ remove: true });
       it('should remove the first/rest triples and return the list members',
         shouldIncludeAll(store.getQuads(),
                          ['s1', 'p1', 'o1']));
-      it('should generate a list of Collections', function () {
+      it('should generate a list of Collections', () => {
         expect(listsToJSON(lists)).to.deep.equal({});
       });
     });
   });
 
-  describe('A Store containing a rdf:Collection without first', function () {
+  describe('A Store containing a rdf:Collection without first', () => {
     var store = new Store();
     store.addQuad(store.createBlankNode(), new NamedNode(namespaces.rdf.rest), namespaces.rdf.nil).should.be.true;
 
-    it('extractLists throws an error', function () {
+    it('extractLists throws an error', () => {
       expect(() => store.extractLists()).throws('b0 has no list head');
     });
   });
 
-  describe('A Store containing an rdf:Collection with multiple rdf:first arcs on head', function () {
+  describe('A Store containing an rdf:Collection with multiple rdf:first arcs on head', () => {
     var store = new Store();
     var listElements = addList(store, store.createBlankNode(), store.createBlankNode());
     store.addQuad(listElements[0], new NamedNode(namespaces.rdf.first), store.createBlankNode()).should.be.true;
 
-    it('extractLists throws an error', function () {
+    it('extractLists throws an error', () => {
       expect(() => store.extractLists()).throws('b2 has multiple rdf:first arcs');
     });
   });
 
-  describe('A Store containing an rdf:Collection with multiple rdf:first arcs on tail', function () {
+  describe('A Store containing an rdf:Collection with multiple rdf:first arcs on tail', () => {
     var store = new Store();
     var listElements = addList(store, store.createBlankNode(), store.createBlankNode());
     store.addQuad(listElements[1], new NamedNode(namespaces.rdf.first), store.createBlankNode()).should.be.true;
 
-    it('extractLists throws an error', function () {
+    it('extractLists throws an error', () => {
       expect(() => store.extractLists()).throws('b3 has multiple rdf:first arcs');
     });
   });
 
-  describe('A Store containing an rdf:Collection with multiple rdf:rest arcs on head', function () {
+  describe('A Store containing an rdf:Collection with multiple rdf:rest arcs on head', () => {
     var store = new Store();
     var listElements = addList(store, store.createBlankNode(), store.createBlankNode());
     store.addQuad(listElements[0], new NamedNode(namespaces.rdf.rest), store.createBlankNode()).should.be.true;
 
-    it('extractLists throws an error', function () {
+    it('extractLists throws an error', () => {
       expect(() => store.extractLists()).throws('b2 has multiple rdf:rest arcs');
     });
   });
 
-  describe('A Store containing an rdf:Collection with multiple rdf:rest arcs on tail', function () {
+  describe('A Store containing an rdf:Collection with multiple rdf:rest arcs on tail', () => {
     var store = new Store();
     var listElements = addList(store, store.createBlankNode(), store.createBlankNode());
     store.addQuad(listElements[1], new NamedNode(namespaces.rdf.rest), store.createBlankNode()).should.be.true;
 
-    it('extractLists throws an error', function () {
+    it('extractLists throws an error', () => {
       expect(() => store.extractLists()).throws('b3 has multiple rdf:rest arcs');
     });
   });
 
-  describe('A Store containing an rdf:Collection with non-list arcs out', function () {
+  describe('A Store containing an rdf:Collection with non-list arcs out', () => {
     var store = new Store();
     var listElements = addList(store, store.createBlankNode(), store.createBlankNode(), store.createBlankNode());
     store.addQuad(listElements[1], new NamedNode('http://a.example/foo'), store.createBlankNode()).should.be.true;
 
-    it('extractLists throws an error', function () {
+    it('extractLists throws an error', () => {
       expect(() => store.extractLists()).throws('b4 can\'t be subject and object');
     });
   });
 
-  describe('A Store containing an rdf:Collection with multiple incoming rdf:rest arcs', function () {
+  describe('A Store containing an rdf:Collection with multiple incoming rdf:rest arcs', () => {
     var store = new Store();
     var listElements = addList(store, store.createBlankNode(), store.createBlankNode(), store.createBlankNode());
     store.addQuad(store.createBlankNode(), new NamedNode(namespaces.rdf.rest), listElements[1]).should.be.true;
 
-    it('extractLists throws an error', function () {
+    it('extractLists throws an error', () => {
       expect(() => store.extractLists()).throws('b4 has incoming rdf:rest arcs');
     });
   });
 
-  describe('A Store containing an rdf:Collection with co-references out of head', function () {
+  describe('A Store containing an rdf:Collection with co-references out of head', () => {
     var store = new Store();
     var listElements = addList(store, store.createBlankNode(), store.createBlankNode(), store.createBlankNode());
     store.addQuad(listElements[0], new NamedNode('p1'), new NamedNode('o1')).should.be.true;
     store.addQuad(listElements[0], new NamedNode('p1'), new NamedNode('o2')).should.be.true;
 
-    it('extractLists throws an error', function () {
+    it('extractLists throws an error', () => {
       expect(() => store.extractLists()).throws('b3 has non-list arcs out');
     });
   });
 
-  describe('A Store containing an rdf:Collection with co-references into head', function () {
+  describe('A Store containing an rdf:Collection with co-references into head', () => {
     var store = new Store();
     var listElements = addList(store, store.createBlankNode(), store.createBlankNode(), store.createBlankNode());
     store.addQuad(new NamedNode('s1'), new NamedNode('p1'), listElements[0]).should.be.true;
     store.addQuad(new NamedNode('s2'), new NamedNode(namespaces.rdf.rest), listElements[0]).should.be.true;
     store.addQuad(new NamedNode('s2'), new NamedNode('p1'), listElements[0]).should.be.true;
 
-    it('extractLists throws an error', function () {
+    it('extractLists throws an error', () => {
       expect(() => store.extractLists()).throws('b3 can\'t have coreferences');
     });
   });
 
-  describe('A Store containing an rdf:Collection spread across graphs', function () {
+  describe('A Store containing an rdf:Collection spread across graphs', () => {
     var member0 = new NamedNode('element1');
     var member1 = new Literal('"element2"');
     var store = new Store();
@@ -1409,13 +1409,13 @@ describe('Store', function () {
     store.addQuad(listElements[1], new NamedNode(namespaces.rdf.rest), new NamedNode(namespaces.rdf.nil)).should.be.true;
     store.addQuad(new NamedNode('s1'), new NamedNode('p1'), listElements[0]).should.be.true;
 
-    describe('extractLists without ignoreErrors', function () {
-      it('extractLists throws an error', function () {
+    describe('extractLists without ignoreErrors', () => {
+      it('extractLists throws an error', () => {
         expect(() => store.extractLists()).throws('b0 not confined to single graph');
       });
     });
 
-    describe('extractLists with ignoreErrors', function () {
+    describe('extractLists with ignoreErrors', () => {
       var lists = store.extractLists({ ignoreErrors: true });
       it('should not delete triples',
         shouldIncludeAll(store.getQuads(),
@@ -1425,7 +1425,7 @@ describe('Store', function () {
           ['_:' + listElements[1].value, namespaces.rdf.first, '"element2"'],
           ['_:' + listElements[1].value, namespaces.rdf.rest, namespaces.rdf.nil]
         ));
-      it('should generate an empty list of Collections', function () {
+      it('should generate an empty list of Collections', () => {
         expect(listsToJSON(lists)).to.deep.equal({});
       });
     });
@@ -1447,19 +1447,19 @@ function collect(store, method, arg1, arg2, arg3, arg4) {
 }
 
 function itShouldBeEmpty(result) {
-  it('should be empty', function () {
+  it('should be empty', () => {
     if (typeof result === 'function') result = result();
     result.should.be.empty;
   });
 }
 
 function shouldIncludeAll(result) {
-  var items = Array.prototype.slice.call(arguments, 1).map(function (arg) {
+  var items = Array.prototype.slice.call(arguments, 1).map(arg => {
     return new Quad(termFromId(arg[0]), termFromId(arg[1]), termFromId(arg[2]), termFromId(arg[3] || ''));
   });
   return function () {
     if (typeof result === 'function') result = result();
-    result = result.map(function (r) { return r.toJSON(); });
+    result = result.map(r => { return r.toJSON(); });
     result.should.have.length(items.length);
     for (var i = 0; i < items.length; i++)
       result.should.include.something.that.deep.equals(items[i].toJSON());
@@ -1471,7 +1471,7 @@ function forResultStream(testFunction, result) {
   return function (done) {
     if (typeof result === 'function') result = result();
     arrayifyStream(result)
-      .then(function (array) {
+      .then(array => {
         items.unshift(array);
         testFunction.apply({}, items)();
       })
@@ -1490,7 +1490,7 @@ function addList(store, ...items) {
     return new NamedNode(namespaces.rdf.nil);
 
   var listElements = [store.createBlankNode()];
-  items.forEach(function (item, i) {
+  items.forEach((item, i) => {
     store.addQuad(listElements[i], new NamedNode(namespaces.rdf.first), item);
     if (i === items.length - 1)
       store.addQuad(listElements[i], new NamedNode(namespaces.rdf.rest), new NamedNode(namespaces.rdf.nil));

--- a/test/N3StreamParser-test.js
+++ b/test/N3StreamParser-test.js
@@ -1,18 +1,18 @@
 import { StreamParser, NamedNode } from '../src/';
 import { Readable, Writable } from 'readable-stream';
 
-describe('StreamParser', function () {
-  describe('The StreamParser export', function () {
-    it('should be a function', function () {
+describe('StreamParser', () => {
+  describe('The StreamParser export', () => {
+    it('should be a function', () => {
       StreamParser.should.be.a('function');
     });
 
-    it('should be a StreamParser constructor', function () {
+    it('should be a StreamParser constructor', () => {
       new StreamParser().should.be.an.instanceof(StreamParser);
     });
   });
 
-  describe('A StreamParser instance', function () {
+  describe('A StreamParser instance', () => {
     it('parses the empty stream', shouldParse([], 0));
 
     it('parses the zero-length stream', shouldParse([''], 0));
@@ -24,10 +24,10 @@ describe('StreamParser', function () {
     it('should parse decimals that are split across chunks in the stream',
       shouldParse('<sub> <pred> 11.2 .'.match(/.{1,2}/g), 1));
 
-    it('should parse non-breaking spaces that are split across chunks in the stream correctly', function (done) {
+    it('should parse non-breaking spaces that are split across chunks in the stream correctly', done => {
       var buffer = Buffer.from('<sub> <pred> " " .'),
           chunks = [buffer, buffer.slice(0, 15), buffer.slice(15, buffer.length)];
-      shouldParse(chunks, 2, function (triples) {
+      shouldParse(chunks, 2, triples => {
         triples[0].should.deep.equal(triples[1]);
       })(done);
     });
@@ -39,12 +39,12 @@ describe('StreamParser', function () {
       shouldEmitPrefixes(['@prefix a: <http://a.org/#>. a:a a:b a:c. @prefix b: <http://b.org/#>.'],
                          { a: new NamedNode('http://a.org/#'), b: new NamedNode('http://b.org/#') }));
 
-    it('passes an error', function () {
+    it('passes an error', () => {
       var input = new Readable(),
           parser = new StreamParser(),
           error = null;
       input._read = function () {};
-      parser.on('error', function (e) { error = e; });
+      parser.on('error', e => { error = e; });
       parser.import(input);
       input.emit('error', new Error());
       expect(error).to.be.an.instanceof(Error);
@@ -62,7 +62,7 @@ function shouldParse(chunks, expectedLength, validateTriples) {
     parser.import(inputStream).should.equal(parser);
     parser.pipe(outputStream);
     parser.on('error', done);
-    parser.on('end', function () {
+    parser.on('end', () => {
       triples.should.have.length(expectedLength);
       if (validateTriples) validateTriples(triples);
       done();
@@ -77,7 +77,7 @@ function shouldNotParse(chunks, expectedMessage, expectedContext) {
         outputStream = new ArrayWriter([]);
     inputStream.pipe(parser);
     parser.pipe(outputStream);
-    parser.on('error', function (error) {
+    parser.on('error', error => {
       error.should.be.an.instanceof(Error);
       error.message.should.equal(expectedMessage);
       if (expectedContext) error.context.should.deep.equal(expectedContext);
@@ -92,10 +92,10 @@ function shouldEmitPrefixes(chunks, expectedPrefixes) {
         parser = new StreamParser(),
         inputStream = new ArrayReader(chunks);
     inputStream.pipe(parser);
-    parser.on('data', function () {});
-    parser.on('prefix', function (prefix, iri) { prefixes[prefix] = iri; });
+    parser.on('data', () => {});
+    parser.on('prefix', (prefix, iri) => { prefixes[prefix] = iri; });
     parser.on('error', done);
-    parser.on('end', function (error) {
+    parser.on('end', error => {
       prefixes.should.deep.equal(expectedPrefixes);
       done(error);
     });

--- a/test/N3StreamWriter-test.js
+++ b/test/N3StreamWriter-test.js
@@ -1,18 +1,18 @@
 import { StreamWriter, Quad, NamedNode, termFromId } from '../src/';
 import { Readable, Writable } from 'readable-stream';
 
-describe('StreamWriter', function () {
-  describe('The StreamWriter export', function () {
-    it('should be a function', function () {
+describe('StreamWriter', () => {
+  describe('The StreamWriter export', () => {
+    it('should be a function', () => {
       StreamWriter.should.be.a('function');
     });
 
-    it('should be a StreamWriter constructor', function () {
+    it('should be a StreamWriter constructor', () => {
       new StreamWriter().should.be.an.instanceof(StreamWriter);
     });
   });
 
-  describe('A StreamWriter instance', function () {
+  describe('A StreamWriter instance', () => {
     it('should serialize 0 triples',
       shouldSerialize(''));
 
@@ -46,7 +46,7 @@ describe('StreamWriter', function () {
                       '<http://a.org/bc/de> <http://a.org/b#e#f> <http://a.org/b#x/t>.\n' +
                       '<http://a.org/3a> <http://a.org/b#3a> b:a3.\n'));
 
-    it('should take over prefixes from the input stream', function (done) {
+    it('should take over prefixes from the input stream', done => {
       var inputStream = new Readable(),
           writer = new StreamWriter(),
           outputStream = new StringWriter();
@@ -59,7 +59,7 @@ describe('StreamWriter', function () {
       inputStream.push(null);
 
       writer.on('error', done);
-      writer.on('end', function () {
+      writer.on('end', () => {
         outputStream.result.should.equal('@prefix a: <http://a.org/>.\n\n' +
                                          '@prefix b: <http://b.org/>.\n\n');
         done();
@@ -67,12 +67,12 @@ describe('StreamWriter', function () {
     });
   });
 
-  it('passes an error', function () {
+  it('passes an error', () => {
     var input = new Readable(),
         writer = new StreamWriter(),
         error = null;
     input._read = function () {};
-    writer.on('error', function (e) { error = e; });
+    writer.on('error', e => { error = e; });
     writer.import(input);
     input.emit('error', new Error());
     expect(error).to.be.an.instanceof(Error);
@@ -85,7 +85,7 @@ function shouldSerialize(/* options?, tripleArrays..., expectedResult */) {
       expectedResult = tripleArrays.pop(),
       options = tripleArrays[0] instanceof Array ? null : tripleArrays.shift();
 
-  tripleArrays = tripleArrays.map(function (i) {
+  tripleArrays = tripleArrays.map(i => {
     return new Quad(termFromId(i[0]), termFromId(i[1]), termFromId(i[2]));
   });
 
@@ -96,7 +96,7 @@ function shouldSerialize(/* options?, tripleArrays..., expectedResult */) {
     writer.import(inputStream).should.equal(writer);
     writer.pipe(outputStream);
     writer.on('error', done);
-    writer.on('end', function () {
+    writer.on('end', () => {
       outputStream.result.should.equal(expectedResult);
       done();
     });

--- a/test/N3Util-test.js
+++ b/test/N3Util-test.js
@@ -8,195 +8,195 @@ import {
   Quad,
 } from '../src/';
 
-describe('Util', function () {
-  describe('isNamedNode', function () {
-    it('matches an IRI', function () {
+describe('Util', () => {
+  describe('isNamedNode', () => {
+    it('matches an IRI', () => {
       Util.isNamedNode(new NamedNode('http://example.org/')).should.be.true;
     });
 
-    it('matches an empty IRI', function () {
+    it('matches an empty IRI', () => {
       Util.isNamedNode(new NamedNode('')).should.be.true;
     });
 
-    it('does not match a literal', function () {
+    it('does not match a literal', () => {
       Util.isNamedNode(new Literal('"http://example.org/"')).should.be.false;
     });
 
-    it('does not match a blank node', function () {
+    it('does not match a blank node', () => {
       Util.isNamedNode(new BlankNode('x')).should.be.false;
     });
 
-    it('does not match a variable', function () {
+    it('does not match a variable', () => {
       Util.isNamedNode(new Variable('x')).should.be.false;
     });
 
-    it('does not match null', function () {
+    it('does not match null', () => {
       expect(Util.isNamedNode(null)).to.be.false;
     });
 
-    it('does not match undefined', function () {
+    it('does not match undefined', () => {
       expect(Util.isNamedNode(undefined)).to.be.false;
     });
   });
 
-  describe('isLiteral', function () {
-    it('matches a literal', function () {
+  describe('isLiteral', () => {
+    it('matches a literal', () => {
       Util.isLiteral(new Literal('"http://example.org/"')).should.be.true;
     });
 
-    it('matches a literal with a language', function () {
+    it('matches a literal with a language', () => {
       Util.isLiteral(new Literal('"English"@en')).should.be.true;
     });
 
-    it('matches a literal with a language that contains a number', function () {
+    it('matches a literal with a language that contains a number', () => {
       Util.isLiteral(new Literal('"English"@es-419')).should.be.true;
     });
 
-    it('matches a literal with a type', function () {
+    it('matches a literal with a type', () => {
       Util.isLiteral(new Literal('"3"^^http://www.w3.org/2001/XMLSchema#integer')).should.be.true;
     });
 
-    it('matches a literal with a newline', function () {
+    it('matches a literal with a newline', () => {
       Util.isLiteral(new Literal('"a\nb"')).should.be.true;
     });
 
-    it('matches a literal with a cariage return', function () {
+    it('matches a literal with a cariage return', () => {
       Util.isLiteral(new Literal('"a\rb"')).should.be.true;
     });
 
-    it('does not match an IRI', function () {
+    it('does not match an IRI', () => {
       Util.isLiteral(new NamedNode('http://example.org/')).should.be.false;
     });
 
-    it('does not match a blank node', function () {
+    it('does not match a blank node', () => {
       Util.isLiteral(new BlankNode('_:x')).should.be.false;
     });
 
-    it('does not match a variable', function () {
+    it('does not match a variable', () => {
       Util.isLiteral(new Variable('x')).should.be.false;
     });
 
-    it('does not match null', function () {
+    it('does not match null', () => {
       expect(Util.isLiteral(null)).to.be.false;
     });
 
-    it('does not match undefined', function () {
+    it('does not match undefined', () => {
       expect(Util.isLiteral(undefined)).to.be.false;
     });
   });
 
-  describe('isBlankNode', function () {
-    it('matches a blank node', function () {
+  describe('isBlankNode', () => {
+    it('matches a blank node', () => {
       Util.isBlankNode(new BlankNode('x')).should.be.true;
     });
 
-    it('does not match an IRI', function () {
+    it('does not match an IRI', () => {
       Util.isBlankNode(new NamedNode('http://example.org/')).should.be.false;
     });
 
-    it('does not match a literal', function () {
+    it('does not match a literal', () => {
       Util.isBlankNode(new Literal('"http://example.org/"')).should.be.false;
     });
 
-    it('does not match a variable', function () {
+    it('does not match a variable', () => {
       Util.isBlankNode(new Variable('x')).should.be.false;
     });
 
-    it('does not match null', function () {
+    it('does not match null', () => {
       expect(Util.isBlankNode(null)).to.be.false;
     });
 
-    it('does not match undefined', function () {
+    it('does not match undefined', () => {
       expect(Util.isBlankNode(undefined)).to.be.false;
     });
   });
 
-  describe('isVariable', function () {
-    it('matches a variable', function () {
+  describe('isVariable', () => {
+    it('matches a variable', () => {
       Util.isVariable(new Variable('x')).should.be.true;
     });
 
-    it('does not match an IRI', function () {
+    it('does not match an IRI', () => {
       Util.isVariable(new NamedNode('http://example.org/')).should.be.false;
     });
 
-    it('does not match a literal', function () {
+    it('does not match a literal', () => {
       Util.isVariable(new Literal('"http://example.org/"')).should.be.false;
     });
 
-    it('does not match a blank node', function () {
+    it('does not match a blank node', () => {
       Util.isNamedNode(new BlankNode('x')).should.be.false;
     });
 
-    it('does not match null', function () {
+    it('does not match null', () => {
       expect(Util.isVariable(null)).to.be.false;
     });
 
-    it('does not match undefined', function () {
+    it('does not match undefined', () => {
       expect(Util.isVariable(undefined)).to.be.false;
     });
   });
 
-  describe('isDefaultGraph', function () {
-    it('does not match a blank node', function () {
+  describe('isDefaultGraph', () => {
+    it('does not match a blank node', () => {
       Util.isDefaultGraph(new BlankNode('x')).should.be.false;
     });
 
-    it('does not match an IRI', function () {
+    it('does not match an IRI', () => {
       Util.isDefaultGraph(new NamedNode('http://example.org/')).should.be.false;
     });
 
-    it('does not match a literal', function () {
+    it('does not match a literal', () => {
       Util.isDefaultGraph(new Literal('"http://example.org/"')).should.be.false;
     });
 
-    it('does not match null', function () {
+    it('does not match null', () => {
       expect(Util.isVariable(null)).to.be.false;
     });
 
-    it('does not match undefined', function () {
+    it('does not match undefined', () => {
       expect(Util.isVariable(undefined)).to.be.false;
     });
   });
 
-  describe('inDefaultGraph', function () {
-    it('does not match a blank node', function () {
+  describe('inDefaultGraph', () => {
+    it('does not match a blank node', () => {
       Util.inDefaultGraph(new Quad(null, null, null, new BlankNode('x'))).should.be.false;
     });
 
-    it('does not match an IRI', function () {
+    it('does not match an IRI', () => {
       Util.inDefaultGraph(new Quad(null, null, null, new NamedNode('http://example.org/'))).should.be.false;
     });
 
-    it('does not match a literal', function () {
+    it('does not match a literal', () => {
       Util.inDefaultGraph(new Quad(null, null, null, new Literal('"http://example.org/"'))).should.be.false;
     });
 
-    it('matches null', function () {
+    it('matches null', () => {
       Util.inDefaultGraph(new Quad(null, null, null, null)).should.be.true;
     });
 
-    it('matches undefined', function () {
+    it('matches undefined', () => {
       Util.inDefaultGraph(new Quad(null, null, null, undefined)).should.be.true;
     });
 
-    it('matches the default graph', function () {
+    it('matches the default graph', () => {
       Util.inDefaultGraph(new Quad(null, null, null, new DefaultGraph())).should.be.true;
     });
   });
 
-  describe('prefix', function () {
+  describe('prefix', () => {
     var rdfs = Util.prefix('http://www.w3.org/2000/01/rdf-schema#');
-    it('should return a function', function () {
+    it('should return a function', () => {
       expect(rdfs).to.be.an.instanceof(Function);
     });
 
-    describe('the function', function () {
-      it('should expand the prefix', function () {
+    describe('the function', () => {
+      it('should expand the prefix', () => {
         expect(rdfs('label')).to.deep.equal(new NamedNode('http://www.w3.org/2000/01/rdf-schema#label'));
       });
 
-      it('should use a custom factory when specified', function () {
+      it('should use a custom factory when specified', () => {
         var factory = { namedNode: function (s) { return 'n-' + s; } };
         var rdfs = Util.prefix('http://www.w3.org/2000/01/rdf-schema#', factory);
         expect(rdfs('label')).to.equal('n-http://www.w3.org/2000/01/rdf-schema#label');
@@ -204,70 +204,70 @@ describe('Util', function () {
     });
   });
 
-  describe('prefixes', function () {
-    describe('called without arguments', function () {
+  describe('prefixes', () => {
+    describe('called without arguments', () => {
       var prefixes = Util.prefixes();
-      it('should return a function', function () {
+      it('should return a function', () => {
         expect(prefixes).to.be.an.instanceof(Function);
       });
 
-      describe('the function', function () {
-        it('should not expand non-registered prefixes', function () {
-          expect(function () { prefixes('foo'); }).to.throw('Unknown prefix: foo');
+      describe('the function', () => {
+        it('should not expand non-registered prefixes', () => {
+          expect(() => { prefixes('foo'); }).to.throw('Unknown prefix: foo');
         });
 
-        it('should allow registering prefixes', function () {
+        it('should allow registering prefixes', () => {
           var p = prefixes('rdfs', 'http://www.w3.org/2000/01/rdf-schema#');
           var rdfs = prefixes('rdfs');
           expect(p).to.exist;
           expect(p).to.equal(rdfs);
         });
 
-        it('should expand the newly registered prefix', function () {
+        it('should expand the newly registered prefix', () => {
           var rdfs = prefixes('rdfs');
           expect(rdfs('label')).to.deep.equal(new NamedNode('http://www.w3.org/2000/01/rdf-schema#label'));
         });
       });
     });
 
-    describe('called with a hash of prefixes', function () {
+    describe('called with a hash of prefixes', () => {
       var prefixes = Util.prefixes({
         rdfs: 'http://www.w3.org/2000/01/rdf-schema#',
         owl: 'http://www.w3.org/2002/07/owl#',
       });
-      it('should return a function', function () {
+      it('should return a function', () => {
         expect(prefixes).to.be.an.instanceof(Function);
       });
 
-      describe('the function', function () {
-        it('should expand registered prefixes', function () {
+      describe('the function', () => {
+        it('should expand registered prefixes', () => {
           expect(prefixes('rdfs')('label')).to.deep.equal(new NamedNode('http://www.w3.org/2000/01/rdf-schema#label'));
           expect(prefixes('owl')('sameAs')).to.deep.equal(new NamedNode('http://www.w3.org/2002/07/owl#sameAs'));
         });
 
-        it('should not expand non-registered prefixes', function () {
-          expect(function () { prefixes('foo'); }).to.throw('Unknown prefix: foo');
+        it('should not expand non-registered prefixes', () => {
+          expect(() => { prefixes('foo'); }).to.throw('Unknown prefix: foo');
         });
 
-        it('should allow registering prefixes', function () {
+        it('should allow registering prefixes', () => {
           var p = prefixes('my', 'http://example.org/#');
           var my = prefixes('my');
           expect(p).to.exist;
           expect(p).to.equal(my);
         });
 
-        it('should expand the newly registered prefix', function () {
+        it('should expand the newly registered prefix', () => {
           var my = prefixes('my');
           expect(my('me')).to.deep.equal(new NamedNode('http://example.org/#me'));
         });
       });
     });
 
-    describe('called with a custom factory', function () {
+    describe('called with a custom factory', () => {
       var factory = { namedNode: function (s) { return 'n-' + s; } };
       var prefixes = Util.prefixes({ my: 'http://example.org/#' }, factory);
 
-      it('should use the custom factory', function () {
+      it('should use the custom factory', () => {
         expect(prefixes('my')('foo')).to.equal('n-http://example.org/#foo');
       });
     });

--- a/test/N3Writer-test.js
+++ b/test/N3Writer-test.js
@@ -7,29 +7,29 @@ import {
   termFromId,
 } from '../src/';
 
-describe('Writer', function () {
-  describe('The Writer export', function () {
-    it('should be a function', function () {
+describe('Writer', () => {
+  describe('The Writer export', () => {
+    it('should be a function', () => {
       Writer.should.be.a('function');
     });
 
-    it('should be a Writer constructor', function () {
+    it('should be a Writer constructor', () => {
       new Writer().should.be.an.instanceof(Writer);
     });
   });
 
-  describe('A Writer instance', function () {
-    it('should serialize a single triple', function () {
+  describe('A Writer instance', () => {
+    it('should serialize a single triple', () => {
       var writer = new Writer();
       writer.quadToString(new NamedNode('a'), new NamedNode('b'), new NamedNode('c')).should.equal('<a> <b> <c> .\n');
     });
 
-    it('should serialize a single quad', function () {
+    it('should serialize a single quad', () => {
       var writer = new Writer();
       writer.quadToString(new NamedNode('a'), new NamedNode('b'), new NamedNode('c'), new NamedNode('g')).should.equal('<a> <b> <c> <g> .\n');
     });
 
-    it('should serialize an array of triples', function () {
+    it('should serialize an array of triples', () => {
       var writer = new Writer();
       var triples = [new Quad(new NamedNode('a'), new NamedNode('b'), new NamedNode('c')),
         new Quad(new NamedNode('d'), new NamedNode('e'), new NamedNode('f'))];
@@ -207,7 +207,7 @@ describe('Writer', function () {
       shouldSerialize(['_:\ud835\udc00', '_:\ud835\udc00', '_:\ud835\udc00', '_:\ud835\udc00'],
                       '_:\ud835\udc00 {\n_:\ud835\udc00 _:\ud835\udc00 _:\ud835\udc00\n}\n'));
 
-    it('calls the done callback when ending the outputstream errors', function (done) {
+    it('calls the done callback when ending the outputstream errors', done => {
       var writer = new Writer({
         write: function () {},
         end: function () { throw new Error('error'); },
@@ -215,42 +215,42 @@ describe('Writer', function () {
       writer.end(done);
     });
 
-    it('sends output through end when no stream argument is given', function (done) {
+    it('sends output through end when no stream argument is given', done => {
       var writer = new Writer(), notCalled = true;
-      writer.addQuad(new Quad(new NamedNode('a'), new NamedNode('b'), new NamedNode('c')), function () { notCalled = false; });
-      writer.end(function (error, output) {
+      writer.addQuad(new Quad(new NamedNode('a'), new NamedNode('b'), new NamedNode('c')), () => { notCalled = false; });
+      writer.end((error, output) => {
         output.should.equal('<a> <b> <c>.\n');
         done(notCalled || error);
       });
     });
 
-    it('respects the prefixes argument when no stream argument is given', function (done) {
+    it('respects the prefixes argument when no stream argument is given', done => {
       var writer = new Writer({ prefixes: { a: 'b#' } });
       writer.addQuad(new Quad(new NamedNode('b#a'), new NamedNode('b#b'), new NamedNode('b#c')));
-      writer.end(function (error, output) {
+      writer.end((error, output) => {
         output.should.equal('@prefix a: <b#>.\n\na:a a:b a:c.\n');
         done(error);
       });
     });
 
-    it('ignores an empty prefix list', function (done) {
+    it('ignores an empty prefix list', done => {
       var writer = new Writer();
       writer.addPrefixes({});
       writer.addQuad(new Quad(new NamedNode('b#a'), new NamedNode('b#b'), new NamedNode('b#c')));
-      writer.end(function (error, output) {
+      writer.end((error, output) => {
         output.should.equal('<b#a> <b#b> <b#c>.\n');
         done(error);
       });
     });
 
-    it('serializes triples of a graph with a prefix declaration in between', function (done) {
+    it('serializes triples of a graph with a prefix declaration in between', done => {
       var writer = new Writer();
       writer.addQuad(new Quad(new NamedNode('b#a'), new NamedNode('b#b'), new NamedNode('b#c')));
       writer.addPrefix('a', 'b#');
       writer.addQuad(new Quad(new NamedNode('b#a'), new NamedNode('b#b'), new NamedNode('b#c'), new NamedNode('b#g')));
       writer.addPrefix('d', 'e#');
       writer.addQuad({ subject: new NamedNode('b#a'), predicate: new NamedNode('b#b'), object: new NamedNode('b#d'), graph: new NamedNode('b#g') });
-      writer.end(function (error, output) {
+      writer.end((error, output) => {
         output.should.equal('<b#a> <b#b> <b#c>.\n' +
                             '@prefix a: <b#>.\n\na:g {\na:a a:b a:c\n}\n' +
                             '@prefix d: <e#>.\n\na:g {\na:a a:b a:d\n}\n');
@@ -258,43 +258,43 @@ describe('Writer', function () {
       });
     });
 
-    it('should accept triples with separated components', function (done) {
+    it('should accept triples with separated components', done => {
       var writer = new Writer();
       writer.addQuad(new NamedNode('a'), new NamedNode('b'), new NamedNode('c'));
       writer.addQuad(new NamedNode('a'), new NamedNode('b'), new NamedNode('d'));
-      writer.end(function (error, output) {
+      writer.end((error, output) => {
         output.should.equal('<a> <b> <c>, <d>.\n');
         done(error);
       });
     });
 
-    it('should accept quads with separated components', function (done) {
+    it('should accept quads with separated components', done => {
       var writer = new Writer();
       writer.addQuad(new NamedNode('a'), new NamedNode('b'), new NamedNode('c'), new NamedNode('g'));
       writer.addQuad(new NamedNode('a'), new NamedNode('b'), new NamedNode('d'), new NamedNode('g'));
-      writer.end(function (error, output) {
+      writer.end((error, output) => {
         output.should.equal('<g> {\n<a> <b> <c>, <d>\n}\n');
         done(error);
       });
     });
 
-    it('should serialize triples with an empty blank node as object', function (done) {
+    it('should serialize triples with an empty blank node as object', done => {
       var writer = new Writer();
       writer.addQuad(new NamedNode('a1'), new NamedNode('b'), writer.blank());
       writer.addQuad(new NamedNode('a2'), new NamedNode('b'), writer.blank([]));
-      writer.end(function (error, output) {
+      writer.end((error, output) => {
         output.should.equal('<a1> <b> [].\n' +
                             '<a2> <b> [].\n');
         done(error);
       });
     });
 
-    it('should serialize triples with a one-triple blank node as object', function (done) {
+    it('should serialize triples with a one-triple blank node as object', done => {
       var writer = new Writer();
       writer.addQuad(new NamedNode('a1'), new NamedNode('b'), writer.blank(new NamedNode('d'), new NamedNode('e')));
       writer.addQuad(new NamedNode('a2'), new NamedNode('b'), writer.blank({ predicate: new NamedNode('d'), object: new NamedNode('e') }));
       writer.addQuad(new NamedNode('a3'), new NamedNode('b'), writer.blank([{ predicate: new NamedNode('d'), object: new NamedNode('e') }]));
-      writer.end(function (error, output) {
+      writer.end((error, output) => {
         output.should.equal('<a1> <b> [ <d> <e> ].\n' +
                             '<a2> <b> [ <d> <e> ].\n' +
                             '<a3> <b> [ <d> <e> ].\n');
@@ -302,13 +302,13 @@ describe('Writer', function () {
       });
     });
 
-    it('should serialize triples with a two-triple blank node as object', function (done) {
+    it('should serialize triples with a two-triple blank node as object', done => {
       var writer = new Writer();
       writer.addQuad(new NamedNode('a'), new NamedNode('b'), writer.blank([
           { predicate: new NamedNode('d'), object: new NamedNode('e') },
           { predicate: new NamedNode('f'), object: new Literal('"g"') },
       ]));
-      writer.end(function (error, output) {
+      writer.end((error, output) => {
         output.should.equal('<a> <b> [\n' +
                             '  <d> <e>;\n' +
                             '  <f> "g"\n' +
@@ -317,14 +317,14 @@ describe('Writer', function () {
       });
     });
 
-    it('should serialize triples with a three-triple blank node as object', function (done) {
+    it('should serialize triples with a three-triple blank node as object', done => {
       var writer = new Writer();
       writer.addQuad(new NamedNode('a'), new NamedNode('b'), writer.blank([
         { predicate: new NamedNode('d'), object: new NamedNode('e') },
         { predicate: new NamedNode('f'), object: new Literal('"g"') },
         { predicate: new NamedNode('h'), object: new NamedNode('i') },
       ]));
-      writer.end(function (error, output) {
+      writer.end((error, output) => {
         output.should.equal('<a> <b> [\n' +
                             '  <d> <e>;\n' +
                             '  <f> "g";\n' +
@@ -334,7 +334,7 @@ describe('Writer', function () {
       });
     });
 
-    it('should serialize triples with predicate-sharing blank node triples as object', function (done) {
+    it('should serialize triples with predicate-sharing blank node triples as object', done => {
       var writer = new Writer();
       writer.addQuad(new NamedNode('a'), new NamedNode('b'), writer.blank([
         { predicate: new NamedNode('d'), object: new NamedNode('e') },
@@ -342,7 +342,7 @@ describe('Writer', function () {
         { predicate: new NamedNode('g'), object: new NamedNode('h') },
         { predicate: new NamedNode('g'), object: new NamedNode('i') },
       ]));
-      writer.end(function (error, output) {
+      writer.end((error, output) => {
         output.should.equal('<a> <b> [\n' +
           '  <d> <e>, <f>;\n' +
           '  <g> <h>, <i>\n' +
@@ -351,7 +351,7 @@ describe('Writer', function () {
       });
     });
 
-    it('should serialize triples with nested blank nodes as object', function (done) {
+    it('should serialize triples with nested blank nodes as object', done => {
       var writer = new Writer();
       writer.addQuad(new NamedNode('a1'), new NamedNode('b'), writer.blank([
         { predicate: new NamedNode('d'), object: writer.blank() },
@@ -366,7 +366,7 @@ describe('Writer', function () {
           { predicate: new NamedNode('j'), object: writer.blank(new NamedNode('k'), new Literal('"l"')) },
         ]) },
       ]));
-      writer.end(function (error, output) {
+      writer.end((error, output) => {
         output.should.equal('<a1> <b> [\n' +
           '  <d> []\n' +
           '].\n' +
@@ -384,23 +384,23 @@ describe('Writer', function () {
       });
     });
 
-    it('should serialize triples with an empty blank node as subject', function (done) {
+    it('should serialize triples with an empty blank node as subject', done => {
       var writer = new Writer();
       writer.addQuad(writer.blank(), new NamedNode('b'), new NamedNode('c'));
       writer.addQuad(writer.blank([]), new NamedNode('b'), new NamedNode('c'));
-      writer.end(function (error, output) {
+      writer.end((error, output) => {
         output.should.equal('[] <b> <c>.\n' +
                             '[] <b> <c>.\n');
         done(error);
       });
     });
 
-    it('should serialize triples with a one-triple blank node as subject', function (done) {
+    it('should serialize triples with a one-triple blank node as subject', done => {
       var writer = new Writer();
       writer.addQuad(writer.blank(new NamedNode('a'), new NamedNode('b')), new NamedNode('c'), new NamedNode('d'));
       writer.addQuad(writer.blank({ predicate: new NamedNode('a'), object: new NamedNode('b') }), new NamedNode('c'), new NamedNode('d'));
       writer.addQuad(writer.blank([{ predicate: new NamedNode('a'), object: new NamedNode('b') }]), new NamedNode('c'), new NamedNode('d'));
-      writer.end(function (error, output) {
+      writer.end((error, output) => {
         output.should.equal('[ <a> <b> ] <c> <d>.\n' +
                             '[ <a> <b> ] <c> <d>.\n' +
                             '[ <a> <b> ] <c> <d>.\n');
@@ -408,82 +408,82 @@ describe('Writer', function () {
       });
     });
 
-    it('should serialize triples with an empty blank node as graph', function (done) {
+    it('should serialize triples with an empty blank node as graph', done => {
       var writer = new Writer();
       writer.addQuad(new NamedNode('a'), new NamedNode('b'), new NamedNode('c'), writer.blank());
       writer.addQuad(new NamedNode('a'), new NamedNode('b'), new NamedNode('c'), writer.blank([]));
-      writer.end(function (error, output) {
+      writer.end((error, output) => {
         output.should.equal('[] {\n<a> <b> <c>\n}\n' +
                             '[] {\n<a> <b> <c>\n}\n');
         done(error);
       });
     });
 
-    it('should serialize triples with an empty list as object', function (done) {
+    it('should serialize triples with an empty list as object', done => {
       var writer = new Writer();
       writer.addQuad(new NamedNode('a1'), new NamedNode('b'), writer.list());
       writer.addQuad(new NamedNode('a2'), new NamedNode('b'), writer.list([]));
-      writer.end(function (error, output) {
+      writer.end((error, output) => {
         output.should.equal('<a1> <b> ().\n' +
                             '<a2> <b> ().\n');
         done(error);
       });
     });
 
-    it('should serialize triples with a one-element list as object', function (done) {
+    it('should serialize triples with a one-element list as object', done => {
       var writer = new Writer();
       writer.addQuad(new NamedNode('a1'), new NamedNode('b'), writer.list([new NamedNode('c')]));
       writer.addQuad(new NamedNode('a2'), new NamedNode('b'), writer.list([new Literal('"c"')]));
-      writer.end(function (error, output) {
+      writer.end((error, output) => {
         output.should.equal('<a1> <b> (<c>).\n' +
                             '<a2> <b> ("c").\n');
         done(error);
       });
     });
 
-    it('should serialize triples with a three-element list as object', function (done) {
+    it('should serialize triples with a three-element list as object', done => {
       var writer = new Writer();
       writer.addQuad(new NamedNode('a1'), new NamedNode('b'), writer.list([new NamedNode('c'), new NamedNode('d'), new NamedNode('e')]));
       writer.addQuad(new NamedNode('a2'), new NamedNode('b'), writer.list([new Literal('"c"'), new Literal('"d"'), new Literal('"e"')]));
-      writer.end(function (error, output) {
+      writer.end((error, output) => {
         output.should.equal('<a1> <b> (<c> <d> <e>).\n' +
                             '<a2> <b> ("c" "d" "e").\n');
         done(error);
       });
     });
 
-    it('should serialize triples with an empty list as subject', function (done) {
+    it('should serialize triples with an empty list as subject', done => {
       var writer = new Writer();
       writer.addQuad(writer.list(),   new NamedNode('b1'), new NamedNode('c'));
       writer.addQuad(writer.list([]), new NamedNode('b2'), new NamedNode('c'));
-      writer.end(function (error, output) {
+      writer.end((error, output) => {
         output.should.equal('() <b1> <c>.\n' +
                             '() <b2> <c>.\n');
         done(error);
       });
     });
 
-    it('should serialize triples with a one-element list as subject', function (done) {
+    it('should serialize triples with a one-element list as subject', done => {
       var writer = new Writer();
       writer.addQuad(writer.list([new NamedNode('a')]), new NamedNode('b1'), new NamedNode('c'));
       writer.addQuad(writer.list([new NamedNode('a')]), new NamedNode('b2'), new NamedNode('c'));
-      writer.end(function (error, output) {
+      writer.end((error, output) => {
         output.should.equal('(<a>) <b1> <c>.\n' +
                             '(<a>) <b2> <c>.\n');
         done(error);
       });
     });
 
-    it('should serialize triples with a three-element list as subject', function (done) {
+    it('should serialize triples with a three-element list as subject', done => {
       var writer = new Writer();
       writer.addQuad(writer.list([new NamedNode('a1'), new Literal('"b"'), new Literal('"c"')]), new NamedNode('d'), new NamedNode('e'));
-      writer.end(function (error, output) {
+      writer.end((error, output) => {
         output.should.equal('(<a1> "b" "c") <d> <e>.\n');
         done(error);
       });
     });
 
-    it('should serialize subject and object triples passed by options.listHeads', function (done) {
+    it('should serialize subject and object triples passed by options.listHeads', done => {
       var lists = {
         l1: [new NamedNode('c'), new NamedNode('d'), new NamedNode('e')],
         l2: [new Literal('c'), new Literal('d'), new Literal('e')],
@@ -492,140 +492,140 @@ describe('Writer', function () {
       var writer = new Writer({ lists });
       writer.addQuad(new BlankNode('l1'), new NamedNode('b'), new BlankNode('l2'));
       writer.addQuad(new NamedNode('a3'), new NamedNode('b'), new BlankNode('m3'));
-      writer.end(function (error, output) {
+      writer.end((error, output) => {
         output.should.equal('(<c> <d> <e>) <b> ("c" "d" "e").\n' +
           '<a3> <b> _:m3.\n');
         done(error);
       });
     });
 
-    it('should accept triples in bulk', function (done) {
+    it('should accept triples in bulk', done => {
       var writer = new Writer();
       writer.addQuads([new Quad(new NamedNode('a'), new NamedNode('b'), new NamedNode('c')),
         new Quad(new NamedNode('a'), new NamedNode('b'), new NamedNode('d'))]);
-      writer.end(function (error, output) {
+      writer.end((error, output) => {
         output.should.equal('<a> <b> <c>, <d>.\n');
         done(error);
       });
     });
 
-    it('should not allow writing after end', function (done) {
+    it('should not allow writing after end', done => {
       var writer = new Writer();
       writer.addQuad(new Quad(new NamedNode('a'), new NamedNode('b'), new NamedNode('c')));
       writer.end();
-      writer.addQuad(new Quad(new NamedNode('d'), new NamedNode('e'), new NamedNode('f')), function (error) {
+      writer.addQuad(new Quad(new NamedNode('d'), new NamedNode('e'), new NamedNode('f')), error => {
         error.should.be.an.instanceof(Error);
         error.should.have.property('message', 'Cannot write because the writer has been closed.');
         done();
       });
     });
 
-    it('should write simple triples in N-Quads mode', function (done) {
+    it('should write simple triples in N-Quads mode', done => {
       var writer = new Writer({ format: 'N-Quads' });
       writer.addQuad(new NamedNode('a'), new NamedNode('b'), new NamedNode('c'));
       writer.addQuad(new NamedNode('a'), new NamedNode('b'), new NamedNode('d'));
-      writer.end(function (error, output) {
+      writer.end((error, output) => {
         output.should.equal('<a> <b> <c> .\n<a> <b> <d> .\n');
         done(error);
       });
     });
 
-    it('should write simple quads in N-Quads mode', function (done) {
+    it('should write simple quads in N-Quads mode', done => {
       var writer = new Writer({ format: 'N-Quads' });
       var called = false;
       function callback() { called = true; }
       writer.addQuad(new NamedNode('a'), new NamedNode('b'), new NamedNode('c'), callback);
       writer.addQuad(new NamedNode('a'), new NamedNode('b'), new NamedNode('d'), new NamedNode('g'));
-      writer.end(function (error, output) {
+      writer.end((error, output) => {
         called.should.be.true;
         output.should.equal('<a> <b> <c> .\n<a> <b> <d> <g> .\n');
         done(error);
       });
     });
 
-    it('should end when the end option is not set', function (done) {
+    it('should end when the end option is not set', done => {
       var outputStream = new QuickStream(), writer = new Writer(outputStream, {});
       outputStream.should.have.property('ended', false);
-      writer.end(function () {
+      writer.end(() => {
         outputStream.should.have.property('ended', true);
         done();
       });
     });
 
-    it('should end when the end option is set to true', function (done) {
+    it('should end when the end option is set to true', done => {
       var outputStream = new QuickStream(), writer = new Writer(outputStream, { end: true });
       outputStream.should.have.property('ended', false);
-      writer.end(function () {
+      writer.end(() => {
         outputStream.should.have.property('ended', true);
         done();
       });
     });
 
-    it('should not end when the end option is set to false', function (done) {
+    it('should not end when the end option is set to false', done => {
       var outputStream = new QuickStream(), writer = new Writer(outputStream, { end: false });
       outputStream.should.have.property('ended', false);
-      writer.end(function () {
+      writer.end(() => {
         outputStream.should.have.property('ended', false);
         done();
       });
     });
 
-    it('should serialize a triple with a triple with mixed component types as subject', function () {
+    it('should serialize a triple with a triple with mixed component types as subject', () => {
       var writer = new Writer();
       writer.quadToString(new Quad(new BlankNode('b1'), new NamedNode('b'), new Literal('l1')), new NamedNode('b'), new NamedNode('c')).should.equal('<<_:b1 <b> "l">> <b> <c> .\n');
     });
 
-    it('should serialize a triple with a triple with iris as subject', function () {
+    it('should serialize a triple with a triple with iris as subject', () => {
       var writer = new Writer();
       writer.quadToString(new Quad(new NamedNode('a'), new NamedNode('b'), new NamedNode('c')), new NamedNode('b'), new NamedNode('c')).should.equal('<<<a> <b> <c>>> <b> <c> .\n');
     });
 
-    it('should serialize a triple with a triple with blanknodes as subject', function () {
+    it('should serialize a triple with a triple with blanknodes as subject', () => {
       var writer = new Writer();
       writer.quadToString(new Quad(new BlankNode('b1'), new BlankNode('b2'), new BlankNode('b3')), new NamedNode('b'), new NamedNode('c')).should.equal('<<_:b1 _:b2 _:b3>> <b> <c> .\n');
     });
 
-    it('should serialize a triple with a triple as object', function () {
+    it('should serialize a triple with a triple as object', () => {
       var writer = new Writer();
       writer.quadToString(new NamedNode('a'), new NamedNode('b'), new Quad(new BlankNode('b1'), new NamedNode('b'), new Literal('l1'))).should.equal('<a> <b> <<_:b1 <b> "l">> .\n');
     });
 
-    it('should serialize a triple with a triple with iris as object', function () {
+    it('should serialize a triple with a triple with iris as object', () => {
       var writer = new Writer();
       writer.quadToString(new NamedNode('a'), new NamedNode('b'), new Quad(new NamedNode('a'), new NamedNode('b'), new NamedNode('c'))).should.equal('<a> <b> <<<a> <b> <c>>> .\n');
     });
 
-    it('should serialize a triple with a triple with blanknodes as object', function () {
+    it('should serialize a triple with a triple with blanknodes as object', () => {
       var writer = new Writer();
       writer.quadToString(new NamedNode('a'), new NamedNode('b'), new Quad(new BlankNode('b1'), new BlankNode('b2'), new BlankNode('b3'))).should.equal('<a> <b> <<_:b1 _:b2 _:b3>> .\n');
     });
 
-    it('should serialize a quad with a triple with mixed component types as subject', function () {
+    it('should serialize a quad with a triple with mixed component types as subject', () => {
       var writer = new Writer();
       writer.quadToString(new Quad(new NamedNode('a'), new NamedNode('b'), new NamedNode('c')), new NamedNode('b'), new NamedNode('c'), new NamedNode('g')).should.equal('<<<a> <b> <c>>> <b> <c> <g> .\n');
     });
 
-    it('should serialize a quad with a triple as object', function () {
+    it('should serialize a quad with a triple as object', () => {
       var writer = new Writer();
       writer.quadToString(new NamedNode('a'), new NamedNode('b'), new Quad(new NamedNode('a'), new NamedNode('b'), new NamedNode('c')), new NamedNode('g')).should.equal('<a> <b> <<<a> <b> <c>>> <g> .\n');
     });
 
-    it('should serialize a quad with a quad as subject', function () {
+    it('should serialize a quad with a quad as subject', () => {
       var writer = new Writer();
       writer.quadToString(new Quad(new NamedNode('a'), new NamedNode('b'), new NamedNode('c'), new NamedNode('g')), new NamedNode('b'), new NamedNode('c'), new NamedNode('g')).should.equal('<<<a> <b> <c> <g>>> <b> <c> <g> .\n');
     });
 
-    it('should serialize a quad with a quad as object', function () {
+    it('should serialize a quad with a quad as object', () => {
       var writer = new Writer();
       writer.quadToString(new NamedNode('a'), new NamedNode('b'), new Quad(new NamedNode('a'), new NamedNode('b'), new NamedNode('c'), new NamedNode('g')), new NamedNode('g')).should.equal('<a> <b> <<<a> <b> <c> <g>>> <g> .\n');
     });
 
-    it('should serialize a triple with a quad as subject', function () {
+    it('should serialize a triple with a quad as subject', () => {
       var writer = new Writer();
       writer.quadToString(new Quad(new NamedNode('a'), new NamedNode('b'), new NamedNode('c'), new NamedNode('g')), new NamedNode('b'), new NamedNode('c')).should.equal('<<<a> <b> <c> <g>>> <b> <c> .\n');
     });
 
-    it('should serialize a triple with a quad as object', function () {
+    it('should serialize a triple with a quad as object', () => {
       var writer = new Writer();
       writer.quadToString(new NamedNode('a'), new NamedNode('b'), new Quad(new NamedNode('a'), new NamedNode('b'), new NamedNode('c'), new NamedNode('g'))).should.equal('<a> <b> <<<a> <b> <c> <g>>> .\n');
     });
@@ -650,7 +650,7 @@ function shouldSerialize(/* prefixes?, tripleArrays..., expectedResult */) {
         writer.addQuad(new Quad(subject, predicate, object, graph), next);
       }
       else
-        writer.end(function (error) {
+        writer.end(error => {
           try {
             outputStream.result.should.equal(expectedResult);
             outputStream.should.have.property('ended', true);

--- a/test/NamedNode-test.js
+++ b/test/NamedNode-test.js
@@ -1,78 +1,78 @@
 import { NamedNode, Term } from '../src/';
 
-describe('NamedNode', function () {
-  describe('The NamedNode module', function () {
-    it('should be a function', function () {
+describe('NamedNode', () => {
+  describe('The NamedNode module', () => {
+    it('should be a function', () => {
       NamedNode.should.be.a('function');
     });
 
-    it('should be a NamedNode constructor', function () {
+    it('should be a NamedNode constructor', () => {
       new NamedNode().should.be.an.instanceof(NamedNode);
     });
 
-    it('should be a Term constructor', function () {
+    it('should be a Term constructor', () => {
       new NamedNode().should.be.an.instanceof(Term);
     });
   });
 
-  describe('A NamedNode instance created from an IRI', function () {
+  describe('A NamedNode instance created from an IRI', () => {
     var namedNode;
-    before(function () { namedNode = new NamedNode('http://example.org/foo#bar'); });
+    before(() => { namedNode = new NamedNode('http://example.org/foo#bar'); });
 
-    it('should be a NamedNode', function () {
+    it('should be a NamedNode', () => {
       namedNode.should.be.an.instanceof(NamedNode);
     });
 
-    it('should be a Term', function () {
+    it('should be a Term', () => {
       namedNode.should.be.an.instanceof(Term);
     });
 
-    it('should have term type "NamedNode"', function () {
+    it('should have term type "NamedNode"', () => {
       namedNode.termType.should.equal('NamedNode');
     });
 
-    it('should have the IRI as value', function () {
+    it('should have the IRI as value', () => {
       namedNode.should.have.property('value', 'http://example.org/foo#bar');
     });
 
-    it('should have the IRI as id', function () {
+    it('should have the IRI as id', () => {
       namedNode.should.have.property('id', 'http://example.org/foo#bar');
     });
 
-    it('should equal a NamedNode instance with the same IRI', function () {
+    it('should equal a NamedNode instance with the same IRI', () => {
       namedNode.equals(new NamedNode('http://example.org/foo#bar')).should.be.true;
     });
 
-    it('should equal an object with the same term type and value', function () {
+    it('should equal an object with the same term type and value', () => {
       namedNode.equals({
         termType: 'NamedNode',
         value: 'http://example.org/foo#bar',
       }).should.be.true;
     });
 
-    it('should not equal a falsy object', function () {
+    it('should not equal a falsy object', () => {
       namedNode.equals(null).should.be.false;
     });
 
-    it('should not equal a NamedNode instance with another IRI', function () {
+    it('should not equal a NamedNode instance with another IRI', () => {
       namedNode.equals(new NamedNode('http://example.org/other')).should.be.false;
     });
 
-    it('should not equal an object with the same term type but a different value', function () {
+    it('should not equal an object with the same term type but a different value', () => {
       namedNode.equals({
         termType: 'NamedNode',
         value: 'http://example.org/other',
       }).should.be.false;
     });
 
-    it('should not equal an object with a different term type but the same value', function () {
+    it('should not equal an object with a different term type but the same value', () => {
       namedNode.equals({
         termType: 'BlankNode',
         value: 'http://example.org/foo#bar',
       }).should.be.false;
     });
 
-    it('should provide a JSON representation', function () {
+    it('should provide a JSON representation', () => {
       namedNode.toJSON().should.deep.equal({
         termType: 'NamedNode',
         value: 'http://example.org/foo#bar',

--- a/test/Quad-test.js
+++ b/test/Quad-test.js
@@ -1,23 +1,23 @@
 import { Quad, Triple, DefaultGraph, termFromId, Term } from '../src/';
 
-describe('Quad', function () {
-  describe('The Quad module', function () {
-    it('should be a function', function () {
+describe('Quad', () => {
+  describe('The Quad module', () => {
+    it('should be a function', () => {
       Quad.should.be.a('function');
     });
 
-    it('should be a Quad constructor', function () {
+    it('should be a Quad constructor', () => {
       new Quad().should.be.an.instanceof(Quad);
     });
 
-    it('should equal Triple', function () {
+    it('should equal Triple', () => {
       Quad.should.equal(Triple);
     });
   });
 
-  describe('A Quad instance created with subject/predicate/object', function () {
+  describe('A Quad instance created with subject/predicate/object', () => {
     var quad, subject, predicate, object;
-    before(function () {
+    before(() => {
       quad = new Quad(
         subject   = termFromId('s'),
         predicate = termFromId('p'),
@@ -25,35 +25,35 @@ describe('Quad', function () {
       );
     });
 
-    it('should be a Quad', function () {
+    it('should be a Quad', () => {
       quad.should.be.an.instanceof(Quad);
     });
 
-    it('should be a Term', function () {
+    it('should be a Term', () => {
       quad.should.be.an.instanceof(Term);
     });
 
-    it('should have the correct termType', function () {
+    it('should have the correct termType', () => {
       quad.termType.should.equal('Quad');
     });
 
-    it('should have the correct subject', function () {
+    it('should have the correct subject', () => {
       quad.subject.should.equal(subject);
     });
 
-    it('should have the correct predicate', function () {
+    it('should have the correct predicate', () => {
       quad.predicate.should.equal(predicate);
     });
 
-    it('should have the correct object', function () {
+    it('should have the correct object', () => {
       quad.object.should.equal(object);
     });
 
-    it('should have the default graph', function () {
+    it('should have the default graph', () => {
       quad.graph.should.equal(new DefaultGraph());
     });
 
-    it('should equal a quad with the same components', function () {
+    it('should equal a quad with the same components', () => {
       quad.equals({
         subject:   subject,
         predicate: predicate,
@@ -62,7 +62,7 @@ describe('Quad', function () {
       }).should.be.true;
     });
 
-    it('should not equal a quad with a different subject', function () {
+    it('should not equal a quad with a different subject', () => {
       quad.equals({
         subject:   termFromId('x'),
         predicate: predicate,
@@ -71,7 +71,7 @@ describe('Quad', function () {
       }).should.be.false;
     });
 
-    it('should not equal a quad with a different predicate', function () {
+    it('should not equal a quad with a different predicate', () => {
       quad.equals({
         subject:   subject,
         predicate: termFromId('x'),
@@ -80,7 +80,7 @@ describe('Quad', function () {
       }).should.be.false;
     });
 
-    it('should not equal a quad with a different object', function () {
+    it('should not equal a quad with a different object', () => {
       quad.equals({
         subject:   subject,
         predicate: predicate,
@@ -89,7 +89,7 @@ describe('Quad', function () {
       }).should.be.false;
     });
 
-    it('should not equal a quad with a different graph', function () {
+    it('should not equal a quad with a different graph', () => {
       quad.equals({
         subject:   subject,
         predicate: predicate,
@@ -98,7 +98,7 @@ describe('Quad', function () {
       }).should.be.false;
     });
 
-    it('should provide a JSON representation', function () {
+    it('should provide a JSON representation', () => {
       quad.toJSON().should.deep.equal({
         termType:  'Quad',
         subject:   { termType: 'NamedNode', value: 's' },
@@ -109,9 +109,9 @@ describe('Quad', function () {
     });
   });
 
-  describe('A Quad instance created with subject/predicate/object/graph', function () {
+  describe('A Quad instance created with subject/predicate/object/graph', () => {
     var quad, subject, predicate, object, graph;
-    before(function () {
+    before(() => {
       quad = new Quad(
         subject   = termFromId('s'),
         predicate = termFromId('p'),
@@ -120,35 +120,35 @@ describe('Quad', function () {
       );
     });
 
-    it('should be a Quad', function () {
+    it('should be a Quad', () => {
       quad.should.be.an.instanceof(Quad);
     });
 
-    it('should be a Term', function () {
+    it('should be a Term', () => {
       quad.should.be.an.instanceof(Term);
     });
 
-    it('should have the correct termType', function () {
+    it('should have the correct termType', () => {
       quad.termType.should.equal('Quad');
     });
 
-    it('should have the correct subject', function () {
+    it('should have the correct subject', () => {
       quad.subject.should.equal(subject);
     });
 
-    it('should have the correct predicate', function () {
+    it('should have the correct predicate', () => {
       quad.predicate.should.equal(predicate);
     });
 
-    it('should have the correct object', function () {
+    it('should have the correct object', () => {
       quad.object.should.equal(object);
     });
 
-    it('should have the default graph', function () {
+    it('should have the default graph', () => {
       quad.graph.should.equal(graph);
     });
 
-    it('should equal a quad with the same components', function () {
+    it('should equal a quad with the same components', () => {
       quad.equals({
         subject:   subject,
         predicate: predicate,
@@ -157,7 +157,7 @@ describe('Quad', function () {
       }).should.be.true;
     });
 
-    it('should not equal a quad with a different subject', function () {
+    it('should not equal a quad with a different subject', () => {
       quad.equals({
         subject:   termFromId('x'),
         predicate: predicate,
@@ -166,7 +166,7 @@ describe('Quad', function () {
       }).should.be.false;
     });
 
-    it('should not equal a quad with a different predicate', function () {
+    it('should not equal a quad with a different predicate', () => {
       quad.equals({
         subject:   subject,
         predicate: termFromId('x'),
@@ -175,7 +175,7 @@ describe('Quad', function () {
       }).should.be.false;
     });
 
-    it('should not equal a quad with a different object', function () {
+    it('should not equal a quad with a different object', () => {
       quad.equals({
         subject:   subject,
         predicate: predicate,
@@ -184,7 +184,7 @@ describe('Quad', function () {
       }).should.be.false;
     });
 
-    it('should not equal a quad with a different graph', function () {
+    it('should not equal a quad with a different graph', () => {
       quad.equals({
         subject:   subject,
         predicate: predicate,
@@ -193,7 +193,7 @@ describe('Quad', function () {
       }).should.be.false;
     });
 
-    it('should provide a JSON representation', function () {
+    it('should provide a JSON representation', () => {
       quad.toJSON().should.deep.equal({
         termType:  'Quad',
         subject:   { termType: 'NamedNode', value: 's' },
@@ -204,9 +204,9 @@ describe('Quad', function () {
     });
   });
 
-  describe('A Quad instance with nested quads', function () {
+  describe('A Quad instance with nested quads', () => {
     var quad, subject, predicate, object;
-    before(function () {
+    before(() => {
       quad = new Quad(
         subject   = termFromId('<<_:n3-123 ?var-a ?var-b _:n3-000>>'),
         predicate = termFromId('p'),
@@ -214,35 +214,35 @@ describe('Quad', function () {
       );
     });
 
-    it('should be a Quad', function () {
+    it('should be a Quad', () => {
       quad.should.be.an.instanceof(Quad);
     });
 
-    it('should be a Term', function () {
+    it('should be a Term', () => {
       quad.should.be.an.instanceof(Term);
     });
 
-    it('should have the correct termType', function () {
+    it('should have the correct termType', () => {
       quad.termType.should.equal('Quad');
     });
 
-    it('should have the correct subject', function () {
+    it('should have the correct subject', () => {
       quad.subject.should.equal(subject);
     });
 
-    it('should have the correct predicate', function () {
+    it('should have the correct predicate', () => {
       quad.predicate.should.equal(predicate);
     });
 
-    it('should have the correct object', function () {
+    it('should have the correct object', () => {
       quad.object.should.equal(object);
     });
 
-    it('should have the default graph', function () {
+    it('should have the default graph', () => {
       quad.graph.should.equal(new DefaultGraph());
     });
 
-    it('should equal a quad with the same components', function () {
+    it('should equal a quad with the same components', () => {
       quad.equals({
         subject:   subject,
         predicate: predicate,
@@ -251,7 +251,7 @@ describe('Quad', function () {
       }).should.be.true;
     });
 
-    it('should not equal a quad with a different subject', function () {
+    it('should not equal a quad with a different subject', () => {
       quad.equals({
         termType: 'Quad',
         value: '',
@@ -262,7 +262,7 @@ describe('Quad', function () {
       }).should.be.false;
     });
 
-    it('should not equal a quad with a different predicate', function () {
+    it('should not equal a quad with a different predicate', () => {
       quad.equals({
         termType: 'Quad',
         value: '',
@@ -273,7 +273,7 @@ describe('Quad', function () {
       }).should.be.false;
     });
 
-    it('should not equal a quad with a different object', function () {
+    it('should not equal a quad with a different object', () => {
       quad.equals({
         termType: 'Quad',
         value: '',
@@ -284,7 +284,7 @@ describe('Quad', function () {
       }).should.be.false;
     });
 
-    it('should not equal a quad with a different graph', function () {
+    it('should not equal a quad with a different graph', () => {
       quad.equals({
         termType: 'Quad',
         value: '',
@@ -295,7 +295,7 @@ describe('Quad', function () {
       }).should.be.false;
     });
 
-    it('should provide a JSON representation', function () {
+    it('should provide a JSON representation', () => {
       quad.toJSON().should.deep.equal({
         termType:  'Quad',
         subject:   termFromId('<<_:n3-123 ?var-a ?var-b _:n3-000>>').toJSON(),

--- a/test/Term-test.js
+++ b/test/Term-test.js
@@ -15,54 +15,54 @@ import {
   unescapeQuotes,
 } from '../src/N3DataFactory';
 
-describe('Term', function () {
-  describe('The Term module', function () {
-    it('should be a function', function () {
+describe('Term', () => {
+  describe('The Term module', () => {
+    it('should be a function', () => {
       Term.should.be.a('function');
     });
 
-    it('should be a Term constructor', function () {
+    it('should be a Term constructor', () => {
       new Term().should.be.an.instanceof(Term);
     });
   });
 
-  describe('termFromId', function () {
-    it('should create a DefaultGraph from a falsy value', function () {
+  describe('termFromId', () => {
+    it('should create a DefaultGraph from a falsy value', () => {
       termFromId(null).toJSON().should.deep.equal({
         termType: 'DefaultGraph',
         value: '',
       });
     });
 
-    it('should create a DefaultGraph from the empty string', function () {
+    it('should create a DefaultGraph from the empty string', () => {
       termFromId('').toJSON().should.deep.equal({
         termType: 'DefaultGraph',
         value: '',
       });
     });
 
-    it('should create a NamedNode from an IRI', function () {
+    it('should create a NamedNode from an IRI', () => {
       termFromId('http://example.org/foo#bar').toJSON().should.deep.equal({
         termType: 'NamedNode',
         value: 'http://example.org/foo#bar',
       });
     });
 
-    it('should create a BlankNode from a string that starts with an underscore', function () {
+    it('should create a BlankNode from a string that starts with an underscore', () => {
       termFromId('_:b1').toJSON().should.deep.equal({
         termType: 'BlankNode',
         value: 'b1',
       });
     });
 
-    it('should create a Variable from a string that starts with a question mark', function () {
+    it('should create a Variable from a string that starts with a question mark', () => {
       termFromId('?v1').toJSON().should.deep.equal({
         termType: 'Variable',
         value: 'v1',
       });
     });
 
-    it('should create a Literal from a string that starts with a quotation mark', function () {
+    it('should create a Literal from a string that starts with a quotation mark', () => {
       termFromId('"abc"@en-us').toJSON().should.deep.equal({
         termType: 'Literal',
         value: 'abc',
@@ -74,7 +74,7 @@ describe('Term', function () {
       });
     });
 
-    it('should create a Quad with the default graph if the id doesnt specify the graph', function () {
+    it('should create a Quad with the default graph if the id doesnt specify the graph', () => {
       termFromId('<<http://ex.org/a http://ex.org/b "abc"@en-us>>').should.deep.equal(new Quad(
         new NamedNode('http://ex.org/a'),
         new NamedNode('http://ex.org/b'),
@@ -83,7 +83,7 @@ describe('Term', function () {
       ));
     });
 
-    it('should create a Quad with the correct graph if the id specifies a graph', function () {
+    it('should create a Quad with the correct graph if the id specifies a graph', () => {
       const id = '<<http://ex.org/a http://ex.org/b "abc"@en-us http://ex.org/d>>';
       termFromId(id).should.deep.equal(new Quad(
         new NamedNode('http://ex.org/a'),
@@ -93,7 +93,7 @@ describe('Term', function () {
       ));
     });
 
-    it('should create a Quad correctly', function () {
+    it('should create a Quad correctly', () => {
       const id = '<<http://ex.org/a http://ex.org/b http://ex.org/c>>';
       termFromId(id).should.deep.equal(new Quad(
         new NamedNode('http://ex.org/a'),
@@ -103,7 +103,7 @@ describe('Term', function () {
       ));
     });
 
-    it('should create a Quad correctly', function () {
+    it('should create a Quad correctly', () => {
       const id = '<<_:n3-123 ?var-a ?var-b _:n3-000>>';
       termFromId(id).should.deep.equal(new Quad(
         new BlankNode('n3-123'),
@@ -113,7 +113,7 @@ describe('Term', function () {
       ));
     });
 
-    it('should create a Quad correctly', function () {
+    it('should create a Quad correctly', () => {
       const id = '<<?var-a ?var-b "abc"@en-us ?var-d>>';
       termFromId(id).should.deep.equal(new Quad(
         new Variable('var-a'),
@@ -123,7 +123,7 @@ describe('Term', function () {
       ));
     });
 
-    it('should create a Quad correctly', function () {
+    it('should create a Quad correctly', () => {
       const id = '<<_:n3-000 ?var-b _:n3-123 http://ex.org/d>>';
       termFromId(id).should.deep.equal(new Quad(
         new BlankNode('n3-000'),
@@ -133,7 +133,7 @@ describe('Term', function () {
       ));
     });
 
-    it('should create a Quad correctly from literal containing escaped quotes', function () {
+    it('should create a Quad correctly from literal containing escaped quotes', () => {
       const id = '<<_:n3-000 ?var-b "Hello ""W""orl""d!"@en-us http://ex.org/d>>';
       termFromId(id).should.deep.equal(new Quad(
         new BlankNode('n3-000'),
@@ -143,7 +143,7 @@ describe('Term', function () {
       ));
     });
 
-    it('should create a Quad correctly from literal containing escaped quotes', function () {
+    it('should create a Quad correctly from literal containing escaped quotes', () => {
       const id = '<<"Hello ""W""orl""d!"@en-us http://ex.org/b http://ex.org/c>>';
       termFromId(id).should.deep.equal(new Quad(
         new Literal('"Hello "W"orl"d!"@en-us'),
@@ -153,7 +153,7 @@ describe('Term', function () {
       ));
     });
 
-    describe('with a custom factory', function () {
+    describe('with a custom factory', () => {
       var factory = {
         defaultGraph: function ()     { return ['d'];       },
         namedNode:    function (n)    { return ['n', n];    },
@@ -162,116 +162,116 @@ describe('Term', function () {
         literal:      function (l, m) { return ['l', l, m]; },
       };
 
-      it('should create a DefaultGraph from a falsy value', function () {
+      it('should create a DefaultGraph from a falsy value', () => {
         termFromId(null, factory).should.deep.equal(['d']);
       });
 
-      it('should create a DefaultGraph from the empty string', function () {
+      it('should create a DefaultGraph from the empty string', () => {
         termFromId('', factory).should.deep.equal(['d']);
       });
 
-      it('should create a NamedNode from an IRI', function () {
+      it('should create a NamedNode from an IRI', () => {
         termFromId('http://example.org/foo#bar', factory).should.deep.equal(['n', 'http://example.org/foo#bar']);
       });
 
-      it('should create a BlankNode from a string that starts with an underscore', function () {
+      it('should create a BlankNode from a string that starts with an underscore', () => {
         termFromId('_:b1', factory).should.deep.equal(['b', 'b1']);
       });
 
-      it('should create a Variable from a string that starts with a question mark', function () {
+      it('should create a Variable from a string that starts with a question mark', () => {
         termFromId('?v1', factory).should.deep.equal(['v', 'v1']);
       });
 
-      it('should create a Literal without language or datatype', function () {
+      it('should create a Literal without language or datatype', () => {
         termFromId('"abc"', factory).should.deep.equal(['l', 'abc', undefined]);
       });
 
-      it('should create a Literal with a language', function () {
+      it('should create a Literal with a language', () => {
         termFromId('"abc"@en-us', factory).should.deep.equal(['l', 'abc', 'en-us']);
       });
 
-      it('should create a Literal with a datatype', function () {
+      it('should create a Literal with a datatype', () => {
         termFromId('"abc"^^https://ex.org/type', factory).should.deep.equal(['l', 'abc', ['n', 'https://ex.org/type']]);
       });
     });
   });
 
-  describe('termToId', function () {
-    it('should create the empty string a falsy value', function () {
+  describe('termToId', () => {
+    it('should create the empty string a falsy value', () => {
       termToId(null).should.equal('');
       termToId(false).should.equal('');
       termToId('').should.equal('');
     });
 
-    it('should create the empty string from the DefaultGraph', function () {
+    it('should create the empty string from the DefaultGraph', () => {
       termToId(new DefaultGraph()).should.equal('');
       termToId(new DefaultGraph().toJSON()).should.equal('');
     });
 
-    it('should create an id that starts with a question mark from a Variable', function () {
+    it('should create an id that starts with a question mark from a Variable', () => {
       termToId(new Variable('abc')).should.equal('?abc');
       termToId(new Variable('abc').toJSON()).should.equal('?abc');
     });
 
-    it('should create an id that starts with a question mark from a Variable string', function () {
+    it('should create an id that starts with a question mark from a Variable string', () => {
       termToId('?abc').should.equal('?abc');
     });
 
-    it('should create an id that starts with a quotation mark from a Literal', function () {
+    it('should create an id that starts with a quotation mark from a Literal', () => {
       termToId(new Literal('"abc"')).should.equal('"abc"');
       termToId(new Literal('"abc"').toJSON()).should.equal('"abc"');
     });
 
-    it('should create an id that starts with a quotation mark from a Literal string', function () {
+    it('should create an id that starts with a quotation mark from a Literal string', () => {
       termToId('"abc"').should.equal('"abc"');
     });
 
-    it('should create an id that starts with a quotation mark and datatype from a Literal with a datatype', function () {
+    it('should create an id that starts with a quotation mark and datatype from a Literal with a datatype', () => {
       termToId(new Literal('"abc"^^http://example.org')).should.equal('"abc"^^http://example.org');
       termToId(new Literal('"abc"^^http://example.org').toJSON()).should.equal('"abc"^^http://example.org');
     });
 
-    it('should create an id that starts with a quotation mark and datatype from a Literal string with a datatype', function () {
+    it('should create an id that starts with a quotation mark and datatype from a Literal string with a datatype', () => {
       termToId('"abc"^^http://example.org').should.equal('"abc"^^http://example.org');
     });
 
-    it('should create an id that starts with a quotation mark and language tag from a Literal with a language', function () {
+    it('should create an id that starts with a quotation mark and language tag from a Literal with a language', () => {
       termToId(new Literal('"abc"@en-us')).should.equal('"abc"@en-us');
       termToId(new Literal('"abc"@en-us').toJSON()).should.equal('"abc"@en-us');
     });
 
-    it('should create an id that starts with a quotation mark and language tag from a Literal string with a language', function () {
+    it('should create an id that starts with a quotation mark and language tag from a Literal string with a language', () => {
       termToId('"abc"@en-us').should.equal('"abc"@en-us');
     });
 
-    it('should create an id that starts with a quotation mark, datatype and language tag from a Literal with a datatype and language', function () {
+    it('should create an id that starts with a quotation mark, datatype and language tag from a Literal with a datatype and language', () => {
       termToId(new Literal('"abc"^^http://example.org@en-us')).should.equal('"abc"^^http://example.org@en-us');
       termToId(new Literal('"abc"^^http://example.org@en-us').toJSON()).should.equal('"abc"^^http://example.org@en-us');
     });
 
-    it('should create an id that starts with a quotation mark, datatype and language tag from a Literal string with a datatype and language', function () {
+    it('should create an id that starts with a quotation mark, datatype and language tag from a Literal string with a datatype and language', () => {
       termToId('"abc"^^http://example.org@en-us').should.equal('"abc"^^http://example.org@en-us');
     });
 
-    it('should create an id that starts with an underscore from a BlankNode', function () {
+    it('should create an id that starts with an underscore from a BlankNode', () => {
       termToId(new BlankNode('abc')).should.equal('_:abc');
       termToId(new BlankNode('abc').toJSON()).should.equal('_:abc');
     });
 
-    it('should create an id that starts with an underscore from a BlankNode string', function () {
+    it('should create an id that starts with an underscore from a BlankNode string', () => {
       termToId('_:abc').should.equal('_:abc');
     });
 
-    it('should create an IRI from a NamedNode', function () {
+    it('should create an IRI from a NamedNode', () => {
       termToId(new NamedNode('http://example.org/')).should.equal('http://example.org/');
       termToId(new NamedNode('http://example.org/').toJSON()).should.equal('http://example.org/');
     });
 
-    it('should create an IRI from a NamedNode string', function () {
+    it('should create an IRI from a NamedNode string', () => {
       termToId('http://example.org/').should.equal('http://example.org/');
     });
 
-    it('should create an id without graph if default graph is used', function () {
+    it('should create an id without graph if default graph is used', () => {
       termToId(new Quad(
         new NamedNode('http://ex.org/a'),
         new NamedNode('http://ex.org/b'),
@@ -280,7 +280,7 @@ describe('Term', function () {
       )).should.equal('<<http://ex.org/a http://ex.org/b "abc"@en-us>>');
     });
 
-    it('should create an id from a Quad', function () {
+    it('should create an id from a Quad', () => {
       termToId(new Quad(
         new NamedNode('http://ex.org/a'),
         new NamedNode('http://ex.org/b'),
@@ -289,7 +289,7 @@ describe('Term', function () {
       )).should.equal('<<http://ex.org/a http://ex.org/b "abc"@en-us http://ex.org/d>>');
     });
 
-    it('should create an id from a manually created Quad', function () {
+    it('should create an id from a manually created Quad', () => {
       termToId({
         subject: new NamedNode('http://ex.org/a'),
         predicate: new NamedNode('http://ex.org/b'),
@@ -300,7 +300,7 @@ describe('Term', function () {
       }).should.equal('<<http://ex.org/a http://ex.org/b "abc"@en-us http://ex.org/d>>');
     });
 
-    it('should create an id with escaped literals from a Quad', function () {
+    it('should create an id with escaped literals from a Quad', () => {
       termToId(new Quad(
         new BlankNode('n3-000'),
         new Variable('var-b'),
@@ -309,7 +309,7 @@ describe('Term', function () {
       )).should.equal('<<_:n3-000 ?var-b "Hello ""W""orl""d!"@en-us http://ex.org/d>>');
     });
 
-    it('should create an id without graph from a Quad with default graph and Quad as subject', function () {
+    it('should create an id without graph from a Quad with default graph and Quad as subject', () => {
       termToId(new Quad(
         new Quad(
           new BlankNode('n3-000'),
@@ -323,7 +323,7 @@ describe('Term', function () {
       )).should.equal('<<<<_:n3-000 ?var-b "abc"@en-us http://ex.org/d>> http://ex.org/b "abc"@en-us>>');
     });
 
-    it('should create an id without graph from a Quad with default graph and Quad as object', function () {
+    it('should create an id without graph from a Quad with default graph and Quad as object', () => {
       termToId(new Quad(
         new Literal('"abc"@en-us'),
         new NamedNode('http://ex.org/b'),
@@ -337,7 +337,7 @@ describe('Term', function () {
       )).should.equal('<<"abc"@en-us http://ex.org/b <<_:n3-000 ?var-b "abc"@en-us http://ex.org/d>>>>');
     });
 
-    it('should create an id without graph from a Quad with default graph and Quad as subject and object', function () {
+    it('should create an id without graph from a Quad with default graph and Quad as subject and object', () => {
       termToId(new Quad(
         new Quad(
           new BlankNode('n3-000'),
@@ -356,7 +356,7 @@ describe('Term', function () {
       )).should.equal('<<<<_:n3-000 ?var-b "abc"@en-us http://ex.org/d>> http://ex.org/b <<_:n3-000 ?var-b "abc"@en-us http://ex.org/d>>>>');
     });
 
-    it('should create an id without graph from a Quad with Quad as subject', function () {
+    it('should create an id without graph from a Quad with Quad as subject', () => {
       termToId(new Quad(
         new Quad(
           new BlankNode('n3-000'),
@@ -370,7 +370,7 @@ describe('Term', function () {
       )).should.equal('<<<<_:n3-000 ?var-b "abc"@en-us http://ex.org/d>> http://ex.org/b "abc"@en-us http://ex.org/d>>');
     });
 
-    it('should create an id without graph from a Quad with Quad as object', function () {
+    it('should create an id without graph from a Quad with Quad as object', () => {
       termToId(new Quad(
         new Literal('"abc"@en-us'),
         new NamedNode('http://ex.org/b'),
@@ -384,7 +384,7 @@ describe('Term', function () {
       )).should.equal('<<"abc"@en-us http://ex.org/b <<_:n3-000 ?var-b "abc"@en-us http://ex.org/d>> http://ex.org/d>>');
     });
 
-    it('should create an id from a Quad with Quad as subject and object', function () {
+    it('should create an id from a Quad with Quad as subject and object', () => {
       termToId(new Quad(
         new Quad(
           new BlankNode('n3-000'),
@@ -403,7 +403,7 @@ describe('Term', function () {
       )).should.equal('<<<<_:n3-000 ?var-b "abc"@en-us http://ex.org/d>> http://ex.org/b <<_:n3-000 ?var-b "abc"@en-us http://ex.org/d>> http://ex.org/d>>');
     });
 
-    it('should escape literals in nested Quads', function () {
+    it('should escape literals in nested Quads', () => {
       termToId(new Quad(
         new Quad(
           new BlankNode('n3-000'),
@@ -422,7 +422,7 @@ describe('Term', function () {
       )).should.equal('<<<<_:n3-000 ?var-b "Hello ""W""orl""d!"@en-us http://ex.org/d>> http://ex.org/b <<_:n3-000 ?var-b "Hello ""W""orl""d!"@en-us http://ex.org/d>>>>');
     });
 
-    it('should correctly handle deeply nested quads', function () {
+    it('should correctly handle deeply nested quads', () => {
       termToId(new Quad(
         new Quad(
           new Quad(
@@ -471,44 +471,44 @@ describe('Term', function () {
       )).should.equal('<<<<<<<<_:n3-000 ?var-b "abc"@en-us http://ex.org/d>> ?var-b <<_:n3-000 ?var-b "abc"@en-us http://ex.org/d>> http://ex.org/d>> ?var-b <<_:n3-000 ?var-b "abc"@en-us http://ex.org/d>> http://ex.org/d>> http://ex.org/b <<<<_:n3-000 ?var-b "abc"@en-us http://ex.org/d>> ?var-b <<_:n3-000 ?var-b "abc"@en-us http://ex.org/d>> http://ex.org/d>> http://ex.org/d>>');
     });
 
-    it('should throw on an unknown type', function () {
+    it('should throw on an unknown type', () => {
       (function () { termToId({ termType: 'unknown' }); })
         .should.throw('Unexpected termType: unknown');
     });
   });
 
-  describe('escaping', function () {
-    it('should unescape an escaped string correctly', function () {
+  describe('escaping', () => {
+    it('should unescape an escaped string correctly', () => {
       let id = '"Hello ""World"""@en-us';
       unescapeQuotes(id).should.equal('"Hello "World""@en-us');
     });
 
-    it('should escape an unescaped string correctly', function () {
+    it('should escape an unescaped string correctly', () => {
       let id = '"Hello "World""@en-us';
       escapeQuotes(id).should.equal('"Hello ""World"""@en-us');
     });
 
-    it('should not change an unescaped string', function () {
+    it('should not change an unescaped string', () => {
       let id = '"Hello "World""@en-us';
       unescapeQuotes(id).should.equal(id);
     });
 
-    it('should not change a string without quotes', function () {
+    it('should not change a string without quotes', () => {
       let id = '"Hello World"@en-us';
       escapeQuotes(id).should.equal(id);
     });
 
-    it('should not change a blank node', function () {
+    it('should not change a blank node', () => {
       let id = '_:b1';
       escapeQuotes(id).should.equal(id);
     });
 
-    it('should not change a variable', function () {
+    it('should not change a variable', () => {
       let id = '?v1';
       escapeQuotes(id).should.equal(id);
     });
 
-    it('should not change the empty string', function () {
+    it('should not change the empty string', () => {
       let id = '';
       escapeQuotes(id).should.equal(id);
     });

--- a/test/Variable-test.js
+++ b/test/Variable-test.js
@@ -1,78 +1,78 @@
 import { Variable, Term } from '../src/';
 
-describe('Variable', function () {
-  describe('The Variable module', function () {
-    it('should be a function', function () {
+describe('Variable', () => {
+  describe('The Variable module', () => {
+    it('should be a function', () => {
       Variable.should.be.a('function');
     });
 
-    it('should be a Variable constructor', function () {
+    it('should be a Variable constructor', () => {
       new Variable().should.be.an.instanceof(Variable);
     });
 
-    it('should be a Term constructor', function () {
+    it('should be a Term constructor', () => {
       new Variable().should.be.an.instanceof(Term);
     });
   });
 
-  describe('A Variable instance created from a name', function () {
+  describe('A Variable instance created from a name', () => {
     var variable;
-    before(function () { variable = new Variable('v1'); });
+    before(() => { variable = new Variable('v1'); });
 
-    it('should be a Variable', function () {
+    it('should be a Variable', () => {
       variable.should.be.an.instanceof(Variable);
     });
 
-    it('should be a Term', function () {
+    it('should be a Term', () => {
       variable.should.be.an.instanceof(Term);
     });
 
-    it('should have term type "Variable"', function () {
+    it('should have term type "Variable"', () => {
       variable.termType.should.equal('Variable');
     });
 
-    it('should have the name as value', function () {
+    it('should have the name as value', () => {
       variable.should.have.property('value', 'v1');
     });
 
-    it('should have "?name" as id value', function () {
+    it('should have "?name" as id value', () => {
       variable.should.have.property('id', '?v1');
     });
 
-    it('should equal a Variable instance with the same name', function () {
+    it('should equal a Variable instance with the same name', () => {
       variable.equals(new Variable('v1')).should.be.true;
     });
 
-    it('should equal an object with the same term type and value', function () {
+    it('should equal an object with the same term type and value', () => {
       variable.equals({
         termType: 'Variable',
         value: 'v1',
       }).should.be.true;
     });
 
-    it('should not equal a falsy object', function () {
+    it('should not equal a falsy object', () => {
       variable.equals(null).should.be.false;
     });
 
-    it('should not equal a Variable instance with another name', function () {
+    it('should not equal a Variable instance with another name', () => {
       variable.equals(new Variable('v2')).should.be.false;
     });
 
-    it('should not equal an object with the same term type but a different value', function () {
+    it('should not equal an object with the same term type but a different value', () => {
       variable.equals({
         termType: 'Variable',
         value: 'v2',
       }).should.be.false;
     });
 
-    it('should not equal an object with a different term type but the same value', function () {
+    it('should not equal an object with a different term type but the same value', () => {
       variable.equals({
         termType: 'NamedNode',
         value: 'v1',
       }).should.be.false;
     });
 
-    it('should provide a JSON representation', function () {
+    it('should provide a JSON representation', () => {
       variable.toJSON().should.deep.equal({
         termType: 'Variable',
         value: 'v1',


### PR DESCRIPTION
Closes #225.

Note: I stacked this branch on top of the patch-1 branch from the #223 PR.

I went ahead and changed several nested functions that were not requiring access to `this` too. Please let me know if you intended for those to remain unchanged.

Note: I did not update the nested functions in the test suite. Last time I used mocha, it was recommended not to use arrow functions. I am not sure if that is still the case. Please let me know if you would like the test suite updated to use arrow functions.