### PR TITLE
Allow using import statements in Node

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,10 @@
   "license": "MIT",
   "main": "./lib/index.js",
   "module": "./src/index.js",
+  "exports": {
+    "require": "./lib/index.js",
+    "import": "./lib/index.js"
+  },
   "sideEffects": false,
   "engines": {
     "node": ">=8.0"


### PR DESCRIPTION
Although the module is still exported as a CommonJS module, this
allows developers to import it using an import statement when
writing Node code in ES modules.

Fixes #196.

For more background and discussion, see https://github.com/rdfjs/N3.js/issues/196#issuecomment-726173831.