### PR TITLE
Allows readable-stream 4.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   ],
   "dependencies": {
     "queue-microtask": "^1.1.2",
-    "readable-stream": "^3.6.0"
+    "readable-stream": "^3.6.0|^4.0.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.16.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   ],
   "dependencies": {
     "queue-microtask": "^1.1.2",
-    "readable-stream": "^3.6.0|^4.0.0"
+    "readable-stream": "^3.6.0||^4.0.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.16.0",


### PR DESCRIPTION
Allows dependencies to avoid shipping both readable-stream v3 and v4.