### PR TITLE
DatasetCoreAndReadableStream - added missing size

### DIFF
--- a/src/N3Store.js
+++ b/src/N3Store.js
@@ -846,6 +846,9 @@ class DatasetCoreAndReadableStream extends Readable {
     }
     return this._filtered;
   }
+  get size() {
+    return this.filtered.size;
+  }
 
   _read() {
     for (const quad of this.filtered.getQuads())

--- a/test/N3Store-test.js
+++ b/test/N3Store-test.js
@@ -533,6 +533,7 @@ describe('Store', () => {
           }
 
           should.equal(count, 4);
+          should.equal(dataset.size, count);
 
           should.equal(dataset.has(new Quad('s2', 'p1', 'o1')), false);
           dataset.add(new Quad('s2', 'p1', 'o1'));


### PR DESCRIPTION
DatasetCoreAndReadableStream was missing `size` required by https://rdf.js.org/dataset-spec/#datasetcore-interface