### PR TITLE
fix: use BlankNode according to RDF/JS spec

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@babel/core": "^7.16.0",
         "@babel/preset-env": "^7.16.0",
         "@babel/register": "^7.16.0",
+        "@rdfjs/data-model": "^1",
         "arrayify-stream": "^1.0.0",
         "browserify": "^17.0.0",
         "chai": "^4.0.2",
@@ -1733,6 +1734,18 @@
       "integrity": "sha512-s88O1aVtXftvp5bCPB7WnmXc5IwOZZ7YPuwNPt+GtOOXpPvad1LfbmjYv+qII7zP6RU2QGnqve27dnLycEnyEQ==",
       "dev": true,
       "optional": true
+    },
+    "node_modules/@rdfjs/data-model": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/@rdfjs/data-model/-/data-model-1.3.4.tgz",
+      "integrity": "sha512-iKzNcKvJotgbFDdti7GTQDCYmL7GsGldkYStiP0K8EYtN7deJu5t7U11rKTz+nR7RtesUggT+lriZ7BakFv8QQ==",
+      "dev": true,
+      "dependencies": {
+        "@rdfjs/types": ">=1.0.1"
+      },
+      "bin": {
+        "rdfjs-data-model-test": "bin/test.js"
+      }
     },
     "node_modules/@rdfjs/types": {
       "version": "1.0.1",
@@ -9381,6 +9394,15 @@
       "integrity": "sha512-s88O1aVtXftvp5bCPB7WnmXc5IwOZZ7YPuwNPt+GtOOXpPvad1LfbmjYv+qII7zP6RU2QGnqve27dnLycEnyEQ==",
       "dev": true,
       "optional": true
+    },
+    "@rdfjs/data-model": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/@rdfjs/data-model/-/data-model-1.3.4.tgz",
+      "integrity": "sha512-iKzNcKvJotgbFDdti7GTQDCYmL7GsGldkYStiP0K8EYtN7deJu5t7U11rKTz+nR7RtesUggT+lriZ7BakFv8QQ==",
+      "dev": true,
+      "requires": {
+        "@rdfjs/types": ">=1.0.1"
+      }
     },
     "@rdfjs/types": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@babel/core": "^7.16.0",
     "@babel/preset-env": "^7.16.0",
     "@babel/register": "^7.16.0",
+    "@rdfjs/data-model": "^1",
     "arrayify-stream": "^1.0.0",
     "browserify": "^17.0.0",
     "chai": "^4.0.2",

--- a/src/N3Parser.js
+++ b/src/N3Parser.js
@@ -86,7 +86,7 @@ export default class N3Parser {
       this._inversePredicate = false;
       // In N3, blank nodes are scoped to a formula
       // (using a dot as separator, as a blank node label cannot start with it)
-      this._prefixes._ = (this._graph ? `${this._graph.id.substr(2)}.` : '.');
+      this._prefixes._ = (this._graph ? `${this._graph.value}.` : '.');
       // Quantifiers are scoped to a formula
       this._quantified = Object.create(this._quantified);
     }

--- a/test/N3Parser-test.js
+++ b/test/N3Parser-test.js
@@ -1,3 +1,4 @@
+import rdfDataModel from '@rdfjs/data-model';
 import { Parser, NamedNode, BlankNode, Quad, termFromId } from '../src/';
 
 const BASE_IRI = 'http://example.org/';
@@ -1869,6 +1870,22 @@ describe('Parser', () => {
         { s: 'n-http://example.org/a', p: 'v-b', o: 'l-1',    g: 'defaultGraph' },
         { s: 'n-http://example.org/a', p: 'v-b', o: 'b-b0_d', g: 'defaultGraph' },
       ]);
+    });
+  });
+
+  describe('A parser instance with external data factory', () => {
+    it('should parse', () => {
+      const parser = new Parser({
+        baseIRI: BASE_IRI,
+        format: 'n3',
+        factory: rdfDataModel,
+      });
+      const quads = parser.parse(`
+        @prefix : <http://example.com/> .
+        { :weather a :Raining } => { :weather a :Cloudy } .
+      `);
+
+      quads.length.should.be.gt(0);
     });
   });
 


### PR DESCRIPTION
Fixes #334 

When parsing n3 rule, the parse tries to access `.id` of a term which is not according to spec and fails when alternative factory is provided, such as `@rdfjs/data-model`. This PR's change is to the `.value` property instead