### PR TITLE
Add a default export

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -22,7 +22,33 @@ import {
   termToId,
 } from './N3DataFactory';
 
+// Named exports
 export {
+  Lexer,
+  Parser,
+  Writer,
+  Store,
+  StreamParser,
+  StreamWriter,
+  Util,
+
+  DataFactory,
+
+  Term,
+  NamedNode,
+  Literal,
+  BlankNode,
+  Variable,
+  DefaultGraph,
+  Quad,
+  Triple,
+
+  termFromId,
+  termToId,
+};
+
+// Export all named exports as a default object for backward compatibility
+export default {
   Lexer,
   Parser,
   Writer,


### PR DESCRIPTION
When importing n3 from an ES module in Node, the exports will be
treated as a default export, because the package itself is not an
ES module.

This _actually_ exports that default module, so that the same
syntax (i.e. importing the default export) can be used with both
Node and bundlers.

(Replaces #232 - this is what I intended to submit there.)

Fixes #196.