### PR TITLE
Feat/reasoning fwd chain

### DIFF
--- a/perf/Reasoning-perf.js
+++ b/perf/Reasoning-perf.js
@@ -50,7 +50,185 @@ async function run() {
         new Variable('?o2'),
       ),
     ]
-  }]);
+  },
+  {
+    premise: [new Quad(
+      new Variable('?s'),
+      new Variable('?p'),
+      new Variable('?o'),
+    )],
+    conclusion: [
+      new Quad(
+        new Variable('?p'),
+        new NamedNode('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'),
+        new NamedNode('http://www.w3.org/1999/02/22-rdf-syntax-ns#Property'),
+      ),
+    ]
+  },
+  {
+    premise: [new Quad(
+      new Variable('?a'),
+      new NamedNode('http://www.w3.org/2000/01/rdf-schema#domain'),
+      new Variable('?x'),
+    ),new Quad(
+      new Variable('?u'),
+      new Variable('?a'),
+      new Variable('?y'),
+    )],
+    conclusion: [
+      new Quad(
+        new Variable('?u'),
+        new NamedNode('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'),
+        new Variable('?x'),
+      ),
+    ]
+  },
+  {
+    premise: [new Quad(
+      new Variable('?a'),
+      new NamedNode('http://www.w3.org/2000/01/rdf-schema#range'),
+      new Variable('?x'),
+    ),new Quad(
+      new Variable('?u'),
+      new Variable('?a'),
+      new Variable('?v'),
+    )],
+    conclusion: [
+      new Quad(
+        new Variable('?v'),
+        new NamedNode('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'),
+        new Variable('?x'),
+      ),
+    ]
+  },
+  {
+    premise: [new Quad(
+      new Variable('?u'),
+      new Variable('?a'),
+      new Variable('?x'),
+    )],
+    conclusion: [
+      new Quad(
+        new Variable('?u'),
+        new NamedNode('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'),
+        new NamedNode('http://www.w3.org/2000/01/rdf-schema#Resource'),
+      ),
+      new Quad(
+        new Variable('?x'),
+        new NamedNode('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'),
+        new NamedNode('http://www.w3.org/2000/01/rdf-schema#Resource'),
+      ),
+    ]
+  },
+  {
+    premise: [new Quad(
+      new Variable('?u'),
+      new NamedNode('http://www.w3.org/2000/01/rdf-schema#subPropertyOf'),
+      new Variable('?v'),
+    ),new Quad(
+      new Variable('?v'),
+      new NamedNode('http://www.w3.org/2000/01/rdf-schema#subPropertyOf'),
+      new Variable('?x'),
+    )],
+    conclusion: [
+      new Quad(
+        new Variable('?u'),
+        new NamedNode('http://www.w3.org/2000/01/rdf-schema#subPropertyOf'),
+        new Variable('?x'),
+      )
+    ]
+  },
+  {
+    premise: [new Quad(
+      new Variable('?u'),
+      new NamedNode('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'),
+      new NamedNode('http://www.w3.org/2000/01/rdf-schema#Class'),
+    )],
+    conclusion: [
+      new Quad(
+        new Variable('?u'),
+        new NamedNode('http://www.w3.org/2000/01/rdf-schema#subClassOf'),
+        new NamedNode('http://www.w3.org/2000/01/rdf-schema#Resource'),
+      )
+    ]
+  },
+  {
+    premise: [new Quad(
+      new Variable('?u'),
+      new NamedNode('http://www.w3.org/2000/01/rdf-schema#subClassOf'),
+      new Variable('?x'),
+    ), new Quad(
+      new Variable('?v'),
+      new NamedNode('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'),
+      new Variable('?u'),
+    )],
+    conclusion: [
+      new Quad(
+        new Variable('?v'),
+        new NamedNode('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'),
+        new Variable('?x'),
+      )
+    ]
+  },{
+    premise: [new Quad(
+      new Variable('?u'),
+      new NamedNode('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'),
+      new NamedNode('http://www.w3.org/2000/01/rdf-schema#Class'),
+    )],
+    conclusion: [
+      new Quad(
+        new Variable('?u'),
+        new NamedNode('http://www.w3.org/2000/01/rdf-schema#subClassOf'),
+        new Variable('?u'),
+      )
+    ]
+  },
+  {
+    premise: [new Quad(
+      new Variable('?u'),
+      new NamedNode('http://www.w3.org/2000/01/rdf-schema#subClassOf'),
+      new Variable('?v'),
+    ),new Quad(
+      new Variable('?v'),
+      new NamedNode('http://www.w3.org/2000/01/rdf-schema#subClassOf'),
+      new Variable('?x'),
+    )],
+    conclusion: [
+      new Quad(
+        new Variable('?u'),
+        new NamedNode('http://www.w3.org/2000/01/rdf-schema#subClassOf'),
+        new Variable('?x'),
+      )
+    ]
+  },{
+    premise: [new Quad(
+      new Variable('?u'),
+      new NamedNode('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'),
+      new NamedNode('http://www.w3.org/2000/01/rdf-schema#ContainerMembershipProperty'),
+    )],
+    conclusion: [
+      new Quad(
+        new Variable('?u'),
+        new NamedNode('http://www.w3.org/2000/01/rdf-schema#subPropertyOf'),
+        new NamedNode('http://www.w3.org/2000/01/rdf-schema#member'),
+      )
+    ]
+  },
+  {
+    premise: [new Quad(
+      new Variable('?u'),
+      new NamedNode('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'),
+      new NamedNode('http://www.w3.org/2000/01/rdf-schema#Datatype'),
+    )],
+    conclusion: [
+      new Quad(
+        new Variable('?u'),
+        new NamedNode('http://www.w3.org/2000/01/rdf-schema#subClassOf'),
+        new NamedNode('http://www.w3.org/2000/01/rdf-schema#Literal'),
+      )
+    ]
+  },
+  ]);
 
   // for (const elem of store.match(null, new NamedNode('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'), null)) {
   //   const r = [...store.match(elem.object, new NamedNode('http://www.w3.org/2000/01/rdf-schema#subClassOf'), null)];

--- a/perf/Reasoning-perf.js
+++ b/perf/Reasoning-perf.js
@@ -87,6 +87,8 @@ async function run() {
       new NamedNode('http://www.w3.org/2003/01/geo/wgs84_pos#SpatialThing'),
     ),
   ))
+
+  console.log(store.size)
 }
 
 run()

--- a/perf/Reasoning-perf.js
+++ b/perf/Reasoning-perf.js
@@ -1,0 +1,92 @@
+#!/usr/bin/env node
+const N3 = require('..');
+const fs = require('fs'),
+    path = require('path'),
+    assert = require('assert');
+
+const { Quad, NamedNode, Variable } = N3;
+
+function load(filename, store) {
+  return new Promise((res) => {
+    new N3.Parser({ baseIRI: 'http://example.org' }).parse(fs.createReadStream(path.join(__dirname, filename)), (error, quad) => {
+      assert(!error, error);
+      if (quad)
+        store.add(quad);
+      else {
+        res();
+      }
+    });
+    
+  })
+}
+
+async function run() {
+  const store = new N3.Store();
+  console.time('loading foaf ontology');
+  await load('./data/foaf.ttl', store);
+  console.timeEnd('loading foaf ontology');
+
+  console.time('loading tim berners lee profile card');
+  await load('./data/timbl.ttl', store);
+  console.timeEnd('loading tim berners lee profile card');
+
+  console.log(store.size)
+
+  console.time('apply reasoning');
+  store.reason([{
+    premise: [new Quad(
+      new Variable('?s'),
+      new NamedNode('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'),
+      new Variable('?o'),
+    ),new Quad(
+      new Variable('?o'),
+      new NamedNode('http://www.w3.org/2000/01/rdf-schema#subClassOf'),
+      new Variable('?o2'),
+    )],
+    conclusion: [
+      new Quad(
+        new Variable('?s'),
+        new NamedNode('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'),
+        new Variable('?o2'),
+      ),
+    ]
+  }]);
+
+  // for (const elem of store.match(null, new NamedNode('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'), null)) {
+  //   const r = [...store.match(elem.object, new NamedNode('http://www.w3.org/2000/01/rdf-schema#subClassOf'), null)];
+  //   if (r.length > 0) {
+  //     // console.log([...store.match(null, new NamedNode('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'), null)])
+  //     console.log(elem.subject.value, r);
+  //   }
+  //   // console.log([...store.match(elem.object, new NamedNode('http://www.w3.org/2000/01/rdf-schema#subClassOf'), null)])
+  // }
+  // console.log([...store.match(null, new NamedNode('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'), null)])
+  // console.log([...store.match(null, new NamedNode('http://www.w3.org/2000/01/rdf-schema#subClassOf'), null)])
+
+  console.timeEnd('apply reasoning');
+
+  console.log(store.has(
+    new Quad(
+      new NamedNode('http://example.org#me'),
+      new NamedNode('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'),
+      new NamedNode('http://www.w3.org/2003/01/geo/wgs84_pos#SpatialThing'),
+    ),
+  ))
+
+  console.log(store.has(
+    new Quad(
+      new NamedNode('http://example.org#me'),
+      new NamedNode('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'),
+      new NamedNode('http://xmlns.com/foaf/0.1/Person'),
+    ),
+  ))
+  console.log(store.has(
+    new Quad(
+      new NamedNode('http://xmlns.com/foaf/0.1/Person'),
+      new NamedNode('http://www.w3.org/2000/01/rdf-schema#subClassOf'),
+      new NamedNode('http://www.w3.org/2003/01/geo/wgs84_pos#SpatialThing'),
+    ),
+  ))
+}
+
+run()

--- a/perf/data/foaf.ttl
+++ b/perf/data/foaf.ttl
@@ -1,0 +1,699 @@
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix dc11: <http://purl.org/dc/elements/1.1/> .
+@prefix wot: <http://xmlns.com/wot/0.1/> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix ns0: <http://www.w3.org/2003/06/sw-vocab-status/ns#> .
+@prefix schema: <http://schema.org/> .
+@prefix geo: <http://www.w3.org/2003/01/geo/wgs84_pos#> .
+@prefix dc: <http://purl.org/dc/terms/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+foaf:
+  a owl:Ontology ;
+  dc11:title "Friend of a Friend (FOAF) vocabulary" ;
+  dc11:description "The Friend of a Friend (FOAF) RDF vocabulary, described using W3C RDF Schema and the Web Ontology Language." .
+
+wot:assurance a owl:AnnotationProperty .
+wot:src_assurance a owl:AnnotationProperty .
+<http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> a owl:AnnotationProperty .
+dc11:description a owl:AnnotationProperty .
+dc11:title a owl:AnnotationProperty .
+dc11:date a owl:AnnotationProperty .
+rdfs:Class a owl:Class .
+foaf:LabelProperty
+  a rdfs:Class, owl:Class ;
+  ns0:term_status "unstable" ;
+  rdfs:label "Label Property" ;
+  rdfs:comment "A foaf:LabelProperty is any RDF property with texual values that serve as labels." ;
+  rdfs:isDefinedBy foaf: .
+
+foaf:Person
+  a rdfs:Class, owl:Class ;
+  rdfs:label "Person" ;
+  rdfs:comment "A person." ;
+  ns0:term_status "stable" ;
+  owl:equivalentClass schema:Person, <http://www.w3.org/2000/10/swap/pim/contact#Person> ;
+  rdfs:subClassOf foaf:Agent, geo:SpatialThing ;
+  rdfs:isDefinedBy foaf: ;
+  owl:disjointWith foaf:Organization, foaf:Project .
+
+foaf:Agent
+  a owl:Class, rdfs:Class ;
+  ns0:term_status "stable" ;
+  rdfs:label "Agent" ;
+  rdfs:comment "An agent (eg. person, group, software or physical artifact)." ;
+  owl:equivalentClass dc:Agent .
+
+geo:SpatialThing
+  a owl:Class ;
+  rdfs:label "Spatial Thing" .
+
+foaf:Document
+  a rdfs:Class, owl:Class ;
+  rdfs:label "Document" ;
+  rdfs:comment "A document." ;
+  ns0:term_status "stable" ;
+  owl:equivalentClass schema:CreativeWork ;
+  rdfs:isDefinedBy foaf: ;
+  owl:disjointWith foaf:Organization, foaf:Project .
+
+foaf:Organization
+  a rdfs:Class, owl:Class ;
+  rdfs:label "Organization" ;
+  rdfs:comment "An organization." ;
+  ns0:term_status "stable" ;
+  rdfs:subClassOf foaf:Agent ;
+  rdfs:isDefinedBy foaf: ;
+  owl:disjointWith foaf:Person, foaf:Document .
+
+foaf:Group
+  a rdfs:Class, owl:Class ;
+  ns0:term_status "stable" ;
+  rdfs:label "Group" ;
+  rdfs:comment "A class of Agents." ;
+  rdfs:subClassOf foaf:Agent .
+
+foaf:Project
+  a rdfs:Class, owl:Class ;
+  ns0:term_status "testing" ;
+  rdfs:label "Project" ;
+  rdfs:comment "A project (a collective endeavour of some kind)." ;
+  rdfs:isDefinedBy foaf: ;
+  owl:disjointWith foaf:Person, foaf:Document .
+
+foaf:Image
+  a rdfs:Class, owl:Class ;
+  ns0:term_status "stable" ;
+  rdfs:label "Image" ;
+  rdfs:comment "An image." ;
+  owl:equivalentClass schema:ImageObject ;
+  rdfs:subClassOf foaf:Document ;
+  rdfs:isDefinedBy foaf: .
+
+foaf:PersonalProfileDocument
+  a rdfs:Class, owl:Class ;
+  rdfs:label "PersonalProfileDocument" ;
+  rdfs:comment "A personal profile RDF document." ;
+  ns0:term_status "testing" ;
+  rdfs:subClassOf foaf:Document .
+
+foaf:OnlineAccount
+  a rdfs:Class, owl:Class ;
+  ns0:term_status "testing" ;
+  rdfs:label "Online Account" ;
+  rdfs:comment "An online account." ;
+  rdfs:isDefinedBy foaf: ;
+  rdfs:subClassOf owl:Thing .
+
+owl:Thing rdfs:label "Thing" .
+foaf:OnlineGamingAccount
+  a rdfs:Class, owl:Class ;
+  ns0:term_status "unstable" ;
+  rdfs:label "Online Gaming Account" ;
+  rdfs:comment "An online gaming account." ;
+  rdfs:subClassOf foaf:OnlineAccount ;
+  rdfs:isDefinedBy foaf: .
+
+foaf:OnlineEcommerceAccount
+  a rdfs:Class, owl:Class ;
+  ns0:term_status "unstable" ;
+  rdfs:label "Online E-commerce Account" ;
+  rdfs:comment "An online e-commerce account." ;
+  rdfs:subClassOf foaf:OnlineAccount ;
+  rdfs:isDefinedBy foaf: .
+
+foaf:OnlineChatAccount
+  a rdfs:Class, owl:Class ;
+  ns0:term_status "unstable" ;
+  rdfs:label "Online Chat Account" ;
+  rdfs:comment "An online chat account." ;
+  rdfs:subClassOf foaf:OnlineAccount ;
+  rdfs:isDefinedBy foaf: .
+
+foaf:mbox
+  a rdf:Property, owl:InverseFunctionalProperty, owl:ObjectProperty ;
+  ns0:term_status "stable" ;
+  rdfs:label "personal mailbox" ;
+  rdfs:comment "A  personal mailbox, ie. an Internet mailbox associated with exactly one owner, the first owner of this mailbox. This is a 'static inverse functional property', in that  there is (across time and change) at most one individual that ever has any particular value for foaf:mbox." ;
+  rdfs:domain foaf:Agent ;
+  rdfs:range owl:Thing ;
+  rdfs:isDefinedBy foaf: .
+
+foaf:mbox_sha1sum
+  a rdf:Property, owl:InverseFunctionalProperty, owl:DatatypeProperty ;
+  ns0:term_status "testing" ;
+  rdfs:label "sha1sum of a personal mailbox URI name" ;
+  rdfs:comment "The sha1sum of the URI of an Internet mailbox associated with exactly one owner, the  first owner of the mailbox." ;
+  rdfs:domain foaf:Agent ;
+  rdfs:range rdfs:Literal ;
+  rdfs:isDefinedBy foaf: .
+
+foaf:gender
+  a rdf:Property, owl:FunctionalProperty, owl:DatatypeProperty ;
+  ns0:term_status "testing" ;
+  rdfs:label "gender" ;
+  rdfs:comment "The gender of this Agent (typically but not necessarily 'male' or 'female')." ;
+  rdfs:domain foaf:Agent ;
+  rdfs:range rdfs:Literal ;
+  rdfs:isDefinedBy foaf: .
+
+foaf:geekcode
+  a rdf:Property, owl:DatatypeProperty ;
+  ns0:term_status "archaic" ;
+  rdfs:label "geekcode" ;
+  rdfs:comment "A textual geekcode for this person, see http://www.geekcode.com/geek.html" ;
+  rdfs:domain foaf:Person ;
+  rdfs:range rdfs:Literal ;
+  rdfs:isDefinedBy foaf: .
+
+foaf:dnaChecksum
+  a rdf:Property, owl:DatatypeProperty ;
+  ns0:term_status "archaic" ;
+  rdfs:label "DNA checksum" ;
+  rdfs:comment "A checksum for the DNA of some thing. Joke." ;
+  rdfs:isDefinedBy foaf: ;
+  rdfs:range rdfs:Literal .
+
+foaf:sha1
+  a rdf:Property, owl:DatatypeProperty ;
+  ns0:term_status "unstable" ;
+  rdfs:label "sha1sum (hex)" ;
+  rdfs:comment "A sha1sum hash, in hex." ;
+  rdfs:domain foaf:Document ;
+  rdfs:isDefinedBy foaf: .
+
+foaf:based_near
+  a rdf:Property, owl:ObjectProperty ;
+  ns0:term_status "testing" ;
+  rdfs:label "based near" ;
+  rdfs:comment "A location that something is based near, for some broadly human notion of near." ;
+  rdfs:domain geo:SpatialThing ;
+  rdfs:range geo:SpatialThing ;
+  rdfs:isDefinedBy foaf: .
+
+foaf:title
+  a rdf:Property, owl:DatatypeProperty ;
+  ns0:term_status "testing" ;
+  rdfs:label "title" ;
+  rdfs:comment "Title (Mr, Mrs, Ms, Dr. etc)" ;
+  rdfs:isDefinedBy foaf: .
+
+foaf:nick
+  a rdf:Property, owl:DatatypeProperty ;
+  ns0:term_status "testing" ;
+  rdfs:label "nickname" ;
+  rdfs:comment "A short informal nickname characterising an agent (includes login identifiers, IRC and other chat nicknames)." ;
+  rdfs:isDefinedBy foaf: .
+
+foaf:jabberID
+  a rdf:Property, owl:DatatypeProperty, owl:InverseFunctionalProperty ;
+  ns0:term_status "testing" ;
+  rdfs:label "jabber ID" ;
+  rdfs:comment "A jabber ID for something." ;
+  rdfs:isDefinedBy foaf: ;
+  rdfs:domain foaf:Agent ;
+  rdfs:range rdfs:Literal .
+
+foaf:aimChatID
+  a rdf:Property, owl:DatatypeProperty, owl:InverseFunctionalProperty ;
+  ns0:term_status "testing" ;
+  rdfs:label "AIM chat ID" ;
+  rdfs:comment "An AIM chat ID" ;
+  rdfs:isDefinedBy foaf: ;
+  rdfs:subPropertyOf foaf:nick ;
+  rdfs:domain foaf:Agent ;
+  rdfs:range rdfs:Literal .
+
+foaf:skypeID
+  a rdf:Property, owl:DatatypeProperty ;
+  ns0:term_status "testing" ;
+  rdfs:label "Skype ID" ;
+  rdfs:comment "A Skype ID" ;
+  rdfs:isDefinedBy foaf: ;
+  rdfs:subPropertyOf foaf:nick ;
+  rdfs:domain foaf:Agent ;
+  rdfs:range rdfs:Literal .
+
+foaf:icqChatID
+  a rdf:Property, owl:DatatypeProperty, owl:InverseFunctionalProperty ;
+  ns0:term_status "testing" ;
+  rdfs:label "ICQ chat ID" ;
+  rdfs:comment "An ICQ chat ID" ;
+  rdfs:isDefinedBy foaf: ;
+  rdfs:subPropertyOf foaf:nick ;
+  rdfs:domain foaf:Agent ;
+  rdfs:range rdfs:Literal .
+
+foaf:yahooChatID
+  a rdf:Property, owl:DatatypeProperty, owl:InverseFunctionalProperty ;
+  ns0:term_status "testing" ;
+  rdfs:label "Yahoo chat ID" ;
+  rdfs:comment "A Yahoo chat ID" ;
+  rdfs:isDefinedBy foaf: ;
+  rdfs:subPropertyOf foaf:nick ;
+  rdfs:domain foaf:Agent ;
+  rdfs:range rdfs:Literal .
+
+foaf:msnChatID
+  a rdf:Property, owl:DatatypeProperty, owl:InverseFunctionalProperty ;
+  ns0:term_status "testing" ;
+  rdfs:label "MSN chat ID" ;
+  rdfs:comment "An MSN chat ID" ;
+  rdfs:isDefinedBy foaf: ;
+  rdfs:subPropertyOf foaf:nick ;
+  rdfs:domain foaf:Agent ;
+  rdfs:range rdfs:Literal .
+
+foaf:name
+  a rdf:Property, owl:DatatypeProperty ;
+  ns0:term_status "testing" ;
+  rdfs:label "name" ;
+  rdfs:comment "A name for some thing." ;
+  rdfs:domain owl:Thing ;
+  rdfs:range rdfs:Literal ;
+  rdfs:isDefinedBy foaf: ;
+  rdfs:subPropertyOf rdfs:label .
+
+foaf:firstName
+  a rdf:Property, owl:DatatypeProperty ;
+  ns0:term_status "testing" ;
+  rdfs:label "firstName" ;
+  rdfs:comment "The first name of a person." ;
+  rdfs:domain foaf:Person ;
+  rdfs:range rdfs:Literal ;
+  rdfs:isDefinedBy foaf: .
+
+foaf:lastName
+  a rdf:Property, owl:DatatypeProperty ;
+  ns0:term_status "testing" ;
+  rdfs:label "lastName" ;
+  rdfs:comment "The last name of a person." ;
+  rdfs:domain foaf:Person ;
+  rdfs:range rdfs:Literal ;
+  rdfs:isDefinedBy foaf: .
+
+foaf:givenName
+  a rdf:Property, owl:DatatypeProperty ;
+  ns0:term_status "testing" ;
+  rdfs:label "Given name" ;
+  rdfs:comment "The given name of some person." ;
+  rdfs:isDefinedBy foaf: .
+
+foaf:givenname
+  a rdf:Property, owl:DatatypeProperty ;
+  ns0:term_status "archaic" ;
+  rdfs:label "Given name" ;
+  rdfs:comment "The given name of some person." ;
+  rdfs:isDefinedBy foaf: .
+
+foaf:surname
+  a rdf:Property, owl:DatatypeProperty ;
+  ns0:term_status "archaic" ;
+  rdfs:label "Surname" ;
+  rdfs:comment "The surname of some person." ;
+  rdfs:domain foaf:Person ;
+  rdfs:range rdfs:Literal ;
+  rdfs:isDefinedBy foaf: .
+
+foaf:family_name
+  a rdf:Property, owl:DatatypeProperty ;
+  ns0:term_status "archaic" ;
+  rdfs:label "family_name" ;
+  rdfs:comment "The family name of some person." ;
+  rdfs:domain foaf:Person ;
+  rdfs:range rdfs:Literal ;
+  rdfs:isDefinedBy foaf: .
+
+foaf:familyName
+  a rdf:Property, owl:DatatypeProperty ;
+  ns0:term_status "testing" ;
+  rdfs:label "familyName" ;
+  rdfs:comment "The family name of some person." ;
+  rdfs:domain foaf:Person ;
+  rdfs:range rdfs:Literal ;
+  rdfs:isDefinedBy foaf: .
+
+foaf:phone
+  a rdf:Property, owl:ObjectProperty ;
+  ns0:term_status "testing" ;
+  rdfs:label "phone" ;
+  rdfs:comment "A phone,  specified using fully qualified tel: URI scheme (refs: http://www.w3.org/Addressing/schemes.html#tel)." ;
+  rdfs:isDefinedBy foaf: .
+
+foaf:homepage
+  a rdf:Property, owl:ObjectProperty, owl:InverseFunctionalProperty ;
+  ns0:term_status "stable" ;
+  rdfs:label "homepage" ;
+  rdfs:comment "A homepage for some thing." ;
+  rdfs:subPropertyOf foaf:page, foaf:isPrimaryTopicOf ;
+  rdfs:domain owl:Thing ;
+  rdfs:range foaf:Document ;
+  rdfs:isDefinedBy foaf: .
+
+foaf:weblog
+  a rdf:Property, owl:ObjectProperty, owl:InverseFunctionalProperty ;
+  ns0:term_status "stable" ;
+  rdfs:label "weblog" ;
+  rdfs:comment "A weblog of some thing (whether person, group, company etc.)." ;
+  rdfs:subPropertyOf foaf:page ;
+  rdfs:domain foaf:Agent ;
+  rdfs:range foaf:Document ;
+  rdfs:isDefinedBy foaf: .
+
+foaf:openid
+  a rdf:Property, owl:ObjectProperty, owl:InverseFunctionalProperty ;
+  ns0:term_status "testing" ;
+  rdfs:label "openid" ;
+  rdfs:comment "An OpenID for an Agent." ;
+  rdfs:subPropertyOf foaf:isPrimaryTopicOf ;
+  rdfs:domain foaf:Agent ;
+  rdfs:range foaf:Document ;
+  rdfs:isDefinedBy foaf: .
+
+foaf:tipjar
+  a rdf:Property, owl:ObjectProperty ;
+  ns0:term_status "testing" ;
+  rdfs:label "tipjar" ;
+  rdfs:comment "A tipjar document for this agent, describing means for payment and reward." ;
+  rdfs:subPropertyOf foaf:page ;
+  rdfs:domain foaf:Agent ;
+  rdfs:range foaf:Document ;
+  rdfs:isDefinedBy foaf: .
+
+foaf:plan
+  a rdf:Property, owl:DatatypeProperty ;
+  ns0:term_status "testing" ;
+  rdfs:label "plan" ;
+  rdfs:comment "A .plan comment, in the tradition of finger and '.plan' files." ;
+  rdfs:isDefinedBy foaf: ;
+  rdfs:domain foaf:Person ;
+  rdfs:range rdfs:Literal .
+
+foaf:made
+  a rdf:Property, owl:ObjectProperty ;
+  ns0:term_status "stable" ;
+  rdfs:label "made" ;
+  rdfs:comment "Something that was made by this agent." ;
+  rdfs:domain foaf:Agent ;
+  rdfs:range owl:Thing ;
+  rdfs:isDefinedBy foaf: ;
+  owl:inverseOf foaf:maker .
+
+foaf:maker
+  a rdf:Property, owl:ObjectProperty ;
+  ns0:term_status "stable" ;
+  rdfs:label "maker" ;
+  rdfs:comment "An agent that  made this thing." ;
+  owl:equivalentProperty dc:creator ;
+  rdfs:domain owl:Thing ;
+  rdfs:range foaf:Agent ;
+  rdfs:isDefinedBy foaf: ;
+  owl:inverseOf foaf:made .
+
+foaf:img
+  a rdf:Property, owl:ObjectProperty ;
+  ns0:term_status "testing" ;
+  rdfs:label "image" ;
+  rdfs:comment "An image that can be used to represent some thing (ie. those depictions which are particularly representative of something, eg. one's photo on a homepage)." ;
+  rdfs:domain foaf:Person ;
+  rdfs:range foaf:Image ;
+  rdfs:subPropertyOf foaf:depiction ;
+  rdfs:isDefinedBy foaf: .
+
+foaf:depiction
+  a rdf:Property, owl:ObjectProperty ;
+  ns0:term_status "testing" ;
+  rdfs:label "depiction" ;
+  rdfs:comment "A depiction of some thing." ;
+  rdfs:domain owl:Thing ;
+  rdfs:range foaf:Image ;
+  rdfs:isDefinedBy foaf: ;
+  owl:inverseOf foaf:depicts .
+
+foaf:depicts
+  a rdf:Property, owl:ObjectProperty ;
+  ns0:term_status "testing" ;
+  rdfs:label "depicts" ;
+  rdfs:comment "A thing depicted in this representation." ;
+  rdfs:range owl:Thing ;
+  rdfs:domain foaf:Image ;
+  rdfs:isDefinedBy foaf: ;
+  owl:inverseOf foaf:depiction .
+
+foaf:thumbnail
+  a rdf:Property, owl:ObjectProperty ;
+  ns0:term_status "testing" ;
+  rdfs:label "thumbnail" ;
+  rdfs:comment "A derived thumbnail image." ;
+  rdfs:domain foaf:Image ;
+  rdfs:range foaf:Image ;
+  rdfs:isDefinedBy foaf: .
+
+foaf:myersBriggs
+  a rdf:Property, owl:DatatypeProperty ;
+  ns0:term_status "testing" ;
+  rdfs:label "myersBriggs" ;
+  rdfs:comment "A Myers Briggs (MBTI) personality classification." ;
+  rdfs:domain foaf:Person ;
+  rdfs:range rdfs:Literal ;
+  rdfs:isDefinedBy foaf: .
+
+foaf:workplaceHomepage
+  a rdf:Property, owl:ObjectProperty ;
+  ns0:term_status "testing" ;
+  rdfs:label "workplace homepage" ;
+  rdfs:comment "A workplace homepage of some person; the homepage of an organization they work for." ;
+  rdfs:domain foaf:Person ;
+  rdfs:range foaf:Document ;
+  rdfs:isDefinedBy foaf: .
+
+foaf:workInfoHomepage
+  a rdf:Property, owl:ObjectProperty ;
+  ns0:term_status "testing" ;
+  rdfs:label "work info homepage" ;
+  rdfs:comment "A work info homepage of some person; a page about their work for some organization." ;
+  rdfs:domain foaf:Person ;
+  rdfs:range foaf:Document ;
+  rdfs:isDefinedBy foaf: .
+
+foaf:schoolHomepage
+  a rdf:Property, owl:ObjectProperty ;
+  ns0:term_status "testing" ;
+  rdfs:label "schoolHomepage" ;
+  rdfs:comment "A homepage of a school attended by the person." ;
+  rdfs:domain foaf:Person ;
+  rdfs:range foaf:Document ;
+  rdfs:isDefinedBy foaf: .
+
+foaf:knows
+  a rdf:Property, owl:ObjectProperty ;
+  ns0:term_status "stable" ;
+  rdfs:label "knows" ;
+  rdfs:comment "A person known by this person (indicating some level of reciprocated interaction between the parties)." ;
+  rdfs:domain foaf:Person ;
+  rdfs:range foaf:Person ;
+  rdfs:isDefinedBy foaf: .
+
+foaf:interest
+  a rdf:Property, owl:ObjectProperty ;
+  ns0:term_status "testing" ;
+  rdfs:label "interest" ;
+  rdfs:comment "A page about a topic of interest to this person." ;
+  rdfs:domain foaf:Agent ;
+  rdfs:range foaf:Document ;
+  rdfs:isDefinedBy foaf: .
+
+foaf:topic_interest
+  a rdf:Property, owl:ObjectProperty ;
+  ns0:term_status "testing" ;
+  rdfs:label "topic_interest" ;
+  rdfs:comment "A thing of interest to this person." ;
+  rdfs:domain foaf:Agent ;
+  rdfs:range owl:Thing ;
+  rdfs:isDefinedBy foaf: .
+
+foaf:publications
+  a rdf:Property, owl:ObjectProperty ;
+  ns0:term_status "testing" ;
+  rdfs:label "publications" ;
+  rdfs:comment "A link to the publications of this person." ;
+  rdfs:domain foaf:Person ;
+  rdfs:range foaf:Document ;
+  rdfs:isDefinedBy foaf: .
+
+foaf:currentProject
+  a rdf:Property, owl:ObjectProperty ;
+  ns0:term_status "testing" ;
+  rdfs:label "current project" ;
+  rdfs:comment "A current project this person works on." ;
+  rdfs:domain foaf:Person ;
+  rdfs:range owl:Thing ;
+  rdfs:isDefinedBy foaf: .
+
+foaf:pastProject
+  a rdf:Property, owl:ObjectProperty ;
+  ns0:term_status "testing" ;
+  rdfs:label "past project" ;
+  rdfs:comment "A project this person has previously worked on." ;
+  rdfs:domain foaf:Person ;
+  rdfs:range owl:Thing ;
+  rdfs:isDefinedBy foaf: .
+
+foaf:fundedBy
+  a rdf:Property, owl:ObjectProperty ;
+  ns0:term_status "archaic" ;
+  rdfs:label "funded by" ;
+  rdfs:comment "An organization funding a project or person." ;
+  rdfs:domain owl:Thing ;
+  rdfs:range owl:Thing ;
+  rdfs:isDefinedBy foaf: .
+
+foaf:logo
+  a rdf:Property, owl:ObjectProperty, owl:InverseFunctionalProperty ;
+  ns0:term_status "testing" ;
+  rdfs:label "logo" ;
+  rdfs:comment "A logo representing some thing." ;
+  rdfs:domain owl:Thing ;
+  rdfs:range owl:Thing ;
+  rdfs:isDefinedBy foaf: .
+
+foaf:topic
+  a rdf:Property, owl:ObjectProperty ;
+  ns0:term_status "testing" ;
+  rdfs:label "topic" ;
+  rdfs:comment "A topic of some page or document." ;
+  rdfs:domain foaf:Document ;
+  rdfs:range owl:Thing ;
+  owl:inverseOf foaf:page ;
+  rdfs:isDefinedBy foaf: .
+
+foaf:primaryTopic
+  a rdf:Property, owl:FunctionalProperty, owl:ObjectProperty ;
+  ns0:term_status "stable" ;
+  rdfs:label "primary topic" ;
+  rdfs:comment "The primary topic of some page or document." ;
+  rdfs:domain foaf:Document ;
+  rdfs:range owl:Thing ;
+  owl:inverseOf foaf:isPrimaryTopicOf ;
+  rdfs:isDefinedBy foaf: .
+
+foaf:focus
+  a rdf:Property, owl:ObjectProperty ;
+  ns0:term_status "testing" ;
+  rdfs:label "focus" ;
+  rdfs:comment "The underlying or 'focal' entity associated with some SKOS-described concept." ;
+  rdfs:domain skos:Concept ;
+  rdfs:range owl:Thing ;
+  rdfs:isDefinedBy foaf: .
+
+skos:Concept rdfs:label "Concept" .
+foaf:isPrimaryTopicOf
+  a rdf:Property, owl:InverseFunctionalProperty ;
+  ns0:term_status "stable" ;
+  rdfs:label "is primary topic of" ;
+  rdfs:comment "A document that this thing is the primary topic of." ;
+  rdfs:subPropertyOf foaf:page ;
+  owl:inverseOf foaf:primaryTopic ;
+  rdfs:domain owl:Thing ;
+  rdfs:range foaf:Document ;
+  rdfs:isDefinedBy foaf: .
+
+foaf:page
+  a rdf:Property, owl:ObjectProperty ;
+  ns0:term_status "stable" ;
+  rdfs:label "page" ;
+  rdfs:comment "A page or document about this thing." ;
+  rdfs:domain owl:Thing ;
+  rdfs:range foaf:Document ;
+  rdfs:isDefinedBy foaf: ;
+  owl:inverseOf foaf:topic .
+
+foaf:theme
+  a rdf:Property, owl:ObjectProperty ;
+  ns0:term_status "archaic" ;
+  rdfs:label "theme" ;
+  rdfs:comment "A theme." ;
+  rdfs:domain owl:Thing ;
+  rdfs:range owl:Thing ;
+  rdfs:isDefinedBy foaf: .
+
+foaf:account
+  a rdf:Property, owl:ObjectProperty ;
+  ns0:term_status "testing" ;
+  rdfs:label "account" ;
+  rdfs:comment "Indicates an account held by this agent." ;
+  rdfs:domain foaf:Agent ;
+  rdfs:range foaf:OnlineAccount ;
+  rdfs:isDefinedBy foaf: .
+
+foaf:holdsAccount
+  a rdf:Property, owl:ObjectProperty ;
+  ns0:term_status "archaic" ;
+  rdfs:label "account" ;
+  rdfs:comment "Indicates an account held by this agent." ;
+  rdfs:domain foaf:Agent ;
+  rdfs:range foaf:OnlineAccount ;
+  rdfs:isDefinedBy foaf: .
+
+foaf:accountServiceHomepage
+  a rdf:Property, owl:ObjectProperty ;
+  ns0:term_status "testing" ;
+  rdfs:label "account service homepage" ;
+  rdfs:comment "Indicates a homepage of the service provide for this online account." ;
+  rdfs:domain foaf:OnlineAccount ;
+  rdfs:range foaf:Document ;
+  rdfs:isDefinedBy foaf: .
+
+foaf:accountName
+  a rdf:Property, owl:DatatypeProperty ;
+  ns0:term_status "testing" ;
+  rdfs:label "account name" ;
+  rdfs:comment "Indicates the name (identifier) associated with this online account." ;
+  rdfs:domain foaf:OnlineAccount ;
+  rdfs:range rdfs:Literal ;
+  rdfs:isDefinedBy foaf: .
+
+foaf:member
+  a rdf:Property, owl:ObjectProperty ;
+  ns0:term_status "stable" ;
+  rdfs:label "member" ;
+  rdfs:comment "Indicates a member of a Group" ;
+  rdfs:domain foaf:Group ;
+  rdfs:range foaf:Agent ;
+  rdfs:isDefinedBy foaf: .
+
+foaf:membershipClass
+  a rdf:Property, owl:AnnotationProperty ;
+  ns0:term_status "unstable" ;
+  rdfs:label "membershipClass" ;
+  rdfs:comment "Indicates the class of individuals that are a member of a Group" ;
+  rdfs:isDefinedBy foaf: .
+
+foaf:birthday
+  a rdf:Property, owl:FunctionalProperty, owl:DatatypeProperty ;
+  ns0:term_status "unstable" ;
+  rdfs:label "birthday" ;
+  rdfs:comment "The birthday of this Agent, represented in mm-dd string form, eg. '12-31'." ;
+  rdfs:domain foaf:Agent ;
+  rdfs:range rdfs:Literal ;
+  rdfs:isDefinedBy foaf: .
+
+foaf:age
+  a rdf:Property, owl:FunctionalProperty, owl:DatatypeProperty ;
+  ns0:term_status "unstable" ;
+  rdfs:label "age" ;
+  rdfs:comment "The age in years of some agent." ;
+  rdfs:domain foaf:Agent ;
+  rdfs:range rdfs:Literal ;
+  rdfs:isDefinedBy foaf: .
+
+foaf:status
+  a rdf:Property, owl:DatatypeProperty ;
+  ns0:term_status "unstable" ;
+  rdfs:label "status" ;
+  rdfs:comment "A string expressing what the user is happy for the general public (normally) to know about their current activity." ;
+  rdfs:domain foaf:Agent ;
+  rdfs:range rdfs:Literal ;
+  rdfs:isDefinedBy foaf: .

--- a/perf/data/timbl.ttl
+++ b/perf/data/timbl.ttl
@@ -1,0 +1,348 @@
+@prefix : <#>.
+@prefix acl: <http://www.w3.org/ns/auth/acl#>.
+@prefix foaf: <http://xmlns.com/foaf/0.1/>.
+@prefix ldp: <http://www.w3.org/ns/ldp#>.
+@prefix org: <http://www.w3.org/ns/org#>.
+@prefix schema: <http://schema.org/>.
+@prefix solid: <http://www.w3.org/ns/solid/terms#>.
+@prefix space: <http://www.w3.org/ns/pim/space#>.
+@prefix vcard: <http://www.w3.org/2006/vcard/ns#>.
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix c33: <https://ddemers.solidcommunity.net/profile/card#>.
+@prefix c34: <https://dickvangelder.solidcommunity.net/profile/card#>.
+@prefix c43: <https://mats.inrupt.net/profile/card#>.
+@prefix c44: <https://mz8i.solidcommunity.net/profile/card#>.
+@prefix c45: <https://olange.solidcommunity.net/profile/card#>.
+@prefix c46: <https://pietervaneverdingen.inrupt.net/profile/card#>.
+@prefix c48: <https://stijntaelemans.inrupt.net/profile/card#>.
+@prefix c49: <https://techny.inrupt.net/profile/card#>.
+@prefix c50: <https://timojkankaanpaa.solidcommunity.net/profile/card#>.
+@prefix c51: <https://ubernatural.inrupt.net/profile/card#>.
+@prefix c52: <https://veronahe.inrupt.net/profile/card#>.
+@prefix occup: <http://data.europa.eu/esco/occupation/>.
+@prefix inr: <https://inrupt.com/>.
+@prefix mit: <https://mit.edu/>.
+@prefix ww: <https://www.cern.ch/>.
+@prefix w: <https://www.oxfordmartin.ox.ac.uk/>.
+@prefix c7: <https://bourgeoa.solidcommunity.net/profile/card#>.
+@prefix c13: <https://karlhrichter.inrupt.net/profile/card#>.
+@prefix c16: <https://megoth.inrupt.net/profile/card#>.
+@prefix c47: <https://rubenverborgh.inrupt.net/profile/card#>.
+@prefix c32: <https://angelo.veltens.org/profile/card#>.
+@prefix skill: <http://data.europa.eu/esco/skill/>.
+@prefix c8: <https://timea.solidcommunity.net/profile/card#>.
+@prefix c39: <https://janschill.net/profile/card#>.
+@prefix l: <https://www.w3.org/ns/iana/language-code/>.
+@prefix wd: <http://www.wikidata.org/entity/>.
+@prefix profi: <./>.
+@prefix inb0: </inbox/>.
+@prefix ti: </>.
+@prefix c36: <https://dimou.solidcommunity.net/profile/card#>.
+@prefix c40: <https://hindia.solidcommunity.net/profile/card#>.
+@prefix c42: <https://janikv.solidcommunity.net/profile/card#>.
+@prefix c53: <https://jenni.inrupt.net/profile/card#>.
+@prefix c54: <https://jyj.solidcommunity.net/profile/card#>.
+@prefix c: <https://vincentt.inrupt.net/profile/card#>.
+@prefix c0: <https://acoburn.inrupt.net/profile/card#>.
+@prefix c1: <https://csarven.inrupt.net/profile/card#>.
+@prefix c2: <https://davi.inrupt.net/profile/card#>.
+@prefix c3: <https://emmettownsend.inrupt.net/profile/card#>.
+@prefix c4: <https://jackson.solidcommunity.net/profile/card#>.
+@prefix c5: <https://jholleran.inrupt.net/profile/card#>.
+@prefix c6: <https://johnb.inrupt.net/profile/card#>.
+@prefix c9: <https://joshcollins.inrupt.net/profile/card#>.
+@prefix c10: <https://justin.inrupt.net/profile/card#>.
+@prefix c11: <https://kellyo.inrupt.net/profile/card#>.
+@prefix c12: <https://khoward.inrupt.net/profile/card#>.
+@prefix c14: <https://michielbdejong.inrupt.net/profile/card#>.
+@prefix c15: <https://nseydoux.inrupt.net/profile/card#>.
+@prefix c17: <https://oz.inrupt.net/profile/card#>.
+@prefix c18: <https://sharonstrats.inrupt.net/profile/card#>.
+@prefix c19: <https://solid.kjernsmo.net/profile/card#>.
+@prefix c20: <https://solid.zwifi.eu/profile/card#>.
+@prefix c21: <https://worrallp.inrupt.net/profile/card#>.
+
+occup:6f7c1e84-8162-4c20-a575-b57ff624eef5 schema:name "taxi driver".
+
+occup:7b1b5da8-573a-49bb-a38e-68725a949f4f schema:name "chief technology officer".
+
+occup:e3229e40-f571-4b26-baca-29edc8fe313e schema:name "computer scientist".
+
+occup:f2b15a0e-e65a-438a-affb-29b9d50b77d1 schema:name "software developer".
+
+skill:6c870993-9341-438b-91c0-c7fe4f96d8f5 schema:name "apply strategic thinking".
+
+skill:a72408af-b488-4ad4-801b-bbf16f7a7b57
+schema:name "install blinds drive systems".
+skill:a917fd91-866d-4ecf-a70e-894b755f9baf
+schema:name "develop mechatronic test procedures".
+skill:f28617ad-afdd-4041-814c-216153a38998
+schema:name "analyse software specifications".
+skill:f6868852-9bf6-4899-a5d6-5f9532fb877d
+schema:name "design component interfaces".
+wd:Q106746930 schema:name "Inrupt Inc."@en.
+
+wd:Q10853538 schema:name "".
+
+wd:Q16601665 schema:name "Principality of Masserano".
+
+wd:Q34433 schema:name "University of Oxford"@en.
+
+wd:Q42944 schema:name "CERN"@en.
+
+wd:Q49108 schema:name "Massachusetts Institute of Technology"@en.
+
+profi:card a foaf:PersonalProfileDocument; foaf:maker :me; foaf:primaryTopic :me.
+
+:id1618591080534
+    a solid:CurrentRole;
+    schema:description
+        "Technical strategic architecture for Inrupt. Leader of the Solid movement. Coordinate and contribute to Solid open source.";
+    schema:startDate "2018-04-05"^^xsd:date;
+    vcard:role "Cofounder and CTO";
+    org:member :me;
+    org:organization :id1619374832756;
+    org:role occup:7b1b5da8-573a-49bb-a38e-68725a949f4f;
+    solid:publicId wd:Q16601665 .
+:id1618785166805
+    a solid:CurrentRole;
+    schema:description
+        "The Decentralized Information Group (DIG) at MIT's Computer Science and Artificial Intelligence Laboratory (CSAIL) build all sorts of things using semantic web tech, and more recently started the Solid movement to allow people complete control of their data. ";
+    schema:endDate "2021-04-30"^^xsd:date;
+    schema:startDate "1994-09-01"^^xsd:date;
+    vcard:role "Professor of Engineering";
+    org:member :me;
+    org:organization :id1620393169135;
+    org:role occup:e3229e40-f571-4b26-baca-29edc8fe313e;
+    solid:publicId wd:Q10853538 .
+:id1619374832756
+    a schema:Corporation;
+    schema:name "Inrupt";
+    schema:uri inr:;
+    solid:publicId wd:Q106746930 .
+:id1619434605326
+vcard:role "Trainer"; solid:publicId skill:a917fd91-866d-4ecf-a70e-894b755f9baf.
+:id1619436441183 vcard:role "skil2".
+
+:id1619436866023
+vcard:role ""; solid:publicId skill:f28617ad-afdd-4041-814c-216153a38998 .
+:id1619530244336 solid:publicId l:en.
+
+:id1619532839375 solid:publicId l:de.
+
+:id1619532904680 solid:publicId l:fr.
+
+:id1619532994614 solid:publicId l:it.
+
+:id1619628182581
+    a solid:CurrentRole;
+    schema:description
+        """Our Oxford Martin School funded Project on "Ethical Web and Data Architectures" researches Data Autonomy, Data Privacy, Algorithmic Accountability, and Data Sharing and is hiring.""";
+    schema:startDate "2016-09-01"^^xsd:date;
+    vcard:role "Prof of Computer Science and Student at Christ Church";
+    org:member :me;
+    org:organization :id1620413454476;
+    org:role occup:e3229e40-f571-4b26-baca-29edc8fe313e.
+:id1619628257057 solid:publicId skill:a72408af-b488-4ad4-801b-bbf16f7a7b57 .
+
+:id1619628297228 solid:publicId l:ar.
+
+:id1619628398581 solid:publicId l:de.
+
+:id1620060965686
+vcard:country-name "USA"; vcard:locality "Boston"; vcard:region "MA".
+:id1620320324718 solid:publicId l:ar.
+
+:id1620383393470
+    a solid:CurrentRole;
+    schema:endDate "1994-09-01"^^xsd:date;
+    schema:startDate "1984-09-01"^^xsd:date;
+    vcard:role "web inventor";
+    org:member :me;
+    org:organization :id1620431912972;
+    org:role occup:f2b15a0e-e65a-438a-affb-29b9d50b77d1 .
+:id1620393169135
+    a schema:EducationalOrganization;
+    schema:name "MIT";
+    schema:uri mit:;
+    schema:url <https://solidproject.org>;
+    solid:publicId wd:Q49108 .
+:id1620413454476
+    a schema:EducationalOrganization;
+    schema:name "University of Oxford";
+    schema:uri w:ethical-web-and-data-architectures;
+    solid:publicId wd:Q34433 .
+:id1620431912972
+    a schema:ResearchOrganization;
+    schema:name "European Particle Physics Laboratory";
+    schema:uri ww:;
+    solid:publicId wd:Q42944 .
+:id1620576947065 solid:publicId skill:f6868852-9bf6-4899-a5d6-5f9532fb877d.
+
+:id1620576952960 solid:publicId skill:6c870993-9341-438b-91c0-c7fe4f96d8f5 .
+
+:id1620660148956
+    vcard:country-name "UK";
+    vcard:locality "Oxford";
+    vcard:postal-code "OX1 1DP";
+    vcard:street-address "Christ Church, St Aldates".
+:id1621523870701 a schema:Corporation; schema:name "University of Ghent  testing".
+
+:id1643222712160 solid:publicId l:el.
+
+:id1650058571308 org:member :me.
+
+:me
+    a schema:Person, foaf:Person;
+    schema:knowsLanguage ( :id1619530244336 :id1619532904680 );
+    schema:skills :id1619436866023, :id1620576947065, :id1620576952960;
+    vcard:bday "1955-06-08"^^xsd:date;
+    vcard:fn "Tim Berners-Lee";
+    vcard:hasAddress :id1620060965686, :id1620660148956;
+    vcard:hasPhoto
+    <TBL%20by%20coz%20Inrupt%20blue.png>, <TBL%20by%20coz%20Inrupt%20blue.psd>;
+    vcard:note
+        "Pescatarian Allergic to crustaceans,    Invented the Web in 1989. Started W3C and co-founded WebFoundation. Now CTO at Inrupt and leading the Solid Project to give people control of their own data.  Lets re-enable the web as a creative and collaborative (and compassionate!) place of individual empowerment. Check out or Oxford Martin School project. ";
+    vcard:organization-name "Inrupt";
+    vcard:role "Cofounder and CTO";
+    acl:trustedApp
+            [
+                acl:mode acl:Append, acl:Control, acl:Read, acl:Write;
+                acl:origin <http://localhost:3000>
+            ],
+            [
+                acl:mode acl:Append, acl:Control, acl:Read, acl:Write;
+                acl:origin <https://arquisoft.github.io>
+            ],
+            [
+                acl:mode acl:Append, acl:Control, acl:Read, acl:Write;
+                acl:origin <https://drive.verborgh.org>
+            ],
+            [
+                acl:mode acl:Append, acl:Control, acl:Read, acl:Write;
+                acl:origin <https://noeldemartin.github.io>
+            ],
+            [
+                acl:mode acl:Append, acl:Control, acl:Read, acl:Write;
+                acl:origin <https://penny.vincenttunru.com>
+            ],
+            [
+                acl:mode acl:Append, acl:Control, acl:Read, acl:Write;
+                acl:origin <https://solid.github.io>
+            ],
+            [
+                acl:mode acl:Append, acl:Control, acl:Read, acl:Write;
+                acl:origin <https://solidcommunity.net:8443>
+            ],
+            [
+                acl:mode acl:Append, acl:Control, acl:Read, acl:Write;
+                acl:origin <https://solidcommunity.net>
+            ],
+            [
+                acl:mode acl:Append, acl:Control, acl:Read, acl:Write;
+                acl:origin <https://solidos.solidcommunity.net>
+            ],
+            [
+                acl:mode acl:Append, acl:Control, acl:Read, acl:Write;
+                acl:origin <https://solidos.solidcommunity.net>
+            ],
+            [
+                acl:mode acl:Append, acl:Control, acl:Read, acl:Write;
+                acl:origin <https://solidproject.solidcommunity.net>
+            ],
+            [
+                acl:mode acl:Append, acl:Control, acl:Read, acl:Write;
+                acl:origin <https://test-pod.solidcommunity.net:8443>
+            ],
+            [
+                acl:mode acl:Append, acl:Control, acl:Read, acl:Write;
+                acl:origin <https://testingsolidos.solidcommunity.net>
+            ],
+            [
+                acl:mode acl:Append, acl:Control, acl:Read, acl:Write;
+                acl:origin <https://testingsolidos.solidcommunity.net>
+            ],
+            [
+                acl:mode acl:Append, acl:Control, acl:Read, acl:Write;
+                acl:origin <https://timbl.com>
+            ],
+            [
+                acl:mode acl:Append, acl:Control, acl:Read, acl:Write;
+                acl:origin <https://timbl.com>
+            ],
+            [
+                acl:mode acl:Append, acl:Control, acl:Read, acl:Write;
+                acl:origin <https://timbl.solidcommunity.net:8443>
+            ],
+            [
+                acl:mode acl:Append, acl:Read, acl:Write;
+                acl:origin <https://gallant-lewin-6da032.netlify.app>
+            ],
+            [
+                acl:mode acl:Append, acl:Read, acl:Write;
+                acl:origin <https://ibex.darcy.is>
+            ],
+            [
+                acl:mode acl:Append, acl:Read, acl:Write;
+                acl:origin <https://jeff-zucker.solidcommunity.net:8443>
+            ],
+            [
+                acl:mode acl:Append, acl:Read, acl:Write;
+                acl:origin <https://mellonscholarlycommunication.github.io>
+            ],
+            [
+                acl:mode acl:Append, acl:Read, acl:Write;
+                acl:origin <https://oxfordhcc.github.io>
+            ],
+            [
+                acl:mode acl:Append, acl:Read, acl:Write;
+                acl:origin <https://ramen.noeldemartin.com>
+            ],
+            [
+                acl:mode acl:Append, acl:Read, acl:Write;
+                acl:origin <https://timea.solidcommunity.net>
+            ],
+            [
+                acl:mode acl:Append, acl:Read, acl:Write;
+                acl:origin <https://umai.noeldemartin.com>
+            ],
+            [
+                acl:mode acl:Append, acl:Read, acl:Write;
+                acl:origin <https://vincenttunru.gitlab.io>
+            ],
+            [
+                acl:mode acl:Append, acl:Read, acl:Write;
+                acl:origin <https://vincenttunru.gitlab.io>
+            ];
+    ldp:inbox inb0:;
+    org:member ( :id1617461235730 ), :id1617528994661, :id1617529080361;
+    space:preferencesFile </settings/prefs.ttl>;
+    space:storage ti:;
+    solid:account ti:;
+    solid:oidcIssuer <https://inrupt.net>;
+    solid:preferredObjectPronoun "him";
+    solid:preferredRelativePronoun "his";
+    solid:preferredSubjectPronoun "he";
+    solid:privateTypeIndex </settings/privateTypeIndex.ttl>;
+    solid:profileHighlightColor "#a356f0"^^xsd:color;
+    solid:publicTypeIndex </settings/publicTypeIndex.ttl>;
+    foaf:knows
+        c0:me, c32:me, c7:me, c1:me, c2:me, c33:me, c34:me, c36:me, c3:me,
+        c40:me, c4:me, c42:me, c39:me, c53:me, c5:me, c6:me, c9:me, c10:me,
+        c54:me, c13:me, c11:me, c12:me, c43:me, c16:me, c14:me, c44:me, c15:me,
+        c45:me, c17:me, c46:me, c47:me, c18:me, c19:me, c20:me, c48:me, c49:me,
+        c8:me, c50:me, c51:me, c52:me, c:me, c21:me;
+    foaf:name "Timothy J Berners-Lee";
+    foaf:nick "timbl".
+l:ar schema:name "Arabic"@en.
+
+l:de schema:name "Deutsch"@de, "German"@en.
+
+l:el schema:name "Modern Greek"@en.
+
+l:en schema:name "English"@en.
+
+l:fr schema:name "French"@en.
+
+l:it schema:name "italiano"@it.
+

--- a/src/N3Store.js
+++ b/src/N3Store.js
@@ -777,6 +777,7 @@ export default class N3Store {
   }
 
   *_evaluatePremise(index0, [val0, val1, val2]) {
+    // console.log('evaluating premise')
     let index1, index2, tmp;
     let v0 = true, v1 = true, v2 = true;
     if (val0.value) {
@@ -804,26 +805,33 @@ export default class N3Store {
             for (let l = 0; l < values.length; l++) {
               if (v2) val2.value = values[l];
               // TODO: probably implement a cb since yielding is slow
-              yield; // At this point we have substituted all the premises
+              // console.log([val0, val1, val2], this._entities[val0.value], this._entities[val1.value], this._entities[val2.value]);
+              yield true; // At this point we have substituted all the premises
             }
+
+            if (v2) delete val2.value;
           }
         }
+        if (v1) delete val1.value;
       }
     }
+    if (v0) delete val0.value;
   }
 
   *_evaluatePremises(premises, content, i) {
+    // console.log(premises)
     for (const _ of this._evaluatePremise(content[premises[i].content], premises[i].value)) {
       if (i < premises.length - 1) {
         yield* this._evaluatePremises(premises, content, i + 1);
       } else {
-        yield;
+        yield true;
       }
     }
   }
 
   *_evaluateRule({ premise, conclusion, variables }, content) {
     for (const _ of this._evaluatePremises(premise, content, 0)) {
+      // console.log(premise, conclusion, variables);
       yield* this._addConclusion(conclusion, content);
     }
     // Reset the variables
@@ -841,6 +849,7 @@ export default class N3Store {
   // A naive reasoning algorithm where rules are just applied by repeatedly applying rules
   // until no more evaluations are made
   _reasonGraphNaive(rules, content) {
+    // console.log('reasoning', rules)
     let add = true;
     while (add) {
       add = false;
@@ -903,6 +912,7 @@ export default class N3Store {
   }
 
   reason(rules) {
+    // console.log('reason called')
     rules = rules.map(rule => this._createRule(rule));
     const graphs = this._getGraphs();
     let content;

--- a/src/N3Store.js
+++ b/src/N3Store.js
@@ -831,16 +831,15 @@ export default class N3Store {
 
   *_evaluateRule({ premise, conclusion, variables }, content) {
     for (const _ of this._evaluatePremises(premise, content, 0)) {
-      // console.log(premise, conclusion, variables);
       yield* this._addConclusion(conclusion, content);
     }
     // Reset the variables
-    for (const v of variables) {
-      delete v.value;
-    }
+    // for (const v of variables) {
+    //   delete v.value;
+    // }
   }
 
-  *_evaluateRules(rules, content, graph) {
+  *_evaluateRules(rules, content) {
     for (const rule of rules) {
       yield* this._evaluateRule(rule, content);
     }
@@ -853,7 +852,6 @@ export default class N3Store {
     let add = true;
     while (add) {
       add = false;
-      console.log('iterating')
       for (const _ of this._evaluateRules(rules, content)) {
         add = true;
       }

--- a/src/N3Store.js
+++ b/src/N3Store.js
@@ -853,6 +853,7 @@ export default class N3Store {
     let add = true;
     while (add) {
       add = false;
+      console.log('iterating')
       for (const _ of this._evaluateRules(rules, content)) {
         add = true;
       }

--- a/src/N3Store.js
+++ b/src/N3Store.js
@@ -851,11 +851,12 @@ export default class N3Store {
   // until no more evaluations are made
   _reasonGraphNaive(rules, content) {
     // console.log('reasoning', rules)
+    console.time('reasoning')
     let add = true;
     while (add) {
       add = false
-      // console.log('reasoning')
       this._evaluateRules(rules, content, () => { add = true })
+      console.timeLog('reasoning')
     }
   }
 

--- a/test/N3Store-test.js
+++ b/test/N3Store-test.js
@@ -1705,7 +1705,7 @@ describe('Store', () => {
         new NamedNode('http://www.w3.org/2003/01/geo/wgs84_pos#SpatialThing'),
       ),
     ])
-    expect(store.size).equal(2);
+    expect(store.size).equal(3);
     store.reason([{
       premise: [new Quad(
         new Variable('?s'),
@@ -1724,7 +1724,6 @@ describe('Store', () => {
         ),
       ]
     }]);
-    expect(store.size).equal(3);
     expect(store.has(
       new Quad(
         new NamedNode('http://example.org#me'),
@@ -1732,6 +1731,7 @@ describe('Store', () => {
         new NamedNode('http://www.w3.org/2003/01/geo/wgs84_pos#SpatialThing'),
       )
     )).equal(true)
+    expect(store.size).equal(4);
   });
 });
 


### PR DESCRIPTION
Supercedes #291 #292 

This is a WIP PR to add RL reasoning support to N3.js. Code still needs a significant cleanup - and a smarter forward chaining algorithm is yet to be implemented.

Part of my reasoning for doing this is to see what the performance difference between reasoning via something like https://github.com/comunica/comunica-feature-reasoning/ vs. reasoning directly using the store internals is.

Currently, this implements a naive algorithm of repeatedly applying rules until no new results are available.

Currently, this can apply RDFS rules over the union of timbl's profile card, and the foaf ontology (~1_000 quads) in 20ms (DELL XPS 15, 32GB), generating ~700 quads. For reference it takes ~27ms to _load_ the data.

I expect that once I implement smarter forwards chaining this will be <10ms

@pbonte @josd thought you might be interested in this :) 