### PR TITLE
Add start and end index to tokens

### DIFF
--- a/src/N3Lexer.js
+++ b/src/N3Lexer.js
@@ -85,7 +85,7 @@ export default class N3Lexer {
       while (whiteSpaceMatch = this._newline.exec(input)) {
         // Try to find a comment
         if (this._comments && (comment = this._comment.exec(whiteSpaceMatch[0])))
-          callback(null, { line: this._line, type: 'comment', value: comment[1], prefix: '' });
+          callback(null, this._createToken(this._line, 'comment', comment[1], '', currentLineLength - input.length, currentLineLength - input.length + whiteSpaceMatch[0].length));
         // Advance the input
         input = input.substr(whiteSpaceMatch[0].length, input.length);
         currentLineLength = input.length;
@@ -101,8 +101,8 @@ export default class N3Lexer {
         if (inputFinished) {
           // Try to find a final comment
           if (this._comments && (comment = this._comment.exec(input)))
-            callback(null, { line: this._line, type: 'comment', value: comment[1], prefix: '' });
-          callback(input = null, { line: this._line, type: 'eof', value: '', prefix: '' });
+            callback(null, this._createToken(this._line, 'comment', comment[1], '', currentLineLength - input.length, currentLineLength));
+          callback(input = null, this._createToken(this._line, 'eof', '', '', currentLineLength, currentLineLength));
         }
         return this._input = input;
       }
@@ -349,7 +349,7 @@ export default class N3Lexer {
       const start = currentLineLength - input.length;
       const length = matchLength || match[0].length;
       const end = start + length;
-      const token = { line, type, value, prefix, start, end };
+      const token = this._createToken(line, type, value, prefix, start, end);
       callback(null, token);
       this.previousToken = token;
       this._previousMarker = type;
@@ -432,6 +432,11 @@ export default class N3Lexer {
       previousToken: this.previousToken,
     };
     return err;
+  }
+
+  // ### Utility method to create a token
+  _createToken(line, type, value, prefix, start, end) {
+    return { line: line, type: type, value: value, prefix: prefix, start: start, end: end };
   }
 
   // ### Strips off any starting UTF BOM mark.

--- a/src/N3Lexer.js
+++ b/src/N3Lexer.js
@@ -78,6 +78,7 @@ export default class N3Lexer {
   _tokenizeToEnd(callback, inputFinished) {
     // Continue parsing as far as possible; the loop will return eventually
     let input = this._input;
+    let lineLength = input.length;
     const outputComments = this._comments;
     while (true) {
       // Count and skip whitespace lines
@@ -88,6 +89,7 @@ export default class N3Lexer {
           callback(null, { line: this._line, type: 'comment', value: comment[1], prefix: '' });
         // Advance the input
         input = input.substr(whiteSpaceMatch[0].length, input.length);
+        lineLength = input.length;
         this._line++;
       }
       // Skip whitespace on current line
@@ -345,12 +347,15 @@ export default class N3Lexer {
       }
 
       // Emit the parsed token
-      const token = { line: line, type: type, value: value, prefix: prefix };
+      const tokenLength = matchLength || match[0].length;
+      const startIndex = lineLength - input.length;
+      const endIndex = startIndex + tokenLength;
+      const token = { line: line, type: type, value: value, prefix: prefix, start: startIndex, end: endIndex };
       callback(null, token);
       this.previousToken = token;
       this._previousMarker = type;
       // Advance to next part to tokenize
-      input = input.substr(matchLength || match[0].length, input.length);
+      input = input.substr(tokenLength, input.length);
     }
 
     // Signals the syntax error through the callback

--- a/test/N3Lexer-test.js
+++ b/test/N3Lexer-test.js
@@ -1171,9 +1171,9 @@ describe('Lexer', () => {
 
       it('returns all tokens synchronously', () => {
         tokens.should.deep.equal([
-          { line: 1, type: 'IRI', value: 'a', prefix: '', start: 0, end: 4 },
-          { line: 1, type: 'IRI', value: 'b', prefix: '', start: 4, end: 8 },
-          { line: 1, type: 'IRI', value: 'c', prefix: '', start: 8, end: 11 },
+          { line: 1, type: 'IRI', value: 'a', prefix: '', start: 0,  end:  4 },
+          { line: 1, type: 'IRI', value: 'b', prefix: '', start: 4,  end:  8 },
+          { line: 1, type: 'IRI', value: 'c', prefix: '', start: 8,  end: 11 },
           { line: 1, type: '.',   value: '',  prefix: '', start: 11, end: 12 },
           { line: 1, type: 'eof', value: '',  prefix: '' },
         ]);

--- a/test/N3Lexer-test.js
+++ b/test/N3Lexer-test.js
@@ -1175,7 +1175,7 @@ describe('Lexer', () => {
           { line: 1, type: 'IRI', value: 'b', prefix: '', start: 4,  end:  8 },
           { line: 1, type: 'IRI', value: 'c', prefix: '', start: 8,  end: 11 },
           { line: 1, type: '.',   value: '',  prefix: '', start: 11, end: 12 },
-          { line: 1, type: 'eof', value: '',  prefix: '' },
+          { line: 1, type: 'eof', value: '',  prefix: '', start: 12, end: 12 },
         ]);
       });
     });
@@ -1191,7 +1191,7 @@ describe('Lexer', () => {
           { line: 1, prefix: '', type: 'literal', value: 'lit', start: 12, end: 17 },
           { line: 1, prefix: '', type: 'langcode', value: 'EN', start: 17, end: 20 },
           { line: 1, prefix: '', type: '.', value: '', start: 20, end: 21 },
-          { line: 1, prefix: '', type: 'eof', value: '' },
+          { line: 1, prefix: '', type: 'eof', value: '', start: 21, end: 21 },
         ]);
       });
 
@@ -1207,7 +1207,7 @@ describe('Lexer', () => {
           { line: 2, prefix: '', type: 'IRI', value: 'b:d', start: 0, end: 6 },
           { line: 2, prefix: '', type: 'IRI', value: 'd:e', start: 6, end: 12 },
           { line: 2, prefix: '', type: '.', value: '', start: 12, end: 13 },
-          { line: 2, prefix: '', type: 'eof', value: '' },
+          { line: 2, prefix: '', type: 'eof', value: '', start: 13, end: 13 },
         ]);
       });
 
@@ -1219,7 +1219,22 @@ describe('Lexer', () => {
           { line: 1, prefix: '', type: 'IRI', value: 'b:c', start: 8, end: 17 },
           { line: 1, prefix: '', type: 'IRI', value: 'd:e', start: 17, end: 24 },
           { line: 1, prefix: '', type: '.', value: '', start: 24, end: 25 },
-          { line: 1, prefix: '', type: 'eof', value: '' },
+          { line: 1, prefix: '', type: 'eof', value: '', start: 25, end: 25 },
+        ]);
+      });
+
+      it('return index for comments and eof', () => {
+        const tokens = new Lexer({ comments: true }).tokenize('# some\n<a:a> <b:b> <c:c> . # trailing comment\n# thing');
+
+        tokens.should.deep.equal([
+          { line: 1, prefix: '', type: 'comment', value: ' some', start: 0, end: 7 },
+          { line: 2, prefix: '', type: 'IRI', value: 'a:a', start: 0, end: 6 },
+          { line: 2, prefix: '', type: 'IRI', value: 'b:b', start: 6, end: 12 },
+          { line: 2, prefix: '', type: 'IRI', value: 'c:c', start: 12, end: 18 },
+          { line: 2, prefix: '', type: '.', value: '', start: 18, end: 19 },
+          { line: 2, prefix: '', type: 'comment', value: ' trailing comment', start: 19, end: 39 },
+          { line: 3, prefix: '', type: 'comment', value: ' thing', start: 0, end: 7 },
+          { line: 3, prefix: '', type: 'eof', value: '', start: 7, end: 7 },
         ]);
       });
     });

--- a/test/N3Parser-test.js
+++ b/test/N3Parser-test.js
@@ -89,6 +89,8 @@ describe('Parser', () => {
                          type: 'type',
                          value: 'z',
                          prefix: 'x',
+                         start: 18,
+                         end: 21,
                        },
                        line: 1,
                        previousToken: {
@@ -96,6 +98,8 @@ describe('Parser', () => {
                          type: 'literal',
                          value: 'string',
                          prefix: '',
+                         start: 8,
+                         end: 16,
                        },
                      }));
 
@@ -132,6 +136,8 @@ describe('Parser', () => {
                          type: '@PREFIX',
                          value: '',
                          prefix: '',
+                         start: 0,
+                         end: 7,
                        },
                        previousToken: undefined,
                        line: 1,
@@ -232,6 +238,8 @@ describe('Parser', () => {
                          type: '[',
                          value: '',
                          prefix: '',
+                         start: 4,
+                         end: 5,
                        },
                        line: 2,
                        previousToken: {
@@ -239,6 +247,8 @@ describe('Parser', () => {
                          type: 'IRI',
                          value: 'a',
                          prefix: '',
+                         start: 0,
+                         end: 4,
                        },
                      }));
 
@@ -250,6 +260,8 @@ describe('Parser', () => {
                          type: 'blank',
                          value: 'b',
                          prefix: '_',
+                         start: 4,
+                         end: 8,
                        },
                        line: 2,
                        previousToken: {
@@ -257,6 +269,8 @@ describe('Parser', () => {
                          type: 'IRI',
                          value: 'a',
                          prefix: '',
+                         start: 0,
+                         end: 4,
                        },
                      }));
 


### PR DESCRIPTION
This PR adds the start and end index to the token object.

I would like to have the start and end index available as a N3.js consumer, because that helps to locate the exact location of parser errors. In my case, i'm using N3.js plugged into a Language Server and i want to create error markers in the editor for all parser errors - currently i always just add them add the beginning of the line as only the line information is present for tokens.

Btw, I did not adapt tests yet as i first wanted to get some feedback whether it's okay to add the start and end indices.

Greetings,
Alex