### PR TITLE
BREAKING CHANGE: Make class Term constructors internal

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -9,15 +9,6 @@ import * as Util from './N3Util';
 import {
   default as DataFactory,
 
-  Term,
-  NamedNode,
-  Literal,
-  BlankNode,
-  Variable,
-  DefaultGraph,
-  Quad,
-  Triple,
-
   termFromId,
   termToId,
 } from './N3DataFactory';
@@ -34,15 +25,6 @@ export {
 
   DataFactory,
 
-  Term,
-  NamedNode,
-  Literal,
-  BlankNode,
-  Variable,
-  DefaultGraph,
-  Quad,
-  Triple,
-
   termFromId,
   termToId,
 };
@@ -58,15 +40,6 @@ export default {
   Util,
 
   DataFactory,
-
-  Term,
-  NamedNode,
-  Literal,
-  BlankNode,
-  Variable,
-  DefaultGraph,
-  Quad,
-  Triple,
 
   termFromId,
   termToId,

--- a/test/BlankNode-test.js
+++ b/test/BlankNode-test.js
@@ -1,4 +1,4 @@
-import { BlankNode, Term } from '../src/';
+import { BlankNode, Term } from '../src/N3DataFactory';
 
 describe('BlankNode', () => {
   describe('The BlankNode module', () => {

--- a/test/DefaultGraph-test.js
+++ b/test/DefaultGraph-test.js
@@ -1,4 +1,4 @@
-import { DefaultGraph, Term } from '../src/';
+import { DefaultGraph, Term } from '../src/N3DataFactory';
 
 describe('DefaultGraph', () => {
   describe('The DefaultGraph module', () => {

--- a/test/Literal-test.js
+++ b/test/Literal-test.js
@@ -1,4 +1,4 @@
-import { Literal, NamedNode, Term } from '../src/';
+import { Literal, NamedNode, Term } from '../src/N3DataFactory';
 
 describe('Literal', () => {
   describe('The Literal module', () => {

--- a/test/N3DataFactory-test.js
+++ b/test/N3DataFactory-test.js
@@ -1,12 +1,12 @@
 import {
-  DataFactory,
   NamedNode,
   Literal,
   BlankNode,
   Variable,
   DefaultGraph,
   Quad,
-} from '../src/';
+} from '../src/N3DataFactory';
+import { DataFactory } from '../src';
 
 describe('DataFactory', () => {
   describe('namedNode', () => {

--- a/test/N3Parser-test.js
+++ b/test/N3Parser-test.js
@@ -1,4 +1,5 @@
-import { Parser, NamedNode, BlankNode, Quad, termFromId } from '../src/';
+import { Parser, termFromId } from '../src/';
+import { NamedNode, BlankNode, Quad } from '../src/N3DataFactory';
 
 const BASE_IRI = 'http://example.org/';
 

--- a/test/N3Store-test.js
+++ b/test/N3Store-test.js
@@ -1,11 +1,13 @@
 import {
   Store,
+  termFromId, termToId,
+} from '../src/';
+import {
   NamedNode,
   Literal,
   DefaultGraph,
   Quad,
-  termFromId, termToId,
-} from '../src/';
+} from '../src/N3DataFactory';
 import namespaces from '../src/IRIs';
 import chai, { expect } from 'chai';
 import { Readable } from 'readable-stream';

--- a/test/N3StreamParser-test.js
+++ b/test/N3StreamParser-test.js
@@ -1,4 +1,5 @@
-import { StreamParser, NamedNode } from '../src/';
+import { StreamParser } from '../src/';
+import { NamedNode } from '../src/N3DataFactory';
 import { Readable, Writable } from 'readable-stream';
 
 describe('StreamParser', () => {

--- a/test/N3StreamWriter-test.js
+++ b/test/N3StreamWriter-test.js
@@ -1,4 +1,5 @@
-import { StreamWriter, Quad, NamedNode, termFromId } from '../src/';
+import { StreamWriter, termFromId } from '../src/';
+import { Quad, NamedNode } from '../src/N3DataFactory';
 import { Readable, Writable } from 'readable-stream';
 
 describe('StreamWriter', () => {

--- a/test/N3Writer-test.js
+++ b/test/N3Writer-test.js
@@ -1,11 +1,11 @@
 import {
   Writer,
-  NamedNode,
-  BlankNode,
-  Literal,
-  Quad,
   termFromId,
 } from '../src/';
+import { NamedNode,
+  BlankNode,
+  Literal,
+  Quad } from '../src/N3DataFactory';
 import namespaces from '../src/IRIs';
 
 const { xsd } = namespaces;

--- a/test/NamedNode-test.js
+++ b/test/NamedNode-test.js
@@ -1,4 +1,4 @@
-import { NamedNode, Term } from '../src/';
+import { NamedNode, Term } from '../src/N3DataFactory';
 
 describe('NamedNode', () => {
   describe('The NamedNode module', () => {

--- a/test/Quad-test.js
+++ b/test/Quad-test.js
@@ -1,4 +1,4 @@
-import { Quad, Triple, DefaultGraph, termFromId, Term } from '../src/';
+import { Quad, Triple, DefaultGraph, termFromId, Term } from '../src/N3DataFactory';
 
 describe('Quad', () => {
   describe('The Quad module', () => {

--- a/test/Term-test.js
+++ b/test/Term-test.js
@@ -1,4 +1,9 @@
 import {
+  termToId,
+  termFromId,
+} from '../src/';
+
+import {
   Term,
   NamedNode,
   BlankNode,
@@ -6,11 +11,6 @@ import {
   Variable,
   DefaultGraph,
   Quad,
-  termToId,
-  termFromId,
-} from '../src/';
-
-import {
   escapeQuotes,
   unescapeQuotes,
 } from '../src/N3DataFactory';

--- a/test/Variable-test.js
+++ b/test/Variable-test.js
@@ -1,4 +1,4 @@
-import { Variable, Term } from '../src/';
+import { Variable, Term } from '../src/N3DataFactory';
 
 describe('Variable', () => {
   describe('The Variable module', () => {


### PR DESCRIPTION
These constructors take the `id` at face value so can be interpreted as the
wrong term type if an invalid value is given; for instance a `NamedNode` can
be interpred as a `Literal` if instantiated with `new NamedNode('"hellow world"')`.

Consumers of the library should use the `DataFactory` instead to create new terms.
