### PR TITLE
Add CDN script to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,12 @@ or
 [_Introduction to browserify_](https://writingjavascript.org/posts/introduction-to-browserify).
 You will need to create a "UMD bundle" and supply a name (e.g. with the `-s N3` option in browserify).
 
+You can also use N3.js from a CDN with the following script:
+
+```html
+<script src="https://cdn.jsdelivr.net/npm/n3-browserify@latest"></script>
+```
+
 ## Creating triples/quads
 N3.js follows the [RDF.js low-level specification](http://rdf.js.org/).
 


### PR DESCRIPTION
I just published [n3-browserify](https://www.npmjs.com/package/n3-browserify) to npm in order to allow using the library from a CDN. I haven't done a lot of testing, but at least I tried parsing Turtle strings and it works. Let me know if I'm doing something wrong.

You don't have to merge this PR if you prefer to keep this undocumented, but I just wanted to let the maintainers of the project know. I'm also happy to transfer ownership of the npm package if you prefer to manage this yourselves. Or maybe you prefer to include a browser bundle in your own npm package. In any case, this gets the job done for now :).