### PR TITLE
performance: fix performance for cases with sparsely connected entities

### DIFF
--- a/perf/.eslintrc
+++ b/perf/.eslintrc
@@ -1,6 +1,6 @@
 {
   rules: {
     no-console: off,
-    no-process-exit: off
+    no-process-exit: off,
   }
 }

--- a/perf/.eslintrc
+++ b/perf/.eslintrc
@@ -1,8 +1,6 @@
 {
   rules: {
     no-console: off,
-    no-process-exit: off,
-    no-unused-vars: off,
-    no-empty: off
+    no-process-exit: off
   }
 }

--- a/perf/.eslintrc
+++ b/perf/.eslintrc
@@ -2,5 +2,7 @@
   rules: {
     no-console: off,
     no-process-exit: off,
+    no-unused-vars: off,
+    no-empty: off
   }
 }

--- a/perf/N3Store-perf.js
+++ b/perf/N3Store-perf.js
@@ -7,7 +7,7 @@ console.log('N3Store performance test');
 const prefix = 'http://example.org/#';
 
 /* Test triples */
-let dim = Number.parseInt(process.argv[2], 10) || 128;
+let dim = Number.parseInt(process.argv[2], 10) || 256;
 let dimSquared = dim * dim;
 let dimCubed = dimSquared * dim;
 

--- a/perf/N3Store-perf.js
+++ b/perf/N3Store-perf.js
@@ -7,7 +7,7 @@ console.log('N3Store performance test');
 const prefix = 'http://example.org/#';
 
 /* Test triples */
-let dim = Number.parseInt(process.argv[2], 10) || 256;
+let dim = Number.parseInt(process.argv[2], 10) || 128;
 let dimSquared = dim * dim;
 let dimCubed = dimSquared * dim;
 

--- a/perf/N3Store-perf.js
+++ b/perf/N3Store-perf.js
@@ -86,7 +86,7 @@ for (l = 0; l < dim; l++)
   assert.equal(store.getQuads(null, null, null, prefix + l).length, dimCubed);
 console.timeEnd(TEST);
 
-console.log();
+console.log('N3 Store tests for sparsely connected entities');
 
 store = new N3.Store();
 TEST = `- Adding ${dimQuads} with all different IRIs`;

--- a/perf/N3Store-perf.js
+++ b/perf/N3Store-perf.js
@@ -7,7 +7,7 @@ console.log('N3Store performance test');
 const prefix = 'http://example.org/#';
 
 /* Test triples */
-let dim = Number.parseInt(process.argv[2], 10) || 256;
+let dim = Number.parseInt(process.argv[2], 10) || 128;
 let dimSquared = dim * dim;
 let dimCubed = dimSquared * dim;
 
@@ -61,7 +61,7 @@ dim /= 4;
 dimSquared = dim * dim;
 dimCubed = dimSquared * dim;
 const dimQuads = dimCubed * dim;
-
+store;
 store = new N3.Store();
 TEST = `- Adding ${dimQuads} quads`;
 console.time(TEST);
@@ -84,4 +84,71 @@ for (k = 0; k < dim; k++)
   assert.equal(store.getQuads(null, null, prefix + k, null).length, dimCubed);
 for (l = 0; l < dim; l++)
   assert.equal(store.getQuads(null, null, null, prefix + l).length, dimCubed);
+console.timeEnd(TEST);
+
+console.log();
+
+store = new N3.Store();
+TEST = `- Adding ${dimQuads} with all different IRIs`;
+console.time(TEST);
+for (let i = 0; i < dimQuads; i++) {
+  store.addQuad(
+    prefix + i,
+    prefix + i,
+    prefix + i
+  );
+}
+console.timeEnd(TEST);
+
+
+TEST = `* Retrieving all ${dimQuads} quads`;
+console.time(TEST);
+for (const quad of store.match(undefined, undefined, undefined)) {
+}
+console.timeEnd(TEST);
+
+TEST = '* Retrieving single by subject';
+console.time(TEST);
+for (const quad of store.match(prefix + 1, undefined, undefined)) {
+}
+console.timeEnd(TEST);
+
+
+TEST = '* Retrieving single by predicate';
+console.time(TEST);
+for (const quad of store.match(undefined, prefix + 1, undefined)) {
+}
+console.timeEnd(TEST);
+
+TEST = '* Retrieving single by object';
+console.time(TEST);
+for (const quad of store.match(undefined, undefined, prefix + 1)) {
+}
+console.timeEnd(TEST);
+
+
+TEST = '* Retrieving single by subject-predicate';
+console.time(TEST);
+for (const quad of store.match(prefix + 1, prefix + 1, undefined)) {
+}
+console.timeEnd(TEST);
+
+
+TEST = '* Retrieving single by subject-object';
+console.time(TEST);
+for (const quad of store.match(prefix + 1, undefined, prefix + 1)) {
+}
+console.timeEnd(TEST);
+
+TEST = '* Retrieving single by predicate-object';
+console.time(TEST);
+for (const quad of store.match(undefined, prefix + 1, prefix + 1)) {
+}
+console.timeEnd(TEST);
+
+
+TEST = '* Retrieving single by subject-predicate-object';
+console.time(TEST);
+for (const quad of store.match(prefix + 1, prefix + 1, prefix + 1)) {
+}
 console.timeEnd(TEST);

--- a/perf/N3Store-perf.js
+++ b/perf/N3Store-perf.js
@@ -104,12 +104,14 @@ console.timeEnd(TEST);
 TEST = `* Retrieving all ${dimQuads} quads`;
 console.time(TEST);
 for (const quad of store.match(undefined, undefined, undefined)) {
+  assert(quad);
 }
 console.timeEnd(TEST);
 
 TEST = '* Retrieving single by subject';
 console.time(TEST);
 for (const quad of store.match(prefix + 1, undefined, undefined)) {
+  assert(quad);
 }
 console.timeEnd(TEST);
 
@@ -117,12 +119,14 @@ console.timeEnd(TEST);
 TEST = '* Retrieving single by predicate';
 console.time(TEST);
 for (const quad of store.match(undefined, prefix + 1, undefined)) {
+  assert(quad);
 }
 console.timeEnd(TEST);
 
 TEST = '* Retrieving single by object';
 console.time(TEST);
 for (const quad of store.match(undefined, undefined, prefix + 1)) {
+  assert(quad);
 }
 console.timeEnd(TEST);
 
@@ -130,6 +134,7 @@ console.timeEnd(TEST);
 TEST = '* Retrieving single by subject-predicate';
 console.time(TEST);
 for (const quad of store.match(prefix + 1, prefix + 1, undefined)) {
+  assert(quad);
 }
 console.timeEnd(TEST);
 
@@ -137,12 +142,14 @@ console.timeEnd(TEST);
 TEST = '* Retrieving single by subject-object';
 console.time(TEST);
 for (const quad of store.match(prefix + 1, undefined, prefix + 1)) {
+  assert(quad);
 }
 console.timeEnd(TEST);
 
 TEST = '* Retrieving single by predicate-object';
 console.time(TEST);
 for (const quad of store.match(undefined, prefix + 1, prefix + 1)) {
+  assert(quad);
 }
 console.timeEnd(TEST);
 
@@ -150,5 +157,6 @@ console.timeEnd(TEST);
 TEST = '* Retrieving single by subject-predicate-object';
 console.time(TEST);
 for (const quad of store.match(prefix + 1, prefix + 1, prefix + 1)) {
+  assert(quad);
 }
 console.timeEnd(TEST);

--- a/perf/N3Store-perf.js
+++ b/perf/N3Store-perf.js
@@ -110,53 +110,67 @@ console.timeEnd(TEST);
 
 TEST = '* Retrieving single by subject';
 console.time(TEST);
-for (const quad of store.match(prefix + 1, undefined, undefined)) {
-  assert(quad);
+for (let i = 0; i < 1000000; i++) {
+  for (const quad of store.match(prefix + 1, undefined, undefined)) {
+    assert(quad);
+  }
 }
 console.timeEnd(TEST);
 
 
 TEST = '* Retrieving single by predicate';
 console.time(TEST);
-for (const quad of store.match(undefined, prefix + 1, undefined)) {
-  assert(quad);
+for (let i = 0; i < 1000000; i++) {
+  for (const quad of store.match(undefined, prefix + 1, undefined)) {
+    assert(quad);
+  }
 }
 console.timeEnd(TEST);
 
 TEST = '* Retrieving single by object';
 console.time(TEST);
-for (const quad of store.match(undefined, undefined, prefix + 1)) {
-  assert(quad);
+for (let i = 0; i < 1000000; i++) {
+  for (const quad of store.match(undefined, undefined, prefix + 1)) {
+    assert(quad);
+  }
 }
 console.timeEnd(TEST);
 
 
 TEST = '* Retrieving single by subject-predicate';
 console.time(TEST);
-for (const quad of store.match(prefix + 1, prefix + 1, undefined)) {
-  assert(quad);
+for (let i = 0; i < 1000000; i++) {
+  for (const quad of store.match(prefix + 1, prefix + 1, undefined)) {
+    assert(quad);
+  }
 }
 console.timeEnd(TEST);
 
 
 TEST = '* Retrieving single by subject-object';
 console.time(TEST);
-for (const quad of store.match(prefix + 1, undefined, prefix + 1)) {
-  assert(quad);
+for (let i = 0; i < 1000000; i++) {
+  for (const quad of store.match(prefix + 1, undefined, prefix + 1)) {
+    assert(quad);
+  }
 }
 console.timeEnd(TEST);
 
 TEST = '* Retrieving single by predicate-object';
 console.time(TEST);
-for (const quad of store.match(undefined, prefix + 1, prefix + 1)) {
-  assert(quad);
+for (let i = 0; i < 1000000; i++) {
+  for (const quad of store.match(undefined, prefix + 1, prefix + 1)) {
+    assert(quad);
+  }
 }
 console.timeEnd(TEST);
 
 
 TEST = '* Retrieving single by subject-predicate-object';
 console.time(TEST);
-for (const quad of store.match(prefix + 1, prefix + 1, prefix + 1)) {
-  assert(quad);
+for (let i = 0; i < 1000000; i++) {
+  for (const quad of store.match(prefix + 1, prefix + 1, prefix + 1)) {
+    assert(quad);
+  }
 }
 console.timeEnd(TEST);

--- a/perf/N3Store-perf.js
+++ b/perf/N3Store-perf.js
@@ -7,7 +7,7 @@ console.log('N3Store performance test');
 const prefix = 'http://example.org/#';
 
 /* Test triples */
-let dim = Number.parseInt(process.argv[2], 10) || 128;
+let dim = Number.parseInt(process.argv[2], 10) || 256;
 let dimSquared = dim * dim;
 let dimCubed = dimSquared * dim;
 
@@ -61,7 +61,7 @@ dim /= 4;
 dimSquared = dim * dim;
 dimCubed = dimSquared * dim;
 const dimQuads = dimCubed * dim;
-store;
+
 store = new N3.Store();
 TEST = `- Adding ${dimQuads} quads`;
 console.time(TEST);

--- a/src/N3Store.js
+++ b/src/N3Store.js
@@ -87,8 +87,7 @@ export default class N3Store {
   // Finally, `graphId` will be the graph of the created quads.
   *_findInIndex(index0, key0, key1, key2, name0, name1, name2, graphId) {
     let tmp, index1, index2;
-    // Depending on the number of variables, keys or reverse index are faster
-    const entityKeys = !(key0 || key1 || key2) ? Object.keys(this._ids) : this._entities;
+    const entityKeys = this._entities;
     const graph = termFromId(graphId, this._factory);
 
     // If a key is specified, use only that part of index 0.

--- a/src/N3Store.js
+++ b/src/N3Store.js
@@ -88,8 +88,7 @@ export default class N3Store {
   *_findInIndex(index0, key0, key1, key2, name0, name1, name2, graphId) {
     let tmp, index1, index2;
     // Depending on the number of variables, keys or reverse index are faster
-    const varCount = !key0 + !key1 + !key2,
-        entityKeys = varCount > 1 ? Object.keys(this._ids) : this._entities;
+    const entityKeys = !(key0 || key1 || key2) ? Object.keys(this._ids) : this._entities;
     const graph = termFromId(graphId, this._factory);
 
     // If a key is specified, use only that part of index 0.


### PR DESCRIPTION
Resolves #277

This PR improves the performance `match`ing against a pattern with one defined term on graphs that are more sparsely connected. Achieving a performance improvement of `60_000`x on the degenerate case of an unconnected graph.

I have added new performance tests to demonstrate this; using a dimension of 128 the results are

Before Changes
```
N3Store performance test
- Adding 2097152 triples to the default graph: 1.269s
* Memory usage for triples: 147MB
- Finding all 2097152 triples in the default graph 16384 times (0 variables): 5.652s
- Finding all 2097152 triples in the default graph 32768 times (1 variable): 1.646s
- Finding all 2097152 triples in the default graph 49152 times (2 variables): 1.854s

- Adding 1048576 quads: 870.612ms
* Memory usage for quads: 127MB
- Finding all 1048576 quads 131072 times: 1.389s

- Adding 1048576 with all different IRIs: 5.873s
* Retrieving all 1048576 quads: 1.460s
* Retrieving single by subject: 310.78ms
* Retrieving single by predicate: 313.62ms
* Retrieving single by object: 305.24ms
* Retrieving single by subject-predicate: 0.061ms
* Retrieving single by subject-object: 0.038ms
* Retrieving single by predicate-object: 0.04ms
* Retrieving single by subject-predicate-object: 0.209ms
```

After Changes
```
N3Store performance test
- Adding 2097152 triples to the default graph: 1.336s
* Memory usage for triples: 149MB
- Finding all 2097152 triples in the default graph 16384 times (0 variables): 5.319s
- Finding all 2097152 triples in the default graph 32768 times (1 variable): 1.504s
- Finding all 2097152 triples in the default graph 49152 times (2 variables): 1.817s

- Adding 1048576 quads: 829.416ms
* Memory usage for quads: 124MB
- Finding all 1048576 quads 131072 times: 1.357s

- Adding 1048576 with all different IRIs: 5.941s
* Retrieving all 1048576 quads: 1.554s
* Retrieving single by subject: 0.057ms
* Retrieving single by predicate: 0.112ms
* Retrieving single by object: 0.062ms
* Retrieving single by subject-predicate: 0.062ms
* Retrieving single by subject-object: 0.117ms
* Retrieving single by predicate-object: 0.084ms
* Retrieving single by subject-predicate-object: 0.107ms
```