### PR TITLE
Add support for the annotated triples syntax

### DIFF
--- a/src/N3Lexer.js
+++ b/src/N3Lexer.js
@@ -300,13 +300,37 @@ export default class N3Lexer {
       case ']':
       case '(':
       case ')':
-      case '{':
       case '}':
         if (!this._lineMode) {
           matchLength = 1;
           type = firstChar;
+          break;
+        }
+      case '{':
+        if (!this._lineMode) {
+          // We need at least 2 tokens lookahead to distinguish "{|" and "{ "
+          if (input.length < 2)
+            break;
+
+          // Try to find a quoted triple annotation start
+          if (input.length > 1 && input[1] === '|') {
+            type = '{|', matchLength = 2;
+            break;
+          }
+
+          matchLength = 1;
+          type = firstChar;
         }
         break;
+      case '|':
+        // We need at least 2 tokens lookahead to distinguish "|}" and "|"
+        if (input.length < 2)
+          break;
+        // Try to find a quoted triple annotation end
+        if (input[0] === '|' && input.length > 1 && input[1] === '}') {
+          type = '|}', matchLength = 2;
+          break;
+        }
 
       default:
         inconclusive = true;

--- a/src/N3Lexer.js
+++ b/src/N3Lexer.js
@@ -323,7 +323,7 @@ export default class N3Lexer {
         }
         break;
       case '|':
-        // We need at least 2 tokens lookahead to distinguish "|}" and "|"
+        // We need 2 tokens lookahead to parse "|}"
         if (input.length < 2)
           break;
         // Try to find a quoted triple annotation end

--- a/src/N3Lexer.js
+++ b/src/N3Lexer.js
@@ -324,13 +324,10 @@ export default class N3Lexer {
         break;
       case '|':
         // We need 2 tokens lookahead to parse "|}"
-        if (input.length < 2)
-          break;
         // Try to find a quoted triple annotation end
-        if (input[0] === '|' && input.length > 1 && input[1] === '}') {
+        if (input.length >= 2 && input[1] === '}')
           type = '|}', matchLength = 2;
-          break;
-        }
+        break;
 
       default:
         inconclusive = true;

--- a/src/N3Lexer.js
+++ b/src/N3Lexer.js
@@ -313,7 +313,7 @@ export default class N3Lexer {
             break;
 
           // Try to find a quoted triple annotation start
-          if (input.length > 1 && input[1] === '|') {
+          if (input[1] === '|') {
             type = '{|', matchLength = 2;
             break;
           }

--- a/src/N3Lexer.js
+++ b/src/N3Lexer.js
@@ -307,19 +307,13 @@ export default class N3Lexer {
           break;
         }
       case '{':
-        if (!this._lineMode) {
-          // We need at least 2 tokens lookahead to distinguish "{|" and "{ "
-          if (input.length < 2)
-            break;
-
+        // We need at least 2 tokens lookahead to distinguish "{|" and "{ "
+        if (!this._lineMode && input.length >= 2) {
           // Try to find a quoted triple annotation start
-          if (input[1] === '|') {
+          if (input[1] === '|')
             type = '{|', matchLength = 2;
-            break;
-          }
-
-          matchLength = 1;
-          type = firstChar;
+          else
+            type = firstChar, matchLength = 1;
         }
         break;
       case '|':

--- a/src/N3Lexer.js
+++ b/src/N3Lexer.js
@@ -304,8 +304,8 @@ export default class N3Lexer {
         if (!this._lineMode) {
           matchLength = 1;
           type = firstChar;
-          break;
         }
+        break;
       case '{':
         // We need at least 2 tokens lookahead to distinguish "{|" and "{ "
         if (!this._lineMode && input.length >= 2) {

--- a/test/N3Lexer-test.js
+++ b/test/N3Lexer-test.js
@@ -1090,6 +1090,49 @@ describe('Lexer', () => {
         { type: '.', line: 1 },
         { type: 'eof', line: 1 }));
 
+    it('should tokenize a quoted triple annotation start',
+        shouldTokenize('{|',
+            { type: '{|', line: 1 },
+            { type: 'eof', line: 1 }));
+
+    it('should tokenize a split quoted triple annotation start',
+        shouldTokenize(streamOf('{', '|'),
+            { type: '{|', line: 1 },
+            { type: 'eof', line: 1 }));
+
+    it('should tokenize a quoted triple annotation end',
+        shouldTokenize('|}',
+            { type: '|}', line: 1 },
+            { type: 'eof', line: 1 }));
+
+    it('should tokenize a split quoted triple annotation end',
+        shouldTokenize(streamOf('|', '}'),
+            { type: '|}', line: 1 },
+            { type: 'eof', line: 1 }));
+
+    it('should tokenize an empty quoted triple annotation',
+        shouldTokenize('{| |}',
+            { type: '{|', line: 1 },
+            { type: '|}', line: 1 },
+            { type: 'eof', line: 1 }));
+
+    it('should tokenize a non-empty quoted triple annotation',
+        shouldTokenize('{| <http://ex.org/?bla#bar> \n\t<http://ex.org/?bla#boo> |}.',
+            { type: '{|', line: 1 },
+            { type: 'IRI', value: 'http://ex.org/?bla#bar', line: 1 },
+            { type: 'IRI', value: 'http://ex.org/?bla#boo', line: 2 },
+            { type: '|}', line: 2 },
+            { type: '.', line: 2 },
+            { type: 'eof', line: 2 }));
+
+    it('should not tokenize an incomplete closing triple annotation',
+        shouldNotTokenize('{| |',
+            'Unexpected "|" on line 1.'));
+
+    it('should not tokenize an invalid closing triple annotation',
+        shouldNotTokenize('{| ||',
+            'Unexpected "||" on line 1.'));
+
     it('returns start and end index for every token', () => {
       const tokens = new Lexer().tokenize('<a:a> <b:c> "lit"@EN.');
       tokens.should.deep.equal([


### PR DESCRIPTION
The RDF-star spec introduces syntatical suggar for annotating triples: https://w3c.github.io/rdf-star/cg-spec/editors_draft.html#annotation-syntax