### PR TITLE
performance: remove unecessary calcs

### DIFF
--- a/src/N3Store.js
+++ b/src/N3Store.js
@@ -91,26 +91,24 @@ export default class N3Store {
     const varCount = !key0 + !key1 + !key2,
         entityKeys = varCount > 1 ? Object.keys(this._ids) : this._entities;
     const graph = termFromId(graphId, this._factory);
+    const parts = { subject: null, predicate: null, object: null };
 
     // If a key is specified, use only that part of index 0.
     if (key0) (tmp = index0, index0 = {})[key0] = tmp[key0];
     for (const value0 in index0) {
-      const entity0 = entityKeys[value0];
+      parts[name0] = termFromId(entityKeys[value0], this._factory);
 
       if (index1 = index0[value0]) {
         // If a key is specified, use only that part of index 1.
         if (key1) (tmp = index1, index1 = {})[key1] = tmp[key1];
         for (const value1 in index1) {
-          const entity1 = entityKeys[value1];
+          parts[name1] = termFromId(entityKeys[value1], this._factory);
 
           if (index2 = index1[value1]) {
             // If a key is specified, use only that part of index 2, if it exists.
             const values = key2 ? (key2 in index2 ? [key2] : []) : Object.keys(index2);
             // Create quads for all items found in index 2.
-            for (let l = 0; l < values.length; l++) {
-              const parts = { subject: null, predicate: null, object: null };
-              parts[name0] = termFromId(entity0, this._factory);
-              parts[name1] = termFromId(entity1, this._factory);
+            for (let l = 0; l < values.length; l++) {      
               parts[name2] = termFromId(entityKeys[values[l]], this._factory);
               yield this._factory.quad(parts.subject, parts.predicate, parts.object, graph);
             }

--- a/src/N3Store.js
+++ b/src/N3Store.js
@@ -96,15 +96,15 @@ export default class N3Store {
     // If a key is specified, use only that part of index 0.
     if (key0) (tmp = index0, index0 = {})[key0] = tmp[key0];
     for (const value0 in index0) {
-      parts[name0] = termFromId(entityKeys[value0], this._factory);
 
       if (index1 = index0[value0]) {
+        parts[name0] = termFromId(entityKeys[value0], this._factory);
         // If a key is specified, use only that part of index 1.
         if (key1) (tmp = index1, index1 = {})[key1] = tmp[key1];
         for (const value1 in index1) {
-          parts[name1] = termFromId(entityKeys[value1], this._factory);
 
           if (index2 = index1[value1]) {
+            parts[name1] = termFromId(entityKeys[value1], this._factory);
             // If a key is specified, use only that part of index 2, if it exists.
             const values = key2 ? (key2 in index2 ? [key2] : []) : Object.keys(index2);
             // Create quads for all items found in index 2.

--- a/src/N3Store.js
+++ b/src/N3Store.js
@@ -96,13 +96,11 @@ export default class N3Store {
     // If a key is specified, use only that part of index 0.
     if (key0) (tmp = index0, index0 = {})[key0] = tmp[key0];
     for (const value0 in index0) {
-
       if (index1 = index0[value0]) {
         parts[name0] = termFromId(entityKeys[value0], this._factory);
         // If a key is specified, use only that part of index 1.
         if (key1) (tmp = index1, index1 = {})[key1] = tmp[key1];
         for (const value1 in index1) {
-
           if (index2 = index1[value1]) {
             parts[name1] = termFromId(entityKeys[value1], this._factory);
             // If a key is specified, use only that part of index 2, if it exists.

--- a/src/N3Store.js
+++ b/src/N3Store.js
@@ -108,7 +108,7 @@ export default class N3Store {
             // If a key is specified, use only that part of index 2, if it exists.
             const values = key2 ? (key2 in index2 ? [key2] : []) : Object.keys(index2);
             // Create quads for all items found in index 2.
-            for (let l = 0; l < values.length; l++) {      
+            for (let l = 0; l < values.length; l++) {
               parts[name2] = termFromId(entityKeys[values[l]], this._factory);
               yield this._factory.quad(parts.subject, parts.predicate, parts.object, graph);
             }


### PR DESCRIPTION
Results in ~50% speedup in the 2 variable iteration case

Before
```
jeswr@debian:~/n3-benchmark/n3-opt/N3.js$ node perf/N3Store-perf.js 128
N3Store performance test
- Adding 2097152 triples to the default graph: 1.239s
* Memory usage for triples: 147MB
- Finding all 2097152 triples in the default graph 16384 times (0 variables): 4.473s
- Finding all 2097152 triples in the default graph 32768 times (1 variable): 1.357s
- Finding all 2097152 triples in the default graph 49152 times (2 variables): 1.453s

- Adding 1048576 quads: 782.903ms
* Memory usage for quads: 133MB
- Finding all 1048576 quads 131072 times: 1.223s
```

After
```
jeswr@debian:~/n3-benchmark/n3-opt/N3.js$ node perf/N3Store-perf.js 128
N3Store performance test
- Adding 2097152 triples to the default graph: 1.184s
* Memory usage for triples: 145MB
- Finding all 2097152 triples in the default graph 16384 times (0 variables): 4.571s
- Finding all 2097152 triples in the default graph 32768 times (1 variable): 1.046s
- Finding all 2097152 triples in the default graph 49152 times (2 variables): 960.889ms

- Adding 1048576 quads: 803.555ms
* Memory usage for quads: 123MB
- Finding all 1048576 quads 131072 times: 816.152ms
```