### PR TITLE
[StreamWriter] Use highWaterMark of 16

### DIFF
--- a/src/N3StreamWriter.js
+++ b/src/N3StreamWriter.js
@@ -5,8 +5,7 @@ import N3Writer from './N3Writer';
 // ## Constructor
 export default class N3StreamWriter extends Transform {
   constructor(options) {
-    super({ encoding: 'utf8' });
-    this._writableState.objectMode = true;
+    super({ encoding: 'utf8', writableObjectMode: true });
 
     // Set up writer with a dummy stream object
     var self = this;


### PR DESCRIPTION
The streamwriter currently uses a highWaterMark of 16.384, which is a value that is typically used for buffered streams. 
As a consequence, some streams may have atypical behaviour (in runtime, progress, and memory usage).

Considering this is an object stream (at least the writable part of it), I'd propose using a highWaterMark of 16 (the nodejs default)

 