### PR TITLE
WIP: fix n3 paths

### DIFF
--- a/src/N3Parser.js
+++ b/src/N3Parser.js
@@ -439,7 +439,7 @@ export default class N3Parser {
       // Was this list the parent's subject?
       if (this._predicate === null) {
         // The next token is the predicate
-        next = this._readPredicate;
+        next = this._n3Mode ? this._getPathReader(this._readPredicateOrNamedGraph) : this._readPredicate;
         // No list tail if this was an empty list
         if (this._subject === this.RDF_NIL)
           return next;
@@ -473,6 +473,10 @@ export default class N3Parser {
       this._saveContext('formula', this._graph, this._subject, this._predicate,
                         this._graph = this._blankNode());
       return this._readSubject;
+    case '!':
+      if (this._n3Mode) {
+        return this._getPathReader(this._readPredicateOrNamedGraph);
+      }
     default:
       if ((item = this._readEntity(token)) === undefined)
         return;
@@ -497,7 +501,7 @@ export default class N3Parser {
     // If an item was read, add it to the list
     if (item !== null) {
       // In N3 mode, the item might be a path
-      if (this._n3Mode && (token.type === 'IRI' || token.type === 'prefixed')) {
+      if (this._n3Mode) {
         // Create a new context to add the item's path
         this._saveContext('item', this._graph, list, this.RDF_FIRST, item);
         this._subject = item, this._predicate = null;

--- a/src/N3Parser.js
+++ b/src/N3Parser.js
@@ -436,15 +436,16 @@ export default class N3Parser {
       // This will be `<parent list element> rdf:first <this list>.`.
       if (stack.length !== 0 && stack[stack.length - 1].type === 'list') {
         if (this._n3Mode) {
-          const { _subject, _predicate, _object, _graph } = this;
-          if (_object.termType !== "NamedNode" || _object.value !== this.RDF_NIL.value) {
-            this._emit(_object, this.RDF_REST, this.RDF_NIL, _graph);
+          const { _subject, _predicate, _graph } = this;
+          if (this._object !== this.RDF_NIL) {
+            this._emit(previousList, this.RDF_REST, this.RDF_NIL, _graph);
           }
-          return this._getPathReader(tk => { 
+          return this._getPathReader(tk => {
             this._emit(_subject, _predicate, this._object, _graph);
-            return this._readListItem(tk)
+            return this._readListItem(tk);
           });
-        } else {
+        }
+        else {
           this._emit(this._subject, this._predicate, this._object, this._graph);
         }
       }
@@ -485,14 +486,6 @@ export default class N3Parser {
       this._saveContext('formula', this._graph, this._subject, this._predicate,
                         this._graph = this._blankNode());
       return this._readSubject;
-    case '!':
-    case '^':
-      // Continue path
-      if (!this._n3Mode)
-        return this._error('Unexpected path', token);
-
-      this._saveContext('item', this._graph, list, this.RDF_FIRST, item);
-      return this._getPathReader(this._readListItem);
     default:
       if ((item = this._readEntity(token)) === undefined)
         return;

--- a/test/N3Parser-test.js
+++ b/test/N3Parser-test.js
@@ -1880,43 +1880,37 @@ describe('Parser', () => {
           return pathType === '!' ? [value, 'f:son', `_:b${bnode}`] : [`_:b${bnode}`, 'f:son', value];
         }
 
-        const prefixes = '@prefix : <ex:>. @prefix fam: <f:>.';
-        for (const [f, triple, listPos] of [
-          [x => `${prefixes}(${x}) a :List .`, ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type',  'ex:List'], 'subject'],
-          [x => `${prefixes}<l> <is> (${x}) .`, ['l', 'is', '_:b0'], 'object'],
+        for (const [f, triple] of [
+          [x => `(${x}) a :List .`, ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type',  'ex:List']],
+          [x => `<l> (${x}) <m> .`, ['l', '_:b0', 'm']],
+          [x => `<l> <is> (${x}) .`, ['l', 'is', '_:b0']],
         ]) {
-          it(`should parse a ${pathType} path in a list as ${listPos} with path as subject - starting with ${elem}`,
-            shouldParse(parser, f(`${elem}${pathType}fam:son <x> <y>`),
-              triple, ...list(['_:b0', '_:b1'], ['_:b2', 'x'], ['_:b3', 'y']), son('1')));
+          // eslint-disable-next-line no-inner-declarations
+          function check(content, ...triples) {
+            it(`should parse [${f(content)}]`,
+              shouldParse(parser, `@prefix : <ex:>. @prefix fam: <f:>.${f(content)}`,
+                triple, ...triples));
+          }
 
-          it(`should parse a ${pathType} path in a single element list as ${listPos} with path as subject - starting with ${elem}`,
-            shouldParse(parser, f(`${elem}${pathType}fam:son <x> <y>`),
-              triple, ...list(['_:b0', '_:b1']), son('1')));
+          check(`${elem}${pathType}fam:son`, ...list(['_:b0', '_:b1']), son('1'));
+          check(`(${elem}${pathType}fam:son)`, ...list(['_:b0', '_:b1']), ...list(['_:b1', '_:b2']), son('2'));
 
-          it(`should parse a ${pathType} path in a list as ${listPos} with path as object - starting with ${elem}`,
-            shouldParse(parser, f(`${elem}${pathType}fam:son <x> <y>`),
-              triple, ...list(['_:b0', 'x'], ['_:b1', 'y'], ['_:b2', '_:b3']), son('3')));
+          check(`${elem}${pathType}fam:son <x> <y>`, ...list(['_:b0', '_:b1'], ['_:b2', 'x'], ['_:b3', 'y']), son('1'));
+          check(`<x> ${elem}${pathType}fam:son <y>`, ...list(['_:b0', 'x'], ['_:b1', '_:b2'], ['_:b3', 'y']), son('2'));
+          check(`<x> <y> ${elem}${pathType}fam:son`, ...list(['_:b0', 'x'], ['_:b1', 'y'], ['_:b2', '_:b3']), son('3'));
 
-          it(`should parse a ${pathType} path in a list as ${listPos} with path as subject - starting with ${elem}`,
-            shouldParse(parser, f(`${elem}${pathType}fam:son <x> <y>`),
-              triple,
-              ...list(['_:b0', '_:b1'], ['_:b3', 'x'], ['_:b4', 'y']),
-              ...list(['_:b1', '_:b2']),
-              son('2')));
-
-          it(`should parse a ${pathType} path in a single element list as ${listPos} with path as subject - starting with ${elem}`,
-            shouldParse(parser, f(`${elem}${pathType}fam:son <x> <y>`),
-              triple,
-              ...list(['_:b0', '_:b1']),
-              ...list(['_:b1', '_:b2']),
-              son('2')));
-
-          it(`should parse a ${pathType} path in a list as ${listPos} with path as object - starting with ${elem}`,
-            shouldParse(parser, f(`${elem}${pathType}fam:son <x> <y>`),
-              triple,
-              ...list(['_:b0', 'x'], ['_:b1', 'y'], ['_:b2', '_:b3']),
-              ...list(['_:b3', '_:b4']),
-              son('4')));
+          check(`(${elem}${pathType}fam:son) <x> <y>`,
+            ...list(['_:b0', '_:b1'], ['_:b3', 'x'], ['_:b4', 'y']),
+            ...list(['_:b1', '_:b2']),
+            son('2'));
+          check(`<x> (${elem}${pathType}fam:son) <y>`,
+            ...list(['_:b0', 'x'], ['_:b1', '_:b2'], ['_:b4', 'y']),
+            ...list(['_:b2', '_:b3']),
+            son('3'));
+          check(`<x> <y> (${elem}${pathType}fam:son)`,
+            ...list(['_:b0', 'x'], ['_:b1', 'y'], ['_:b2', '_:b3']),
+            ...list(['_:b3', '_:b4']),
+            son('4'));
         }
       }
     }

--- a/test/N3Parser-test.js
+++ b/test/N3Parser-test.js
@@ -1873,7 +1873,14 @@ describe('Parser', () => {
       shouldNotParse(parser, '<<_:a <http://ex.org/b> _:b <http://ex.org/b>>> <http://ex.org/b> "c" .',
         'Expected >> to follow "_:.b" on line 1.'));
 
-    for (const [elem, value] of [['()', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil'], [':joe', 'ex:joe'], ['<<:joe a :Person>>', '<<:joe a :Person>>']]) {
+    for (const [elem, value] of [
+      ['()', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil'],
+      ['( )', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil'],
+      ['(  )', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil'],
+      ['<http://www.w3.org/1999/02/22-rdf-syntax-ns#nil>', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil'],
+      [':joe', 'ex:joe'],
+      // ['<<:joe a :Person>>', '<<:joe a :Person>>']
+    ]) {
       for (const pathType of ['!', '^']) {
         // eslint-disable-next-line no-inner-declarations
         function son(bnode) {
@@ -1882,7 +1889,7 @@ describe('Parser', () => {
 
         for (const [f, triple] of [
           [x => `(${x}) a :List .`, ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type',  'ex:List']],
-          [x => `<l> (${x}) <m> .`, ['l', '_:b0', 'm']],
+          // [x => `<l> (${x}) <m> .`, ['l', '_:b0', 'm']],
           [x => `<l> <is> (${x}) .`, ['l', 'is', '_:b0']],
         ]) {
           // eslint-disable-next-line no-inner-declarations

--- a/test/N3Parser-test.js
+++ b/test/N3Parser-test.js
@@ -1809,15 +1809,14 @@ describe('Parser', () => {
     it('should parse a ! path of length 2 as nested subject in a list',
       shouldParse(parser, '@prefix : <ex:>. @prefix fam: <f:>.' +
                           '((:joe!fam:mother) 1) a fam:Person.',
-                  ['ex:joe', 'f:mother', '_:b2'],
-                  ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', '_:b1'],
-                  ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', '_:b3'],
-                  ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'f:Person'],
-                  ['_:b1', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', '_:b2'],
-                  ['_:b1', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil'],
-                  ['_:b3', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', '"1"^^http://www.w3.org/2001/XMLSchema#integer'],
-                  ['_:b3', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil']
-                  ));
+        ['ex:joe', 'f:mother', '_:b2'],
+        ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', '_:b1'],
+        ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', '_:b3'],
+        ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'f:Person'],
+        ['_:b1', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', '_:b2'],
+        ['_:b1', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil'],
+        ['_:b3', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', '"1"^^http://www.w3.org/2001/XMLSchema#integer'],
+        ['_:b3', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil']));
 
     it('should parse a formula as list item',
         shouldParse(parser, '<a> <findAll> ( <b> { <b> a <type>. <b> <something> <foo> } <o> ).',

--- a/test/N3Parser-test.js
+++ b/test/N3Parser-test.js
@@ -1759,40 +1759,48 @@ describe('Parser', () => {
     it('should parse a ! path of length 2 starting with a non-empty list',
       shouldParse(parser, '@prefix : <ex:>. @prefix fam: <f:>.' +
                           '( :a )!fam:mother a fam:Person.',
-                  ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', 'ex:a'],
-                  ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil'],
+                  ...list(['_:b0', 'ex:a']),
                   ['_:b0', 'f:mother', '_:b1'],
                   ['_:b1', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'f:Person']));
 
     it('should parse a ! path of length 2 starting with a non-empty list in another list',
       shouldParse(parser, '@prefix : <ex:>. @prefix fam: <f:>.' +
                           '(( :a )!fam:mother 1) a fam:Person.',
-                  ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', 'ex:a'],
-                  ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil'],
-                  ['_:b0', 'f:mother', '_:b1'],
-                  ['_:b1', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'f:Person']));
+                  ...list(['_:b0', '_:b2'], ['_:b3', '"1"^^http://www.w3.org/2001/XMLSchema#integer']),
+                  ...list(['_:b1', 'ex:a']),
+                  ['_:b1', 'f:mother', '_:b2'],
+                  ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'f:Person']));
 
     it('should parse a ! path of length 2 starting with an empty list in another list',
       shouldParse(parser, '@prefix : <ex:>. @prefix fam: <f:>.' +
                           '(()!fam:mother 1) a fam:Person.',
-                  ['http://www.w3.org/1999/02/22-rdf-syntax-ns#nil', 'f:mother', '_:b0'],
-                  ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'f:Person']));
-
+                  ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'f:Person'],
+                  ...list(['_:b0', '_:b1'], ['_:b2', '"1"^^http://www.w3.org/2001/XMLSchema#integer']),
+                  ['http://www.w3.org/1999/02/22-rdf-syntax-ns#nil', 'f:mother', '_:b1']
+                  ));
 
     it('should parse a ! path of length 2 starting with an empty list in another list as second element',
       shouldParse(parser, '@prefix : <ex:>. @prefix fam: <f:>.' +
                           '(1 ()!fam:mother) a fam:Person.',
-                  ['http://www.w3.org/1999/02/22-rdf-syntax-ns#nil', 'f:mother', '_:b0'],
-                  ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'f:Person']
+                  ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'f:Person'],
+                  ...list(['_:b0', '"1"^^http://www.w3.org/2001/XMLSchema#integer'], ['_:b1', '_:b2']),
+                  ['http://www.w3.org/1999/02/22-rdf-syntax-ns#nil', 'f:mother', '_:b2']
                   ));
-
 
     it('should parse a ! path of length 2 starting with an empty list in another list of one element',
       shouldParse(parser, '@prefix : <ex:>. @prefix fam: <f:>.' +
                           '(()!fam:mother) a fam:Person.',
-                  ['http://www.w3.org/1999/02/22-rdf-syntax-ns#nil', 'f:mother', '_:b0'],
-                  ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'f:Person']));
+                  ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'f:Person'],
+                  ...list(['_:b0', '_:b1']),
+                  ['http://www.w3.org/1999/02/22-rdf-syntax-ns#nil', 'f:mother', '_:b1']));
 
+    it('should parse a ! path of length 2 as nested subject in a list',
+      shouldParse(parser, '@prefix : <ex:>. @prefix fam: <f:>.' +
+                          '((:joe!fam:mother) 1) a fam:Person.',
+                  ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'f:Person'],
+                  ...list(['_:b0', '_:b1'], ['_:b3', '"1"^^http://www.w3.org/2001/XMLSchema#integer']),
+                  ...list(['_:b1', '_:b2']),
+                  ['ex:joe', 'f:mother', '_:b2']));
 
     it('should parse a birthday rule',
       shouldParse(parser,
@@ -1804,27 +1812,24 @@ describe('Parser', () => {
         '  ?x :trueOnDate ?date.' +
         '} <= {' +
         '  ((?date ?s!foaf:birthday)!math:difference 31622400) math:integerQuotient ?age .' +
-        '} .'));
-
-    it('should parse a ! path of length 2 as nested subject in a list',
-      shouldParse(parser, '@prefix : <ex:>. @prefix fam: <f:>.' +
-                          '((:joe!fam:mother) 1) a fam:Person.',
-        ['ex:joe', 'f:mother', '_:b2'],
-        ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', '_:b1'],
-        ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', '_:b3'],
-        ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'f:Person'],
-        ['_:b1', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', '_:b2'],
-        ['_:b1', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil'],
-        ['_:b3', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', '"1"^^http://www.w3.org/2001/XMLSchema#integer'],
-        ['_:b3', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil']));
+        '} .',
+          ['?x', 'http://example.org/trueOnDate', '?date', '_:b0'],
+          // eslint-disable-next-line no-warning-comments
+          // FIXME: when merging with https://github.com/rdfjs/N3.js/pull/327
+          ['_:b1', 'http://www.w3.org/2000/10/swap/log#implies', '_:b0'],
+          ...[
+            ...list(['_:b2', '_:b6'], ['_:b7', '"31622400"^^http://www.w3.org/2001/XMLSchema#integer']),
+            ['_:b2', 'http://www.w3.org/2000/10/swap/math#integerQuotient', '?age'],
+            ...list(['_:b3', '?date'], ['_:b4', '_:b5']),
+            ['?s', 'http://xmlns.com/foaf/0.1/birthday', '_:b5'],
+            ['_:b3', 'http://www.w3.org/2000/10/swap/math#difference', '_:b6'],
+          ].map(elem => [...elem, '_:b1'])
+        ));
 
     it('should parse a formula as list item',
         shouldParse(parser, '<a> <findAll> ( <b> { <b> a <type>. <b> <something> <foo> } <o> ).',
         ['a', 'findAll', '_:b0'],
-        ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', 'b'],
-        ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', '_:b2'],
-        ['_:b2', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', 'o'],
-        ['_:b2', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil'],
+        ...list(['_:b0', 'b'], ['_:b2', 'o']),
         ['b', 'something', 'foo', '_:b1'],
         ['b', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'type', '_:b1']
     ));

--- a/test/N3Parser-test.js
+++ b/test/N3Parser-test.js
@@ -1733,6 +1733,92 @@ describe('Parser', () => {
                   ['_:b3', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil'],
                   ['_:b2', 'f:son', 'ex:joe']));
 
+    it('should parse a ! path of length 2 as subject in a list',
+      shouldParse(parser, '@prefix : <ex:>. @prefix fam: <f:>.' +
+                          '(:joe!fam:mother) a fam:Person.',
+                  ['ex:joe', 'f:mother', '_:b1'],
+                  ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', '_:b1'],
+                  ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil'],
+                  ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'f:Person']));
+
+    it('should parse a !^ path of length 3 as subject in a list',
+      shouldParse(parser, '@prefix : <ex:>. @prefix fam: <f:>.' +
+                          '(:joe!fam:mother^fam:father) a fam:Person.',
+                  ['ex:joe', 'f:mother', '_:b1'],
+                  ['_:b2', 'f:father', '_:b1'],
+                  ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', '_:b2'],
+                  ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil'],
+                  ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'f:Person']));
+
+    it('should parse a ! path of length 2 starting with an empty list',
+      shouldParse(parser, '@prefix : <ex:>. @prefix fam: <f:>.' +
+                          '()!fam:mother a fam:Person.',
+                  ['http://www.w3.org/1999/02/22-rdf-syntax-ns#nil', 'f:mother', '_:b0'],
+                  ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'f:Person']));
+
+    it('should parse a ! path of length 2 starting with a non-empty list',
+      shouldParse(parser, '@prefix : <ex:>. @prefix fam: <f:>.' +
+                          '( :a )!fam:mother a fam:Person.',
+                  ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', 'ex:a'],
+                  ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil'],
+                  ['_:b0', 'f:mother', '_:b1'],
+                  ['_:b1', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'f:Person']));
+
+    it('should parse a ! path of length 2 starting with a non-empty list in another list',
+      shouldParse(parser, '@prefix : <ex:>. @prefix fam: <f:>.' +
+                          '(( :a )!fam:mother 1) a fam:Person.',
+                  ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', 'ex:a'],
+                  ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil'],
+                  ['_:b0', 'f:mother', '_:b1'],
+                  ['_:b1', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'f:Person']));
+
+    it('should parse a ! path of length 2 starting with an empty list in another list',
+      shouldParse(parser, '@prefix : <ex:>. @prefix fam: <f:>.' +
+                          '(()!fam:mother 1) a fam:Person.',
+                  ['http://www.w3.org/1999/02/22-rdf-syntax-ns#nil', 'f:mother', '_:b0'],
+                  ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'f:Person']));
+
+
+    it('should parse a ! path of length 2 starting with an empty list in another list as second element',
+      shouldParse(parser, '@prefix : <ex:>. @prefix fam: <f:>.' +
+                          '(1 ()!fam:mother) a fam:Person.',
+                  ['http://www.w3.org/1999/02/22-rdf-syntax-ns#nil', 'f:mother', '_:b0'],
+                  ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'f:Person']
+                  ));
+
+
+    it('should parse a ! path of length 2 starting with an empty list in another list of one element',
+      shouldParse(parser, '@prefix : <ex:>. @prefix fam: <f:>.' +
+                          '(()!fam:mother) a fam:Person.',
+                  ['http://www.w3.org/1999/02/22-rdf-syntax-ns#nil', 'f:mother', '_:b0'],
+                  ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'f:Person']));
+
+
+    it('should parse a birthday rule',
+      shouldParse(parser,
+        '@prefix foaf: <http://xmlns.com/foaf/0.1/> .' +
+        '@prefix math: <http://www.w3.org/2000/10/swap/math#> .' +
+        '@prefix : <http://example.org/> .' +
+        '' +
+        '{' +
+        '  ?x :trueOnDate ?date.' +
+        '} <= {' +
+        '  ((?date ?s!foaf:birthday)!math:difference 31622400) math:integerQuotient ?age .' +
+        '} .'));
+
+    it('should parse a ! path of length 2 as nested subject in a list',
+      shouldParse(parser, '@prefix : <ex:>. @prefix fam: <f:>.' +
+                          '((:joe!fam:mother) 1) a fam:Person.',
+                  ['ex:joe', 'f:mother', '_:b2'],
+                  ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', '_:b1'],
+                  ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', '_:b3'],
+                  ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'f:Person'],
+                  ['_:b1', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', '_:b2'],
+                  ['_:b1', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil'],
+                  ['_:b3', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', '"1"^^http://www.w3.org/2001/XMLSchema#integer'],
+                  ['_:b3', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil']
+                  ));
+
     it('should parse a formula as list item',
         shouldParse(parser, '<a> <findAll> ( <b> { <b> a <type>. <b> <something> <foo> } <o> ).',
         ['a', 'findAll', '_:b0'],

--- a/test/N3Parser-test.js
+++ b/test/N3Parser-test.js
@@ -1872,6 +1872,300 @@ describe('Parser', () => {
     it('should not parse nested quads',
       shouldNotParse(parser, '<<_:a <http://ex.org/b> _:b <http://ex.org/b>>> <http://ex.org/b> "c" .',
         'Expected >> to follow "_:.b" on line 1.'));
+
+    for (const [elem, value] of [['()', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil'], [':joe', 'ex:joe'], ['<<:joe a :Person>>', '<<:joe a :Person>>']]) {
+      it(`should parse a ^ path in a list as subject with path as subject - starting with ${elem}`,
+              shouldParse(parser, '@prefix : <ex:>. @prefix fam: <f:>.' +
+                                  `(${elem}^fam:son <x> <y>) a :List.`,
+                          ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type',  'ex:List'],
+                          ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', '_:b1'],
+                          ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest',  '_:b2'],
+                          ['_:b2', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', 'x'],
+                          ['_:b2', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest',  '_:b3'],
+                          ['_:b3', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', 'y'],
+                          ['_:b3', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil'],
+                          ['_:b1', 'f:son', value]));
+
+      it(`should parse a ^ path in a list as object with path as subject - starting with ${elem}`,
+              shouldParse(parser, '@prefix : <ex:>. @prefix fam: <f:>.' +
+                                  `<l> <is> (${elem}^fam:son <x>  <y>).`,
+                          ['l', 'is', '_:b0'],
+                          ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', '_:b1'],
+                          ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest',  '_:b2'],
+                          ['_:b2', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', 'x'],
+                          ['_:b2', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest',  '_:b3'],
+                          ['_:b3', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', 'y'],
+                          ['_:b3', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil'],
+                          ['_:b1', 'f:son', value]));
+
+      it(`should parse a ^ path in a single element list as subject with path as subject - starting with ${elem}`,
+              shouldParse(parser, '@prefix : <ex:>. @prefix fam: <f:>.' +
+                                  `(${elem}^fam:son) a :List.`,
+                          ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type',  'ex:List'],
+                          ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', '_:b1'],
+                          ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil'],
+                          ['_:b1', 'f:son', value]));
+
+      it(`should parse a ^ path in a single element list as object with path as subject - starting with ${elem}`,
+              shouldParse(parser, '@prefix : <ex:>. @prefix fam: <f:>.' +
+                                  `<l> <is> (${elem}^fam:son).`,
+                          ['l', 'is', '_:b0'],
+                          ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', '_:b1'],
+                          ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil'],
+                          ['_:b1', 'f:son', value]));
+
+      it(`should parse a ^ path in a list as subject with path as object - starting with ${elem}`,
+              shouldParse(parser, '@prefix : <ex:>. @prefix fam: <f:>.' +
+                                  `(<x> <y> ${elem}^fam:son) a :List.`,
+                          ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type',  'ex:List'],
+                          ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', 'x'],
+                          ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest',  '_:b1'],
+                          ['_:b1', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', 'y'],
+                          ['_:b1', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest',  '_:b2'],
+                          ['_:b2', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', '_:b3'],
+                          ['_:b2', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil'],
+                          ['_:b3', 'f:son', value]));
+
+      it(`should parse a ^ path in a list as object with path as object - starting with ${elem}`,
+              shouldParse(parser, '@prefix : <ex:>. @prefix fam: <f:>.' +
+                                  `<l> <is> (<x>  <y> ${elem}^fam:son).`,
+                          ['l', 'is', '_:b0'],
+                          ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', 'x'],
+                          ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest',  '_:b1'],
+                          ['_:b1', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', 'y'],
+                          ['_:b1', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest',  '_:b2'],
+                          ['_:b2', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', '_:b3'],
+                          ['_:b2', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil'],
+                          ['_:b3', 'f:son', value]));
+
+      it(`should parse a ! path in a list as subject with path as subject - starting with ${elem}`,
+              shouldParse(parser, '@prefix : <ex:>. @prefix fam: <f:>.' +
+                                  `(${elem}!fam:son <x> <y>) a :List.`,
+                          ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type',  'ex:List'],
+                          ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', '_:b1'],
+                          ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest',  '_:b2'],
+                          ['_:b2', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', 'x'],
+                          ['_:b2', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest',  '_:b3'],
+                          ['_:b3', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', 'y'],
+                          ['_:b3', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil'],
+                          [value, 'f:son', '_:b1']));
+
+      it(`should parse a ! path in a list as object with path as subject - starting with ${elem}`,
+              shouldParse(parser, '@prefix : <ex:>. @prefix fam: <f:>.' +
+                                  `<l> <is> (${elem}!fam:son <x>  <y>).`,
+                          ['l', 'is', '_:b0'],
+                          ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', '_:b1'],
+                          ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest',  '_:b2'],
+                          ['_:b2', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', 'x'],
+                          ['_:b2', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest',  '_:b3'],
+                          ['_:b3', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', 'y'],
+                          ['_:b3', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil'],
+                          [value, 'f:son', '_:b1']));
+
+      it(`should parse a ! path in a list as subject with path as subject - starting with ${elem}`,
+              shouldParse(parser, '@prefix : <ex:>. @prefix fam: <f:>.' +
+                                  `(${elem}!fam:son) a :List.`,
+                          ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type',  'ex:List'],
+                          ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', '_:b1'],
+                          ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil'],
+                          [value, 'f:son', '_:b1']));
+
+      it(`should parse a ! path in a list as object with path as subject - starting with ${elem}`,
+              shouldParse(parser, '@prefix : <ex:>. @prefix fam: <f:>.' +
+                                  `<l> <is> (${elem}!fam:son).`,
+                          ['l', 'is', '_:b0'],
+                          ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', '_:b1'],
+                          ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil'],
+                          [value, 'f:son', '_:b1']));
+
+      it(`should parse a ! path in a list as subject with path as object - starting with ${elem}`,
+              shouldParse(parser, '@prefix : <ex:>. @prefix fam: <f:>.' +
+                                  `(<x> <y> ${elem}!fam:son) a :List.`,
+                          ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type',  'ex:List'],
+                          ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', 'x'],
+                          ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest',  '_:b1'],
+                          ['_:b1', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', 'y'],
+                          ['_:b1', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest',  '_:b2'],
+                          ['_:b2', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', '_:b3'],
+                          ['_:b2', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil'],
+                          [value, 'f:son', '_:b3']));
+
+      it(`should parse a ! path in a list as object with path as object - starting with ${elem}`,
+              shouldParse(parser, '@prefix : <ex:>. @prefix fam: <f:>.' +
+                                  `<l> <is> (<x>  <y> ${elem}!fam:son).`,
+                          ['l', 'is', '_:b0'],
+                          ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', 'x'],
+                          ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest',  '_:b1'],
+                          ['_:b1', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', 'y'],
+                          ['_:b1', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest',  '_:b2'],
+                          ['_:b2', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', '_:b3'],
+                          ['_:b2', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil'],
+                          [value, 'f:son', '_:b3']));
+
+      it(`should parse a ^ path in a list as subject with path as subject - starting with ${elem}`,
+              shouldParse(parser, '@prefix : <ex:>. @prefix fam: <f:>.' +
+                                  `((${elem}^fam:son) <x> <y>) a :List.`,
+                          ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type',  'ex:List'],
+                          ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', '_:b1'],
+                          ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest',  '_:b3'],
+                          ['_:b3', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', 'x'],
+                          ['_:b3', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest',  '_:b4'],
+                          ['_:b4', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', 'y'],
+                          ['_:b4', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil'],
+                          ['_:b1', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', '_:b2'],
+                          ['_:b1', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil'],
+                          ['_:b2', 'f:son', value]));
+
+      it(`should parse a ^ path in a list as object with path as subject - starting with ${elem}`,
+              shouldParse(parser, '@prefix : <ex:>. @prefix fam: <f:>.' +
+                                  `<l> <is> ((${elem}^fam:son) <x>  <y>).`,
+                          ['l', 'is', '_:b0'],
+                          ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', '_:b1'],
+                          ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest',  '_:b3'],
+                          ['_:b3', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', 'x'],
+                          ['_:b3', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest',  '_:b4'],
+                          ['_:b4', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', 'y'],
+                          ['_:b4', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil'],
+                          ['_:b1', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', '_:b2'],
+                          ['_:b1', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil'],
+                          ['_:b2', 'f:son', value]));
+
+      it(`should parse a ^ path in a single element list as subject with path as subject - starting with ${elem}`,
+              shouldParse(parser, '@prefix : <ex:>. @prefix fam: <f:>.' +
+                                  `((${elem}^fam:son)) a :List.`,
+                          ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type',  'ex:List'],
+                          ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', '_:b1'],
+                          ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil'],
+                          ['_:b1', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', '_:b2'],
+                          ['_:b1', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil'],
+                          ['_:b2', 'f:son', value]));
+
+      it(`should parse a ^ path in a single element list as object with path as subject - starting with ${elem}`,
+              shouldParse(parser, '@prefix : <ex:>. @prefix fam: <f:>.' +
+                                  `<l> <is> ((${elem}^fam:son)).`,
+                          ['l', 'is', '_:b0'],
+                          ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', '_:b1'],
+                          ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil'],
+                          ['_:b1', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', '_:b2'],
+                          ['_:b1', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil'],
+                          ['_:b2', 'f:son', value]));
+
+      it(`should parse a ^ path in a list as subject with path as object - starting with ${elem}`,
+              shouldParse(parser, '@prefix : <ex:>. @prefix fam: <f:>.' +
+                                  `(<x> <y> (${elem}^fam:son)) a :List.`,
+                          ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type',  'ex:List'],
+                          ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', 'x'],
+                          ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest',  '_:b1'],
+                          ['_:b1', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', 'y'],
+                          ['_:b1', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest',  '_:b2'],
+                          ['_:b2', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', '_:b3'],
+                          ['_:b2', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil'],
+
+                          ['_:b3', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', '_:b4'],
+                          ['_:b3', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil'],
+
+                          ['_:b4', 'f:son', value]));
+
+      it(`should parse a ^ path in a list as object with path as object - starting with ${elem}`,
+              shouldParse(parser, '@prefix : <ex:>. @prefix fam: <f:>.' +
+                                  `<l> <is> (<x>  <y> (${elem}^fam:son)).`,
+                          ['l', 'is', '_:b0'],
+                          ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', 'x'],
+                          ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest',  '_:b1'],
+                          ['_:b1', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', 'y'],
+                          ['_:b1', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest',  '_:b2'],
+                          ['_:b2', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', '_:b3'],
+                          ['_:b2', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil'],
+
+                          ['_:b3', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', '_:b4'],
+                          ['_:b3', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil'],
+
+                          ['_:b4', 'f:son', value]));
+
+      it(`should parse a ! path in a list as subject with path as subject - starting with ${elem}`,
+              shouldParse(parser, '@prefix : <ex:>. @prefix fam: <f:>.' +
+                                  `((${elem}!fam:son) <x> <y>) a :List.`,
+                          ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type',  'ex:List'],
+                          ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', '_:b1'],
+                          ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest',  '_:b3'],
+                          ['_:b3', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', 'x'],
+                          ['_:b3', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest',  '_:b4'],
+                          ['_:b4', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', 'y'],
+                          ['_:b4', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil'],
+
+                          ['_:b1', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', '_:b2'],
+                          ['_:b1', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil'],
+
+                          [value, 'f:son', '_:b2']));
+
+      it(`should parse a ! path in a list as object with path as subject - starting with ${elem}`,
+              shouldParse(parser, '@prefix : <ex:>. @prefix fam: <f:>.' +
+                                  `<l> <is> ((${elem}!fam:son) <x>  <y>).`,
+                          ['l', 'is', '_:b0'],
+                          ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', '_:b1'],
+                          ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest',  '_:b3'],
+                          ['_:b3', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', 'x'],
+                          ['_:b3', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest',  '_:b4'],
+                          ['_:b4', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', 'y'],
+                          ['_:b4', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil'],
+
+                          ['_:b1', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', '_:b2'],
+                          ['_:b1', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil'],
+
+                          [value, 'f:son', '_:b2']));
+
+      it(`should parse a ! path in a list as subject with path as subject - starting with ${elem}`,
+              shouldParse(parser, '@prefix : <ex:>. @prefix fam: <f:>.' +
+                                  `((${elem}!fam:son)) a :List.`,
+                          ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type',  'ex:List'],
+                          ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', '_:b1'],
+                          ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil'],
+
+                          ['_:b1', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', '_:b2'],
+                          ['_:b1', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil'],
+
+                          [value, 'f:son', '_:b2']));
+
+      it(`should parse a ! path in a list as object with path as subject - starting with ${elem}`,
+              shouldParse(parser, '@prefix : <ex:>. @prefix fam: <f:>.' +
+                                  `<l> <is> ((${elem}!fam:son)).`,
+                          ['l', 'is', '_:b0'],
+                          ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', '_:b1'],
+                          ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil'],
+
+                          ['_:b1', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', '_:b2'],
+                          ['_:b1', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil'],
+
+                          [value, 'f:son', '_:b2']));
+
+      it(`should parse a ! path in a list as subject with path as object - starting with ${elem}`,
+              shouldParse(parser, '@prefix : <ex:>. @prefix fam: <f:>.' +
+                                  `(<x> <y> (${elem}!fam:son)) a :List.`,
+                          ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type',  'ex:List'],
+                          ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', 'x'],
+                          ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest',  '_:b1'],
+                          ['_:b1', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', 'y'],
+                          ['_:b1', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest',  '_:b2'],
+                          ['_:b2', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', '_:b3'],
+                          ['_:b2', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil'],
+                          ['_:b3', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', '_:b4'],
+                          ['_:b3', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil'],
+                          [value, 'f:son', '_:b4']));
+
+      it(`should parse a ! path in a list as object with path as object - starting with ${elem}`,
+              shouldParse(parser, '@prefix : <ex:>. @prefix fam: <f:>.' +
+                                  `<l> <is> (<x>  <y> (${elem}!fam:son)).`,
+                          ['l', 'is', '_:b0'],
+                          ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', 'x'],
+                          ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest',  '_:b1'],
+                          ['_:b1', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', 'y'],
+                          ['_:b1', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest',  '_:b2'],
+                          ['_:b2', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', '_:b3'],
+                          ['_:b2', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil'],
+                          ['_:b3', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', '_:b4'],
+                          ['_:b3', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil'],
+                          [value, 'f:son', '_:b4']));
+    }
   });
 
   describe('A Parser instance for the N3 format with the explicitQuantifiers option', () => {


### PR DESCRIPTION
This is a WIP PR to get `N3.js` to support all of the styles of paths used by EYE.

Complimentary to https://github.com/rdfjs/N3.js/pull/311/commits/2e655fba7fef05973102d45b8c352e662751cf72.

@josd are there any key test cases that you think are missing?