### PR TITLE
Allow using import statements in Node

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,10 @@
   "license": "MIT",
   "main": "./lib/index.js",
   "module": "./src/index.js",
+  "exports": {
+    "require": "./lib/index.js",
+    "import": "./lib/index.js"
+  },
   "sideEffects": false,
   "engines": {
     "node": ">=8.0"


### PR DESCRIPTION
Although the module is still exported as a CommonJS module, this
allows developers to import it using an import statement when
writing Node code in ES modules.

This is pretty risk-free: it only _adds_ an additional export. It does make the default export explicitly part of the API, but that is actually already the case, i.e. if you import from n3 in an ES module in Node.

This fixes #196, at least in the sense that its title says "provide a default export".