### PR TITLE
chore: migrate to jest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on: [push, pull_request]
+on: [push]
 
 jobs:
   test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,11 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version:
-          - 14.x
-          - 16.x
-          - 18.x
-          - 20.x
+        node-version: [14, 16, 18, 20]
     steps:
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v2
@@ -29,12 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version:
-          - 12.x
-          - 14.x
-          - 16.x
-          - 18.x
-          - 20.x
+        node-version: [12, 14, 16, 18, 20]
     steps:
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v2
@@ -46,16 +37,6 @@ jobs:
       - run: npm run spec-ntriples
       - run: npm run spec-nquads
       - run: npm run spec-trig
-
-  coveralls:
-    needs: test
-    runs-on: ubuntu-latest
-    steps:
-      - name: Consolidate test coverage from different jobs
-        uses: coverallsapp/github-action@master
-        with:
-          github-token: ${{ secrets.github_token }}
-          parallel-finished: true
 
   docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,6 @@ jobs:
       fail-fast: false
       matrix:
         node-version:
-          - 12.x
           - 14.x
           - 16.x
           - 18.x

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,13 +23,6 @@ jobs:
       - run: npm run build
       - run: npm run lint
       - run: npm run test
-      - run: npx nyc report --reporter=text-lcov > lcov.info
-      - uses: coverallsapp/github-action@master
-        with:
-          github-token: ${{ secrets.github_token }}
-          flag-name: run-${{ matrix.node-version }}
-          parallel: true
-          path-to-lcov: lcov.info
 
   spec:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [14, 16, 18, 20]
+        node-version: [14.x, 16.x, 18.x, 20.x]
     steps:
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v2
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [12, 14, 16, 18, 20]
+        node-version: [12.x, 14.x, 16.x, 18.x, 20.x]
     steps:
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v2

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ browser
 docs
 lib
 node_modules
+coverage

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,14 +20,10 @@
         "@rdfjs/data-model": "^1",
         "arrayify-stream": "^1.0.0",
         "browserify": "^17.0.0",
-        "chai": "^4.0.2",
-        "chai-things": "^0.2.0",
         "colors": "^1.1.2",
         "docco": "^0.8.0",
         "eslint": "^5.14.1",
         "jest": "^29.7.0",
-        "mocha": "^8.0.0",
-        "nyc": "^14.1.1",
         "pre-commit": "^1.2.2",
         "rdf-isomorphic": "^1.3.1",
         "rdf-test-suite": "^1.25.0",
@@ -2959,12 +2955,6 @@
       "integrity": "sha512-axdPBuLuEJt0c4yI5OZssC19K2Mq1uKdrfZBzuxLvaztgqUtFYZUNw7lETExPYJR9jdEoIg4mb7RQKRQzOkeGQ==",
       "dev": true
     },
-    "node_modules/@ungap/promise-all-settled": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
-      "integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
-      "dev": true
-    },
     "node_modules/abort-controller": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
@@ -3045,15 +3035,6 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
-    "node_modules/ansi-colors": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
-      "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/ansi-escapes": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
@@ -3096,24 +3077,6 @@
       "engines": {
         "node": ">= 8"
       }
-    },
-    "node_modules/append-transform": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/append-transform/-/append-transform-1.0.0.tgz",
-      "integrity": "sha512-P009oYkeHyU742iSZJzZZywj4QRJdnTWffaKuJQLablCZ1uz6/cW4yaRgcDaoQ+uwOxxnt0gRUcwfsNP2ri0gw==",
-      "dev": true,
-      "dependencies": {
-        "default-require-extensions": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/archy": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
-      "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
-      "dev": true
     },
     "node_modules/argparse": {
       "version": "1.0.10",
@@ -3171,15 +3134,6 @@
       "dev": true,
       "dependencies": {
         "inherits": "2.0.1"
-      }
-    },
-    "node_modules/assertion-error": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
-      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
-      "dev": true,
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/astral-regex": {
@@ -3509,6 +3463,7 @@
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
       "dev": true,
+      "optional": true,
       "engines": {
         "node": ">=8"
       }
@@ -3572,12 +3527,6 @@
       "dependencies": {
         "resolve": "^1.17.0"
       }
-    },
-    "node_modules/browser-stdout": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
-      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
-      "dev": true
     },
     "node_modules/browserify": {
       "version": "17.0.0",
@@ -3830,21 +3779,6 @@
       "integrity": "sha512-5r2GqsoEb4qMTTN9J+WzXfjov+hjxT+j3u5K+kIVNIwAd99DLCJE9pBIMP1qVeybV6JiijL385Oz0DcYxfbOIg==",
       "dev": true
     },
-    "node_modules/caching-transform": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/caching-transform/-/caching-transform-3.0.2.tgz",
-      "integrity": "sha512-Mtgcv3lh3U0zRii/6qVgQODdPA4G3zhG+jtbCWj39RXuUFTMzH0vcdMtaJS1jPowd+It2Pqr6y3NJMQqOqCE2w==",
-      "dev": true,
-      "dependencies": {
-        "hasha": "^3.0.0",
-        "make-dir": "^2.0.0",
-        "package-hash": "^3.0.0",
-        "write-file-atomic": "^2.4.2"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/call-bind": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
@@ -3902,29 +3836,6 @@
       "integrity": "sha512-0CNTVCLZggSh7bc5VkX5WWPWO+cyZbNd07IHIsSXLia/eAq+r836hgk+8BKoEh7949Mda87VUOitx5OddVj64A==",
       "dev": true
     },
-    "node_modules/chai": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.4.tgz",
-      "integrity": "sha512-yS5H68VYOCtN1cjfwumDSuzn/9c+yza4f3reKXlE5rUg7SFcCEy90gJvydNgOYtblyf4Zi6jIWRnXOgErta0KA==",
-      "dev": true,
-      "dependencies": {
-        "assertion-error": "^1.1.0",
-        "check-error": "^1.0.2",
-        "deep-eql": "^3.0.1",
-        "get-func-name": "^2.0.0",
-        "pathval": "^1.1.1",
-        "type-detect": "^4.0.5"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/chai-things": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/chai-things/-/chai-things-0.2.0.tgz",
-      "integrity": "sha1-xVEoN4+bs5nplPAAUhUZhO1uvnA=",
-      "dev": true
-    },
     "node_modules/chalk": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -3953,15 +3864,6 @@
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
       "dev": true
-    },
-    "node_modules/check-error": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
-      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
-      "dev": true,
-      "engines": {
-        "node": "*"
-      }
     },
     "node_modules/chokidar": {
       "version": "3.5.2",
@@ -4046,52 +3948,6 @@
       "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.1.tgz",
       "integrity": "sha512-GRMWDxpOB6Dgk2E5Uo+3eEBvtOOlimMmpbFiKuLFnQzYDavtLFY3K5ona41jgN/WdRZtG7utuVSVTL4HbZHGkw==",
       "dev": true
-    },
-    "node_modules/cliui": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
-      "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
-      "dev": true,
-      "dependencies": {
-        "string-width": "^3.1.0",
-        "strip-ansi": "^5.2.0",
-        "wrap-ansi": "^5.1.0"
-      }
-    },
-    "node_modules/cliui/node_modules/ansi-regex": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-      "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/cliui/node_modules/string-width": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-      "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-      "dev": true,
-      "dependencies": {
-        "emoji-regex": "^7.0.1",
-        "is-fullwidth-code-point": "^2.0.0",
-        "strip-ansi": "^5.1.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/cliui/node_modules/strip-ansi": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-      "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-      "dev": true,
-      "dependencies": {
-        "ansi-regex": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
     },
     "node_modules/clone-deep": {
       "version": "4.0.1",
@@ -4286,22 +4142,6 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
-    },
-    "node_modules/cp-file": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/cp-file/-/cp-file-6.2.0.tgz",
-      "integrity": "sha512-fmvV4caBnofhPe8kOcitBwSn2f39QLjnAnGq3gO9dfd75mUytzKNZB1hde6QHunW2Rt+OwuBOMc3i1tNElbszA==",
-      "dev": true,
-      "dependencies": {
-        "graceful-fs": "^4.1.2",
-        "make-dir": "^2.0.0",
-        "nested-error-stacks": "^2.0.0",
-        "pify": "^4.0.1",
-        "safe-buffer": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=6"
-      }
     },
     "node_modules/create-ecdh": {
       "version": "4.0.4",
@@ -4507,15 +4347,6 @@
         }
       }
     },
-    "node_modules/decamelize": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/dedent": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.5.1.tgz",
@@ -4528,18 +4359,6 @@
         "babel-plugin-macros": {
           "optional": true
         }
-      }
-    },
-    "node_modules/deep-eql": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
-      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
-      "dev": true,
-      "dependencies": {
-        "type-detect": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=0.12"
       }
     },
     "node_modules/deep-is": {
@@ -4555,18 +4374,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/default-require-extensions": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-2.0.0.tgz",
-      "integrity": "sha1-9fj7sYp9bVCyH2QfZJ67Uiz+JPc=",
-      "dev": true,
-      "dependencies": {
-        "strip-bom": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/define-properties": {
@@ -4636,15 +4443,6 @@
       },
       "engines": {
         "node": ">=0.8.0"
-      }
-    },
-    "node_modules/diff": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
-      "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.3.1"
       }
     },
     "node_modules/diff-sequences": {
@@ -4857,12 +4655,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/es6-error": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
-      "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
-      "dev": true
     },
     "node_modules/escalade": {
       "version": "3.1.1",
@@ -5332,15 +5124,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/flat": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
-      "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
-      "dev": true,
-      "bin": {
-        "flat": "cli.js"
-      }
-    },
     "node_modules/flat-cache": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
@@ -5366,26 +5149,6 @@
       "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
       "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
       "dev": true
-    },
-    "node_modules/foreground-child": {
-      "version": "1.5.6",
-      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-1.5.6.tgz",
-      "integrity": "sha1-T9ca0t/elnibmApcCilZN8svXOk=",
-      "dev": true,
-      "dependencies": {
-        "cross-spawn": "^4",
-        "signal-exit": "^3.0.0"
-      }
-    },
-    "node_modules/foreground-child/node_modules/cross-spawn": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
-      "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^4.0.1",
-        "which": "^1.2.9"
-      }
     },
     "node_modules/fs-extra": {
       "version": "10.0.0",
@@ -5461,15 +5224,6 @@
       "dev": true,
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
-      }
-    },
-    "node_modules/get-func-name": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
-      "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
-      "dev": true,
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/get-intrinsic": {
@@ -5548,6 +5302,7 @@
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
       "dev": true,
+      "optional": true,
       "dependencies": {
         "is-glob": "^4.0.1"
       },
@@ -5569,15 +5324,6 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true
-    },
-    "node_modules/growl": {
-      "version": "1.10.5",
-      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
-      "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
-      "dev": true,
-      "engines": {
-        "node": ">=4.x"
-      }
     },
     "node_modules/has": {
       "version": "1.0.3",
@@ -5674,27 +5420,6 @@
         "minimalistic-assert": "^1.0.1"
       }
     },
-    "node_modules/hasha": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/hasha/-/hasha-3.0.0.tgz",
-      "integrity": "sha1-UqMvq4Vp1BymmmH/GiFPjrfIvTk=",
-      "dev": true,
-      "dependencies": {
-        "is-stream": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/he": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
-      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
-      "dev": true,
-      "bin": {
-        "he": "bin/he"
-      }
-    },
     "node_modules/highlight.js": {
       "version": "11.0.1",
       "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.0.1.tgz",
@@ -5714,12 +5439,6 @@
         "minimalistic-assert": "^1.0.0",
         "minimalistic-crypto-utils": "^1.0.1"
       }
-    },
-    "node_modules/hosted-git-info": {
-      "version": "2.8.9",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
-      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
-      "dev": true
     },
     "node_modules/html-escaper": {
       "version": "2.0.2",
@@ -6044,6 +5763,7 @@
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
       "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
       "dev": true,
+      "optional": true,
       "dependencies": {
         "binary-extensions": "^2.0.0"
       },
@@ -6113,6 +5833,7 @@
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
       "dev": true,
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6155,6 +5876,7 @@
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
       "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
       "dev": true,
+      "optional": true,
       "dependencies": {
         "is-extglob": "^2.1.1"
       },
@@ -6195,15 +5917,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/is-plain-obj": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
-      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/is-plain-object": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
@@ -6239,15 +5952,6 @@
       "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-stream": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/is-string": {
@@ -6342,117 +6046,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/istanbul-lib-coverage": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.5.tgz",
-      "integrity": "sha512-8aXznuEPCJvGnMSRft4udDRDtb1V3pkQkMMI5LI+6HuQz5oQ4J2UFn1H82raA3qJtyOLkkwVqICBQkjnGtn5mA==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/istanbul-lib-hook": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-2.0.7.tgz",
-      "integrity": "sha512-vrRztU9VRRFDyC+aklfLoeXyNdTfga2EI3udDGn4cZ6fpSXpHLV9X6CHvfoMCPtggg8zvDDmC4b9xfu0z6/llA==",
-      "dev": true,
-      "dependencies": {
-        "append-transform": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/istanbul-lib-instrument": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-3.3.0.tgz",
-      "integrity": "sha512-5nnIN4vo5xQZHdXno/YDXJ0G+I3dAm4XgzfSVTPLQpj/zAV2dV6Juy0yaf10/zrJOJeHoN3fraFe+XRq2bFVZA==",
-      "dev": true,
-      "dependencies": {
-        "@babel/generator": "^7.4.0",
-        "@babel/parser": "^7.4.3",
-        "@babel/template": "^7.4.0",
-        "@babel/traverse": "^7.4.3",
-        "@babel/types": "^7.4.0",
-        "istanbul-lib-coverage": "^2.0.5",
-        "semver": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/istanbul-lib-instrument/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/istanbul-lib-report": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-2.0.8.tgz",
-      "integrity": "sha512-fHBeG573EIihhAblwgxrSenp0Dby6tJMFR/HvlerBsrCTD5bkUuoNtn3gVh29ZCS824cGGBPn7Sg7cNk+2xUsQ==",
-      "dev": true,
-      "dependencies": {
-        "istanbul-lib-coverage": "^2.0.5",
-        "make-dir": "^2.1.0",
-        "supports-color": "^6.1.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/istanbul-lib-report/node_modules/supports-color": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-      "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/istanbul-lib-source-maps": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-3.0.6.tgz",
-      "integrity": "sha512-R47KzMtDJH6X4/YW9XTx+jrLnZnscW4VpNN+1PViSYTejLVPWv7oov+Duf8YQSPyVRUvueQqz1TcsC6mooZTXw==",
-      "dev": true,
-      "dependencies": {
-        "debug": "^4.1.1",
-        "istanbul-lib-coverage": "^2.0.5",
-        "make-dir": "^2.1.0",
-        "rimraf": "^2.6.3",
-        "source-map": "^0.6.1"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/istanbul-lib-source-maps/node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/istanbul-reports": {
-      "version": "2.2.7",
-      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-2.2.7.tgz",
-      "integrity": "sha512-uu1F/L1o5Y6LzPVSVZXNOoD/KXpJue9aeLRd0sM9uMXfZvzomB0WxVamWb5ue8kA2vVWEmW7EG+A5n3f1kqHKg==",
-      "dev": true,
-      "dependencies": {
-        "html-escaper": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/jest": {
@@ -8343,12 +7936,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/json-parse-better-errors": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
-      "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
-      "dev": true
-    },
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
@@ -8552,30 +8139,6 @@
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true
     },
-    "node_modules/load-json-file": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
-      "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
-      "dev": true,
-      "dependencies": {
-        "graceful-fs": "^4.1.2",
-        "parse-json": "^4.0.0",
-        "pify": "^3.0.0",
-        "strip-bom": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/load-json-file/node_modules/pify": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-      "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/locate-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
@@ -8601,99 +8164,11 @@
       "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
       "dev": true
     },
-    "node_modules/lodash.flattendeep": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
-      "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
-      "dev": true
-    },
     "node_modules/lodash.memoize": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-3.0.4.tgz",
       "integrity": "sha1-LcvSwofLwKVcxCMovQxzYVDVPj8=",
       "dev": true
-    },
-    "node_modules/log-symbols": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.0.0.tgz",
-      "integrity": "sha512-FN8JBzLx6CzeMrB0tg6pqlGU1wCrXW+ZXGH481kfsBqer0hToTIiHdjH4Mq8xJUbvATujKCvaREGWpGUionraA==",
-      "dev": true,
-      "dependencies": {
-        "chalk": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/log-symbols/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/log-symbols/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/log-symbols/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/log-symbols/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
-    },
-    "node_modules/log-symbols/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/log-symbols/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
     },
     "node_modules/lru-cache": {
       "version": "4.1.5",
@@ -8748,24 +8223,6 @@
         "hash-base": "^3.0.0",
         "inherits": "^2.0.1",
         "safe-buffer": "^5.1.2"
-      }
-    },
-    "node_modules/merge-source-map": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/merge-source-map/-/merge-source-map-1.1.0.tgz",
-      "integrity": "sha512-Qkcp7P2ygktpMPh2mCQZaf3jhN6D3Z/qVZHSdWvQ+2Ef5HgRAPBO57A77+ENm0CPx2+1Ce/MYKi3ymqdfuqibw==",
-      "dev": true,
-      "dependencies": {
-        "source-map": "^0.6.1"
-      }
-    },
-    "node_modules/merge-source-map/node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/merge-stream": {
@@ -8863,418 +8320,6 @@
       "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
       "dev": true
     },
-    "node_modules/mocha": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-8.4.0.tgz",
-      "integrity": "sha512-hJaO0mwDXmZS4ghXsvPVriOhsxQ7ofcpQdm8dE+jISUOKopitvnXFQmpRR7jd2K6VBG6E26gU3IAbXXGIbu4sQ==",
-      "dev": true,
-      "dependencies": {
-        "@ungap/promise-all-settled": "1.1.2",
-        "ansi-colors": "4.1.1",
-        "browser-stdout": "1.3.1",
-        "chokidar": "3.5.1",
-        "debug": "4.3.1",
-        "diff": "5.0.0",
-        "escape-string-regexp": "4.0.0",
-        "find-up": "5.0.0",
-        "glob": "7.1.6",
-        "growl": "1.10.5",
-        "he": "1.2.0",
-        "js-yaml": "4.0.0",
-        "log-symbols": "4.0.0",
-        "minimatch": "3.0.4",
-        "ms": "2.1.3",
-        "nanoid": "3.1.20",
-        "serialize-javascript": "5.0.1",
-        "strip-json-comments": "3.1.1",
-        "supports-color": "8.1.1",
-        "which": "2.0.2",
-        "wide-align": "1.1.3",
-        "workerpool": "6.1.0",
-        "yargs": "16.2.0",
-        "yargs-parser": "20.2.4",
-        "yargs-unparser": "2.0.0"
-      },
-      "bin": {
-        "_mocha": "bin/_mocha",
-        "mocha": "bin/mocha"
-      },
-      "engines": {
-        "node": ">= 10.12.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mochajs"
-      }
-    },
-    "node_modules/mocha/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/mocha/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/mocha/node_modules/argparse": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true
-    },
-    "node_modules/mocha/node_modules/chokidar": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.1.tgz",
-      "integrity": "sha512-9+s+Od+W0VJJzawDma/gvBNQqkTiqYTWLuZoyAsivsI4AaWTCzHG06/TMjsf1cYe9Cb97UCEhjz7HvnPk2p/tw==",
-      "dev": true,
-      "dependencies": {
-        "anymatch": "~3.1.1",
-        "braces": "~3.0.2",
-        "glob-parent": "~5.1.0",
-        "is-binary-path": "~2.1.0",
-        "is-glob": "~4.0.1",
-        "normalize-path": "~3.0.0",
-        "readdirp": "~3.5.0"
-      },
-      "engines": {
-        "node": ">= 8.10.0"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.1"
-      }
-    },
-    "node_modules/mocha/node_modules/cliui": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
-      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
-      "dev": true,
-      "dependencies": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.0",
-        "wrap-ansi": "^7.0.0"
-      }
-    },
-    "node_modules/mocha/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/mocha/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
-    },
-    "node_modules/mocha/node_modules/debug": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-      "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
-      "dev": true,
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/mocha/node_modules/debug/node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
-    },
-    "node_modules/mocha/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true
-    },
-    "node_modules/mocha/node_modules/escape-string-regexp": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/mocha/node_modules/find-up": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
-      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
-      "dev": true,
-      "dependencies": {
-        "locate-path": "^6.0.0",
-        "path-exists": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/mocha/node_modules/glob": {
-      "version": "7.1.6",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
-      "dev": true,
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.0.4",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/mocha/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/mocha/node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/mocha/node_modules/js-yaml": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.0.0.tgz",
-      "integrity": "sha512-pqon0s+4ScYUvX30wxQi3PogGFAlUyH0awepWvwkj4jD4v+ova3RiYw8bmA6x2rDrEaj8i/oWKoRxpVNW+Re8Q==",
-      "dev": true,
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
-    "node_modules/mocha/node_modules/locate-path": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
-      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
-      "dev": true,
-      "dependencies": {
-        "p-locate": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/mocha/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true
-    },
-    "node_modules/mocha/node_modules/p-limit": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
-      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-      "dev": true,
-      "dependencies": {
-        "yocto-queue": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/mocha/node_modules/p-locate": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
-      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
-      "dev": true,
-      "dependencies": {
-        "p-limit": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/mocha/node_modules/path-exists": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/mocha/node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/mocha/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/mocha/node_modules/strip-json-comments": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
-      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/mocha/node_modules/supports-color": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/supports-color?sponsor=1"
-      }
-    },
-    "node_modules/mocha/node_modules/which": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
-      "dependencies": {
-        "isexe": "^2.0.0"
-      },
-      "bin": {
-        "node-which": "bin/node-which"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/mocha/node_modules/wrap-ansi": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/mocha/node_modules/y18n": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
-      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/mocha/node_modules/yargs": {
-      "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
-      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
-      "dev": true,
-      "dependencies": {
-        "cliui": "^7.0.2",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.0",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^20.2.2"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/mocha/node_modules/yargs-parser": {
-      "version": "20.2.4",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
-      "integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/module-deps": {
       "version": "6.2.3",
       "resolved": "https://registry.npmjs.org/module-deps/-/module-deps-6.2.3.tgz",
@@ -9359,28 +8404,10 @@
         "node": ">=12.0"
       }
     },
-    "node_modules/nanoid": {
-      "version": "3.1.20",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.20.tgz",
-      "integrity": "sha512-a1cQNyczgKbLX9jwbS/+d7W8fX/RfgYR7lVWwWOGIPNgK2m0MWvrGF6/m4kk6U3QcFMnZf3RIhL0v2Jgh/0Uxw==",
-      "dev": true,
-      "bin": {
-        "nanoid": "bin/nanoid.cjs"
-      },
-      "engines": {
-        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
-      }
-    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
-      "dev": true
-    },
-    "node_modules/nested-error-stacks": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/nested-error-stacks/-/nested-error-stacks-2.1.0.tgz",
-      "integrity": "sha512-AO81vsIO1k1sM4Zrd6Hu7regmJN1NSiAja10gc4bX3F0wd+9rQmcuHQaHVQCYIEC8iFXnE+mavh23GOt7wBgug==",
       "dev": true
     },
     "node_modules/nice-try": {
@@ -9421,18 +8448,6 @@
       "integrity": "sha512-CqyzN6z7Q6aMeF/ktcMVTzhAHCEpf8SOarwpzpf8pNBY2k5/oM34UHldUwp8VKI7uxct2HxSRdJjBaZeESzcxA==",
       "dev": true
     },
-    "node_modules/normalize-package-data": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
-      "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
-      "dev": true,
-      "dependencies": {
-        "hosted-git-info": "^2.1.4",
-        "resolve": "^1.10.0",
-        "semver": "2 || 3 || 4 || 5",
-        "validate-npm-package-license": "^3.0.1"
-      }
-    },
     "node_modules/normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -9461,45 +8476,6 @@
       "dev": true,
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/nyc": {
-      "version": "14.1.1",
-      "resolved": "https://registry.npmjs.org/nyc/-/nyc-14.1.1.tgz",
-      "integrity": "sha512-OI0vm6ZGUnoGZv/tLdZ2esSVzDwUC88SNs+6JoSOMVxA+gKMB8Tk7jBwgemLx4O40lhhvZCVw1C+OYLOBOPXWw==",
-      "dev": true,
-      "dependencies": {
-        "archy": "^1.0.0",
-        "caching-transform": "^3.0.2",
-        "convert-source-map": "^1.6.0",
-        "cp-file": "^6.2.0",
-        "find-cache-dir": "^2.1.0",
-        "find-up": "^3.0.0",
-        "foreground-child": "^1.5.6",
-        "glob": "^7.1.3",
-        "istanbul-lib-coverage": "^2.0.5",
-        "istanbul-lib-hook": "^2.0.7",
-        "istanbul-lib-instrument": "^3.3.0",
-        "istanbul-lib-report": "^2.0.8",
-        "istanbul-lib-source-maps": "^3.0.6",
-        "istanbul-reports": "^2.2.4",
-        "js-yaml": "^3.13.1",
-        "make-dir": "^2.1.0",
-        "merge-source-map": "^1.1.0",
-        "resolve-from": "^4.0.0",
-        "rimraf": "^2.6.3",
-        "signal-exit": "^3.0.2",
-        "spawn-wrap": "^1.4.2",
-        "test-exclude": "^5.2.3",
-        "uuid": "^3.3.2",
-        "yargs": "^13.2.2",
-        "yargs-parser": "^13.0.0"
-      },
-      "bin": {
-        "nyc": "bin/nyc.js"
-      },
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/object-assign": {
@@ -9591,15 +8567,6 @@
       "integrity": "sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc=",
       "dev": true
     },
-    "node_modules/os-homedir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/os-shim": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/os-shim/-/os-shim-0.1.3.tgz",
@@ -9654,21 +8621,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/package-hash": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/package-hash/-/package-hash-3.0.0.tgz",
-      "integrity": "sha512-lOtmukMDVvtkL84rJHI7dpTYq+0rli8N2wlnqUcBuDWCfVhRUfOmnR9SsoHFMLpACvEV60dX7rd0rFaYDZI+FA==",
-      "dev": true,
-      "dependencies": {
-        "graceful-fs": "^4.1.15",
-        "hasha": "^3.0.0",
-        "lodash.flattendeep": "^4.4.0",
-        "release-zalgo": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/pako": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
@@ -9707,19 +8659,6 @@
         "evp_bytestokey": "^1.0.0",
         "pbkdf2": "^3.0.3",
         "safe-buffer": "^5.1.1"
-      }
-    },
-    "node_modules/parse-json": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
-      "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
-      "dev": true,
-      "dependencies": {
-        "error-ex": "^1.3.1",
-        "json-parse-better-errors": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/path-browserify": {
@@ -9774,36 +8713,6 @@
       "dev": true,
       "engines": {
         "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/path-type": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
-      "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
-      "dev": true,
-      "dependencies": {
-        "pify": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/path-type/node_modules/pify": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-      "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/pathval": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
-      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
-      "dev": true,
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/pbkdf2": {
@@ -10402,33 +9311,6 @@
         "safe-buffer": "~5.1.0"
       }
     },
-    "node_modules/read-pkg": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
-      "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
-      "dev": true,
-      "dependencies": {
-        "load-json-file": "^4.0.0",
-        "normalize-package-data": "^2.3.2",
-        "path-type": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/read-pkg-up": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-4.0.0.tgz",
-      "integrity": "sha512-6etQSH7nJGsK0RbG/2TeDzZFa8shjQ1um+SwQQ5cwKy0dhSXdOncEhb1CPpvQG4h7FyOV6EB6YlV0yJvZQNAkA==",
-      "dev": true,
-      "dependencies": {
-        "find-up": "^3.0.0",
-        "read-pkg": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/readable-stream": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.1.0.tgz",
@@ -10468,18 +9350,6 @@
       },
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/readdirp": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.5.0.tgz",
-      "integrity": "sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==",
-      "dev": true,
-      "dependencies": {
-        "picomatch": "^2.2.1"
-      },
-      "engines": {
-        "node": ">=8.10.0"
       }
     },
     "node_modules/regenerate": {
@@ -10574,18 +9444,6 @@
       "integrity": "sha512-Xw5/Zx6iWSCMJUXwXVOjySjH8Xli4hVFL9QQFvkl1qEmFBG94J+QUI9emnoctOCD3285f1jNV+QWV9eDYwIdfQ==",
       "dev": true
     },
-    "node_modules/release-zalgo": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/release-zalgo/-/release-zalgo-1.0.0.tgz",
-      "integrity": "sha1-CXALflB0Mpc5Mw5TXFqQ+2eFFzA=",
-      "dev": true,
-      "dependencies": {
-        "es6-error": "^4.0.1"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -10594,12 +9452,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/require-main-filename": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
-      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
-      "dev": true
     },
     "node_modules/resolve": {
       "version": "1.20.0",
@@ -10755,21 +9607,6 @@
       "bin": {
         "semver": "bin/semver"
       }
-    },
-    "node_modules/serialize-javascript": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-5.0.1.tgz",
-      "integrity": "sha512-SaaNal9imEO737H2c05Og0/8LUXG7EnsZyMa8MzkmuHoELfT6txuj0cMqRj6zfPKnmQ1yasR4PCJc8x+M4JSPA==",
-      "dev": true,
-      "dependencies": {
-        "randombytes": "^2.1.0"
-      }
-    },
-    "node_modules/set-blocking": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
-      "dev": true
     },
     "node_modules/sha.js": {
       "version": "2.4.11",
@@ -10990,52 +9827,6 @@
         "concat-stream": "^1.4.7",
         "os-shim": "^0.1.2"
       }
-    },
-    "node_modules/spawn-wrap": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/spawn-wrap/-/spawn-wrap-1.4.3.tgz",
-      "integrity": "sha512-IgB8md0QW/+tWqcavuFgKYR/qIRvJkRLPJDFaoXtLLUaVcCDK0+HeFTkmQHj3eprcYhc+gOl0aEA1w7qZlYezw==",
-      "dev": true,
-      "dependencies": {
-        "foreground-child": "^1.5.6",
-        "mkdirp": "^0.5.0",
-        "os-homedir": "^1.0.1",
-        "rimraf": "^2.6.2",
-        "signal-exit": "^3.0.2",
-        "which": "^1.3.0"
-      }
-    },
-    "node_modules/spdx-correct": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.1.tgz",
-      "integrity": "sha512-cOYcUWwhCuHCXi49RhFRCyJEK3iPj1Ziz9DpViV3tbZOwXD49QzIN3MpOLJNxh2qwq2lJJZaKMVw9qNi4jTC0w==",
-      "dev": true,
-      "dependencies": {
-        "spdx-expression-parse": "^3.0.0",
-        "spdx-license-ids": "^3.0.0"
-      }
-    },
-    "node_modules/spdx-exceptions": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
-      "integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A==",
-      "dev": true
-    },
-    "node_modules/spdx-expression-parse": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
-      "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
-      "dev": true,
-      "dependencies": {
-        "spdx-exceptions": "^2.1.0",
-        "spdx-license-ids": "^3.0.0"
-      }
-    },
-    "node_modules/spdx-license-ids": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.9.tgz",
-      "integrity": "sha512-Ki212dKK4ogX+xDo4CtOZBVIwhsKBEfsEEcwmJfLQzirgc2jIWdzg40Unxz/HzEUqM1WFzVlQSMF9kZZ2HboLQ==",
-      "dev": true
     },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
@@ -11309,15 +10100,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/strip-bom": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/strip-final-newline": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
@@ -11411,21 +10193,6 @@
       "dev": true,
       "dependencies": {
         "ansi-regex": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/test-exclude": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-5.2.3.tgz",
-      "integrity": "sha512-M+oxtseCFO3EDtAaGH7iiej3CBkzXqFMbzqYAACdzKui4eZA+pq3tZEwChvOdNfa7xxy8BfbmgJSIr43cC/+2g==",
-      "dev": true,
-      "dependencies": {
-        "glob": "^7.1.3",
-        "minimatch": "^3.0.4",
-        "read-pkg-up": "^4.0.0",
-        "require-main-filename": "^2.0.0"
       },
       "engines": {
         "node": ">=6"
@@ -11743,16 +10510,6 @@
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
       "dev": true
     },
-    "node_modules/uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
-      "dev": true,
-      "bin": {
-        "uuid": "bin/uuid"
-      }
-    },
     "node_modules/v8-to-istanbul": {
       "version": "9.1.3",
       "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.1.3.tgz",
@@ -11772,16 +10529,6 @@
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true
-    },
-    "node_modules/validate-npm-package-license": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
-      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
-      "dev": true,
-      "dependencies": {
-        "spdx-correct": "^3.0.0",
-        "spdx-expression-parse": "^3.0.0"
-      }
     },
     "node_modules/vm-browserify": {
       "version": "1.1.2",
@@ -11842,12 +10589,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/which-module": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
-      "dev": true
-    },
     "node_modules/which-typed-array": {
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.7.tgz",
@@ -11868,15 +10609,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/wide-align": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
-      "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
-      "dev": true,
-      "dependencies": {
-        "string-width": "^1.0.2 || 2"
-      }
-    },
     "node_modules/word-wrap": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
@@ -11884,61 +10616,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/workerpool": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.1.0.tgz",
-      "integrity": "sha512-toV7q9rWNYha963Pl/qyeZ6wG+3nnsyvolaNUS8+R5Wtw6qJPTxIlOP1ZSvcGhEJw+l3HMMmtiNo9Gl61G4GVg==",
-      "dev": true
-    },
-    "node_modules/wrap-ansi": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
-      "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^3.2.0",
-        "string-width": "^3.0.0",
-        "strip-ansi": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/wrap-ansi/node_modules/ansi-regex": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-      "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/wrap-ansi/node_modules/string-width": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-      "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-      "dev": true,
-      "dependencies": {
-        "emoji-regex": "^7.0.1",
-        "is-fullwidth-code-point": "^2.0.0",
-        "strip-ansi": "^5.1.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/wrap-ansi/node_modules/strip-ansi": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-      "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-      "dev": true,
-      "dependencies": {
-        "ansi-regex": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/wrappy": {
@@ -11959,17 +10636,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/write-file-atomic": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.3.tgz",
-      "integrity": "sha512-GaETH5wwsX+GcnzhPgKcKjJ6M2Cq3/iZp1WyY/X1CSqrW+jVNM9Y7D8EC2sM4ZG/V8wZlSniJnCKWPmBYAucRQ==",
-      "dev": true,
-      "dependencies": {
-        "graceful-fs": "^4.1.11",
-        "imurmurhash": "^0.1.4",
-        "signal-exit": "^3.0.2"
-      }
-    },
     "node_modules/xmlchars": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
@@ -11985,119 +10651,11 @@
         "node": ">=0.4"
       }
     },
-    "node_modules/y18n": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
-      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
-      "dev": true
-    },
     "node_modules/yallist": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
       "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
       "dev": true
-    },
-    "node_modules/yargs": {
-      "version": "13.3.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
-      "integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
-      "dev": true,
-      "dependencies": {
-        "cliui": "^5.0.0",
-        "find-up": "^3.0.0",
-        "get-caller-file": "^2.0.1",
-        "require-directory": "^2.1.1",
-        "require-main-filename": "^2.0.0",
-        "set-blocking": "^2.0.0",
-        "string-width": "^3.0.0",
-        "which-module": "^2.0.0",
-        "y18n": "^4.0.0",
-        "yargs-parser": "^13.1.2"
-      }
-    },
-    "node_modules/yargs-parser": {
-      "version": "13.1.2",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
-      "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
-      "dev": true,
-      "dependencies": {
-        "camelcase": "^5.0.0",
-        "decamelize": "^1.2.0"
-      }
-    },
-    "node_modules/yargs-unparser": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
-      "integrity": "sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==",
-      "dev": true,
-      "dependencies": {
-        "camelcase": "^6.0.0",
-        "decamelize": "^4.0.0",
-        "flat": "^5.0.2",
-        "is-plain-obj": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/yargs-unparser/node_modules/camelcase": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
-      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/yargs-unparser/node_modules/decamelize": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
-      "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/yargs/node_modules/ansi-regex": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-      "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/yargs/node_modules/string-width": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-      "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-      "dev": true,
-      "dependencies": {
-        "emoji-regex": "^7.0.1",
-        "is-fullwidth-code-point": "^2.0.0",
-        "strip-ansi": "^5.1.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/yargs/node_modules/strip-ansi": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-      "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-      "dev": true,
-      "dependencies": {
-        "ansi-regex": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
@@ -14256,12 +12814,6 @@
       "integrity": "sha512-axdPBuLuEJt0c4yI5OZssC19K2Mq1uKdrfZBzuxLvaztgqUtFYZUNw7lETExPYJR9jdEoIg4mb7RQKRQzOkeGQ==",
       "dev": true
     },
-    "@ungap/promise-all-settled": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
-      "integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
-      "dev": true
-    },
     "abort-controller": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
@@ -14320,12 +12872,6 @@
         "uri-js": "^4.2.2"
       }
     },
-    "ansi-colors": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
-      "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
-      "dev": true
-    },
     "ansi-escapes": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
@@ -14356,21 +12902,6 @@
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
       }
-    },
-    "append-transform": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/append-transform/-/append-transform-1.0.0.tgz",
-      "integrity": "sha512-P009oYkeHyU742iSZJzZZywj4QRJdnTWffaKuJQLablCZ1uz6/cW4yaRgcDaoQ+uwOxxnt0gRUcwfsNP2ri0gw==",
-      "dev": true,
-      "requires": {
-        "default-require-extensions": "^2.0.0"
-      }
-    },
-    "archy": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
-      "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
-      "dev": true
     },
     "argparse": {
       "version": "1.0.10",
@@ -14433,12 +12964,6 @@
           }
         }
       }
-    },
-    "assertion-error": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
-      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
-      "dev": true
     },
     "astral-regex": {
       "version": "1.0.0",
@@ -14680,7 +13205,8 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "bn.js": {
       "version": "5.2.0",
@@ -14735,12 +13261,6 @@
       "requires": {
         "resolve": "^1.17.0"
       }
-    },
-    "browser-stdout": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
-      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
-      "dev": true
     },
     "browserify": {
       "version": "17.0.0",
@@ -14978,18 +13498,6 @@
       "integrity": "sha512-5r2GqsoEb4qMTTN9J+WzXfjov+hjxT+j3u5K+kIVNIwAd99DLCJE9pBIMP1qVeybV6JiijL385Oz0DcYxfbOIg==",
       "dev": true
     },
-    "caching-transform": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/caching-transform/-/caching-transform-3.0.2.tgz",
-      "integrity": "sha512-Mtgcv3lh3U0zRii/6qVgQODdPA4G3zhG+jtbCWj39RXuUFTMzH0vcdMtaJS1jPowd+It2Pqr6y3NJMQqOqCE2w==",
-      "dev": true,
-      "requires": {
-        "hasha": "^3.0.0",
-        "make-dir": "^2.0.0",
-        "package-hash": "^3.0.0",
-        "write-file-atomic": "^2.4.2"
-      }
-    },
     "call-bind": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
@@ -15024,26 +13532,6 @@
       "integrity": "sha512-0CNTVCLZggSh7bc5VkX5WWPWO+cyZbNd07IHIsSXLia/eAq+r836hgk+8BKoEh7949Mda87VUOitx5OddVj64A==",
       "dev": true
     },
-    "chai": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.4.tgz",
-      "integrity": "sha512-yS5H68VYOCtN1cjfwumDSuzn/9c+yza4f3reKXlE5rUg7SFcCEy90gJvydNgOYtblyf4Zi6jIWRnXOgErta0KA==",
-      "dev": true,
-      "requires": {
-        "assertion-error": "^1.1.0",
-        "check-error": "^1.0.2",
-        "deep-eql": "^3.0.1",
-        "get-func-name": "^2.0.0",
-        "pathval": "^1.1.1",
-        "type-detect": "^4.0.5"
-      }
-    },
-    "chai-things": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/chai-things/-/chai-things-0.2.0.tgz",
-      "integrity": "sha1-xVEoN4+bs5nplPAAUhUZhO1uvnA=",
-      "dev": true
-    },
     "chalk": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -15065,12 +13553,6 @@
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
-      "dev": true
-    },
-    "check-error": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
-      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
       "dev": true
     },
     "chokidar": {
@@ -15138,45 +13620,6 @@
       "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.1.tgz",
       "integrity": "sha512-GRMWDxpOB6Dgk2E5Uo+3eEBvtOOlimMmpbFiKuLFnQzYDavtLFY3K5ona41jgN/WdRZtG7utuVSVTL4HbZHGkw==",
       "dev": true
-    },
-    "cliui": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
-      "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
-      "dev": true,
-      "requires": {
-        "string-width": "^3.1.0",
-        "strip-ansi": "^5.2.0",
-        "wrap-ansi": "^5.1.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-          "dev": true
-        },
-        "string-width": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-          "dev": true,
-          "requires": {
-            "emoji-regex": "^7.0.1",
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^5.1.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^4.1.0"
-          }
-        }
-      }
     },
     "clone-deep": {
       "version": "4.0.1",
@@ -15357,19 +13800,6 @@
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
     },
-    "cp-file": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/cp-file/-/cp-file-6.2.0.tgz",
-      "integrity": "sha512-fmvV4caBnofhPe8kOcitBwSn2f39QLjnAnGq3gO9dfd75mUytzKNZB1hde6QHunW2Rt+OwuBOMc3i1tNElbszA==",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "^4.1.2",
-        "make-dir": "^2.0.0",
-        "nested-error-stacks": "^2.0.0",
-        "pify": "^4.0.1",
-        "safe-buffer": "^5.0.1"
-      }
-    },
     "create-ecdh": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.4.tgz",
@@ -15537,27 +13967,12 @@
         "ms": "2.1.2"
       }
     },
-    "decamelize": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
-      "dev": true
-    },
     "dedent": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.5.1.tgz",
       "integrity": "sha512-+LxW+KLWxu3HW3M2w2ympwtqPrqYRzU8fqi6Fhd18fBALe15blJPI/I4+UHveMVG6lJqB4JNd4UG0S5cnVHwIg==",
       "dev": true,
       "requires": {}
-    },
-    "deep-eql": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
-      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
-      "dev": true,
-      "requires": {
-        "type-detect": "^4.0.0"
-      }
     },
     "deep-is": {
       "version": "0.1.3",
@@ -15570,15 +13985,6 @@
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
       "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
       "dev": true
-    },
-    "default-require-extensions": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-2.0.0.tgz",
-      "integrity": "sha1-9fj7sYp9bVCyH2QfZJ67Uiz+JPc=",
-      "dev": true,
-      "requires": {
-        "strip-bom": "^3.0.0"
-      }
     },
     "define-properties": {
       "version": "1.1.3",
@@ -15633,12 +14039,6 @@
         "defined": "^1.0.0",
         "minimist": "^1.1.1"
       }
-    },
-    "diff": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
-      "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
-      "dev": true
     },
     "diff-sequences": {
       "version": "29.6.3",
@@ -15822,12 +14222,6 @@
         "is-date-object": "^1.0.1",
         "is-symbol": "^1.0.2"
       }
-    },
-    "es6-error": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
-      "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
-      "dev": true
     },
     "escalade": {
       "version": "3.1.1",
@@ -16185,12 +14579,6 @@
         "locate-path": "^3.0.0"
       }
     },
-    "flat": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
-      "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
-      "dev": true
-    },
     "flat-cache": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
@@ -16213,28 +14601,6 @@
       "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
       "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
       "dev": true
-    },
-    "foreground-child": {
-      "version": "1.5.6",
-      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-1.5.6.tgz",
-      "integrity": "sha1-T9ca0t/elnibmApcCilZN8svXOk=",
-      "dev": true,
-      "requires": {
-        "cross-spawn": "^4",
-        "signal-exit": "^3.0.0"
-      },
-      "dependencies": {
-        "cross-spawn": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
-          "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^4.0.1",
-            "which": "^1.2.9"
-          }
-        }
-      }
     },
     "fs-extra": {
       "version": "10.0.0",
@@ -16296,12 +14662,6 @@
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
       "dev": true
     },
-    "get-func-name": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
-      "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
-      "dev": true
-    },
     "get-intrinsic": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
@@ -16354,6 +14714,7 @@
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
       "dev": true,
+      "optional": true,
       "requires": {
         "is-glob": "^4.0.1"
       }
@@ -16368,12 +14729,6 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "dev": true
-    },
-    "growl": {
-      "version": "1.10.5",
-      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
-      "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
       "dev": true
     },
     "has": {
@@ -16446,21 +14801,6 @@
         "minimalistic-assert": "^1.0.1"
       }
     },
-    "hasha": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/hasha/-/hasha-3.0.0.tgz",
-      "integrity": "sha1-UqMvq4Vp1BymmmH/GiFPjrfIvTk=",
-      "dev": true,
-      "requires": {
-        "is-stream": "^1.0.1"
-      }
-    },
-    "he": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
-      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
-      "dev": true
-    },
     "highlight.js": {
       "version": "11.0.1",
       "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.0.1.tgz",
@@ -16477,12 +14817,6 @@
         "minimalistic-assert": "^1.0.0",
         "minimalistic-crypto-utils": "^1.0.1"
       }
-    },
-    "hosted-git-info": {
-      "version": "2.8.9",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
-      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
-      "dev": true
     },
     "html-escaper": {
       "version": "2.0.2",
@@ -16725,6 +15059,7 @@
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
       "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
       "dev": true,
+      "optional": true,
       "requires": {
         "binary-extensions": "^2.0.0"
       }
@@ -16769,7 +15104,8 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "is-fullwidth-code-point": {
       "version": "2.0.0",
@@ -16797,6 +15133,7 @@
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
       "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
       "dev": true,
+      "optional": true,
       "requires": {
         "is-extglob": "^2.1.1"
       }
@@ -16817,12 +15154,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.5.tgz",
       "integrity": "sha512-RU0lI/n95pMoUKu9v1BZP5MBcZuNSVJkMkAG2dJqC4z2GlkGUNeH68SuHuBKBD/XFe+LHZ+f9BKkLET60Niedw==",
-      "dev": true
-    },
-    "is-plain-obj": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
-      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
       "dev": true
     },
     "is-plain-object": {
@@ -16848,12 +15179,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.1.tgz",
       "integrity": "sha512-IU0NmyknYZN0rChcKhRO1X8LYz5Isj/Fsqh8NJOSf+N/hCOTwy29F32Ik7a+QszE63IdvmwdTPDd6cZ5pg4cwA==",
-      "dev": true
-    },
-    "is-stream": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
       "dev": true
     },
     "is-string": {
@@ -16919,96 +15244,6 @@
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
       "dev": true
-    },
-    "istanbul-lib-coverage": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.5.tgz",
-      "integrity": "sha512-8aXznuEPCJvGnMSRft4udDRDtb1V3pkQkMMI5LI+6HuQz5oQ4J2UFn1H82raA3qJtyOLkkwVqICBQkjnGtn5mA==",
-      "dev": true
-    },
-    "istanbul-lib-hook": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-2.0.7.tgz",
-      "integrity": "sha512-vrRztU9VRRFDyC+aklfLoeXyNdTfga2EI3udDGn4cZ6fpSXpHLV9X6CHvfoMCPtggg8zvDDmC4b9xfu0z6/llA==",
-      "dev": true,
-      "requires": {
-        "append-transform": "^1.0.0"
-      }
-    },
-    "istanbul-lib-instrument": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-3.3.0.tgz",
-      "integrity": "sha512-5nnIN4vo5xQZHdXno/YDXJ0G+I3dAm4XgzfSVTPLQpj/zAV2dV6Juy0yaf10/zrJOJeHoN3fraFe+XRq2bFVZA==",
-      "dev": true,
-      "requires": {
-        "@babel/generator": "^7.4.0",
-        "@babel/parser": "^7.4.3",
-        "@babel/template": "^7.4.0",
-        "@babel/traverse": "^7.4.3",
-        "@babel/types": "^7.4.0",
-        "istanbul-lib-coverage": "^2.0.5",
-        "semver": "^6.0.0"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-          "dev": true
-        }
-      }
-    },
-    "istanbul-lib-report": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-2.0.8.tgz",
-      "integrity": "sha512-fHBeG573EIihhAblwgxrSenp0Dby6tJMFR/HvlerBsrCTD5bkUuoNtn3gVh29ZCS824cGGBPn7Sg7cNk+2xUsQ==",
-      "dev": true,
-      "requires": {
-        "istanbul-lib-coverage": "^2.0.5",
-        "make-dir": "^2.1.0",
-        "supports-color": "^6.1.0"
-      },
-      "dependencies": {
-        "supports-color": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^3.0.0"
-          }
-        }
-      }
-    },
-    "istanbul-lib-source-maps": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-3.0.6.tgz",
-      "integrity": "sha512-R47KzMtDJH6X4/YW9XTx+jrLnZnscW4VpNN+1PViSYTejLVPWv7oov+Duf8YQSPyVRUvueQqz1TcsC6mooZTXw==",
-      "dev": true,
-      "requires": {
-        "debug": "^4.1.1",
-        "istanbul-lib-coverage": "^2.0.5",
-        "make-dir": "^2.1.0",
-        "rimraf": "^2.6.3",
-        "source-map": "^0.6.1"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
-        }
-      }
-    },
-    "istanbul-reports": {
-      "version": "2.2.7",
-      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-2.2.7.tgz",
-      "integrity": "sha512-uu1F/L1o5Y6LzPVSVZXNOoD/KXpJue9aeLRd0sM9uMXfZvzomB0WxVamWb5ue8kA2vVWEmW7EG+A5n3f1kqHKg==",
-      "dev": true,
-      "requires": {
-        "html-escaper": "^2.0.0"
-      }
     },
     "jest": {
       "version": "29.7.0",
@@ -18395,12 +16630,6 @@
       "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
       "dev": true
     },
-    "json-parse-better-errors": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
-      "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
-      "dev": true
-    },
     "json-parse-even-better-errors": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
@@ -18557,26 +16786,6 @@
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true
     },
-    "load-json-file": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
-      "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "^4.1.2",
-        "parse-json": "^4.0.0",
-        "pify": "^3.0.0",
-        "strip-bom": "^3.0.0"
-      },
-      "dependencies": {
-        "pify": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-          "dev": true
-        }
-      }
-    },
     "locate-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
@@ -18599,77 +16808,11 @@
       "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
       "dev": true
     },
-    "lodash.flattendeep": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
-      "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
-      "dev": true
-    },
     "lodash.memoize": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-3.0.4.tgz",
       "integrity": "sha1-LcvSwofLwKVcxCMovQxzYVDVPj8=",
       "dev": true
-    },
-    "log-symbols": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.0.0.tgz",
-      "integrity": "sha512-FN8JBzLx6CzeMrB0tg6pqlGU1wCrXW+ZXGH481kfsBqer0hToTIiHdjH4Mq8xJUbvATujKCvaREGWpGUionraA==",
-      "dev": true,
-      "requires": {
-        "chalk": "^4.0.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
-        "chalk": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "dev": true,
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "dev": true
-        },
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        }
-      }
     },
     "lru-cache": {
       "version": "4.1.5",
@@ -18715,23 +16858,6 @@
         "hash-base": "^3.0.0",
         "inherits": "^2.0.1",
         "safe-buffer": "^5.1.2"
-      }
-    },
-    "merge-source-map": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/merge-source-map/-/merge-source-map-1.1.0.tgz",
-      "integrity": "sha512-Qkcp7P2ygktpMPh2mCQZaf3jhN6D3Z/qVZHSdWvQ+2Ef5HgRAPBO57A77+ENm0CPx2+1Ce/MYKi3ymqdfuqibw==",
-      "dev": true,
-      "requires": {
-        "source-map": "^0.6.1"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
-        }
       }
     },
     "merge-stream": {
@@ -18816,299 +16942,6 @@
       "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
       "dev": true
     },
-    "mocha": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-8.4.0.tgz",
-      "integrity": "sha512-hJaO0mwDXmZS4ghXsvPVriOhsxQ7ofcpQdm8dE+jISUOKopitvnXFQmpRR7jd2K6VBG6E26gU3IAbXXGIbu4sQ==",
-      "dev": true,
-      "requires": {
-        "@ungap/promise-all-settled": "1.1.2",
-        "ansi-colors": "4.1.1",
-        "browser-stdout": "1.3.1",
-        "chokidar": "3.5.1",
-        "debug": "4.3.1",
-        "diff": "5.0.0",
-        "escape-string-regexp": "4.0.0",
-        "find-up": "5.0.0",
-        "glob": "7.1.6",
-        "growl": "1.10.5",
-        "he": "1.2.0",
-        "js-yaml": "4.0.0",
-        "log-symbols": "4.0.0",
-        "minimatch": "3.0.4",
-        "ms": "2.1.3",
-        "nanoid": "3.1.20",
-        "serialize-javascript": "5.0.1",
-        "strip-json-comments": "3.1.1",
-        "supports-color": "8.1.1",
-        "which": "2.0.2",
-        "wide-align": "1.1.3",
-        "workerpool": "6.1.0",
-        "yargs": "16.2.0",
-        "yargs-parser": "20.2.4",
-        "yargs-unparser": "2.0.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-          "dev": true
-        },
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
-        "argparse": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-          "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-          "dev": true
-        },
-        "chokidar": {
-          "version": "3.5.1",
-          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.1.tgz",
-          "integrity": "sha512-9+s+Od+W0VJJzawDma/gvBNQqkTiqYTWLuZoyAsivsI4AaWTCzHG06/TMjsf1cYe9Cb97UCEhjz7HvnPk2p/tw==",
-          "dev": true,
-          "requires": {
-            "anymatch": "~3.1.1",
-            "braces": "~3.0.2",
-            "fsevents": "~2.3.1",
-            "glob-parent": "~5.1.0",
-            "is-binary-path": "~2.1.0",
-            "is-glob": "~4.0.1",
-            "normalize-path": "~3.0.0",
-            "readdirp": "~3.5.0"
-          }
-        },
-        "cliui": {
-          "version": "7.0.4",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
-          "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
-          "dev": true,
-          "requires": {
-            "string-width": "^4.2.0",
-            "strip-ansi": "^6.0.0",
-            "wrap-ansi": "^7.0.0"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "dev": true,
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "dev": true
-        },
-        "debug": {
-          "version": "4.3.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
-          "dev": true,
-          "requires": {
-            "ms": "2.1.2"
-          },
-          "dependencies": {
-            "ms": {
-              "version": "2.1.2",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-              "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-              "dev": true
-            }
-          }
-        },
-        "emoji-regex": {
-          "version": "8.0.0",
-          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-          "dev": true
-        },
-        "escape-string-regexp": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-          "dev": true
-        },
-        "find-up": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
-          "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
-          "dev": true,
-          "requires": {
-            "locate-path": "^6.0.0",
-            "path-exists": "^4.0.0"
-          }
-        },
-        "glob": {
-          "version": "7.1.6",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-          "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
-          "dev": true,
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        },
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-          "dev": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-          "dev": true
-        },
-        "js-yaml": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.0.0.tgz",
-          "integrity": "sha512-pqon0s+4ScYUvX30wxQi3PogGFAlUyH0awepWvwkj4jD4v+ova3RiYw8bmA6x2rDrEaj8i/oWKoRxpVNW+Re8Q==",
-          "dev": true,
-          "requires": {
-            "argparse": "^2.0.1"
-          }
-        },
-        "locate-path": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
-          "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
-          "dev": true,
-          "requires": {
-            "p-locate": "^5.0.0"
-          }
-        },
-        "ms": {
-          "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-          "dev": true
-        },
-        "p-limit": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
-          "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-          "dev": true,
-          "requires": {
-            "yocto-queue": "^0.1.0"
-          }
-        },
-        "p-locate": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
-          "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
-          "dev": true,
-          "requires": {
-            "p-limit": "^3.0.2"
-          }
-        },
-        "path-exists": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-          "dev": true
-        },
-        "string-width": {
-          "version": "4.2.3",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-          "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-          "dev": true,
-          "requires": {
-            "emoji-regex": "^8.0.0",
-            "is-fullwidth-code-point": "^3.0.0",
-            "strip-ansi": "^6.0.1"
-          }
-        },
-        "strip-ansi": {
-          "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^5.0.1"
-          }
-        },
-        "strip-json-comments": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
-          "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "8.1.1",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-          "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        },
-        "which": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-          "dev": true,
-          "requires": {
-            "isexe": "^2.0.0"
-          }
-        },
-        "wrap-ansi": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-          "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.0.0",
-            "string-width": "^4.1.0",
-            "strip-ansi": "^6.0.0"
-          }
-        },
-        "y18n": {
-          "version": "5.0.8",
-          "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
-          "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-          "dev": true
-        },
-        "yargs": {
-          "version": "16.2.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
-          "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
-          "dev": true,
-          "requires": {
-            "cliui": "^7.0.2",
-            "escalade": "^3.1.1",
-            "get-caller-file": "^2.0.5",
-            "require-directory": "^2.1.1",
-            "string-width": "^4.2.0",
-            "y18n": "^5.0.5",
-            "yargs-parser": "^20.2.2"
-          }
-        },
-        "yargs-parser": {
-          "version": "20.2.4",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
-          "integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==",
-          "dev": true
-        }
-      }
-    },
     "module-deps": {
       "version": "6.2.3",
       "resolved": "https://registry.npmjs.org/module-deps/-/module-deps-6.2.3.tgz",
@@ -19186,22 +17019,10 @@
         "readable-stream": "^4.0.0"
       }
     },
-    "nanoid": {
-      "version": "3.1.20",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.20.tgz",
-      "integrity": "sha512-a1cQNyczgKbLX9jwbS/+d7W8fX/RfgYR7lVWwWOGIPNgK2m0MWvrGF6/m4kk6U3QcFMnZf3RIhL0v2Jgh/0Uxw==",
-      "dev": true
-    },
     "natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
-      "dev": true
-    },
-    "nested-error-stacks": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/nested-error-stacks/-/nested-error-stacks-2.1.0.tgz",
-      "integrity": "sha512-AO81vsIO1k1sM4Zrd6Hu7regmJN1NSiAja10gc4bX3F0wd+9rQmcuHQaHVQCYIEC8iFXnE+mavh23GOt7wBgug==",
       "dev": true
     },
     "nice-try": {
@@ -19231,18 +17052,6 @@
       "integrity": "sha512-CqyzN6z7Q6aMeF/ktcMVTzhAHCEpf8SOarwpzpf8pNBY2k5/oM34UHldUwp8VKI7uxct2HxSRdJjBaZeESzcxA==",
       "dev": true
     },
-    "normalize-package-data": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
-      "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
-      "dev": true,
-      "requires": {
-        "hosted-git-info": "^2.1.4",
-        "resolve": "^1.10.0",
-        "semver": "2 || 3 || 4 || 5",
-        "validate-npm-package-license": "^3.0.1"
-      }
-    },
     "normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -19264,39 +17073,6 @@
           "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
           "dev": true
         }
-      }
-    },
-    "nyc": {
-      "version": "14.1.1",
-      "resolved": "https://registry.npmjs.org/nyc/-/nyc-14.1.1.tgz",
-      "integrity": "sha512-OI0vm6ZGUnoGZv/tLdZ2esSVzDwUC88SNs+6JoSOMVxA+gKMB8Tk7jBwgemLx4O40lhhvZCVw1C+OYLOBOPXWw==",
-      "dev": true,
-      "requires": {
-        "archy": "^1.0.0",
-        "caching-transform": "^3.0.2",
-        "convert-source-map": "^1.6.0",
-        "cp-file": "^6.2.0",
-        "find-cache-dir": "^2.1.0",
-        "find-up": "^3.0.0",
-        "foreground-child": "^1.5.6",
-        "glob": "^7.1.3",
-        "istanbul-lib-coverage": "^2.0.5",
-        "istanbul-lib-hook": "^2.0.7",
-        "istanbul-lib-instrument": "^3.3.0",
-        "istanbul-lib-report": "^2.0.8",
-        "istanbul-lib-source-maps": "^3.0.6",
-        "istanbul-reports": "^2.2.4",
-        "js-yaml": "^3.13.1",
-        "make-dir": "^2.1.0",
-        "merge-source-map": "^1.1.0",
-        "resolve-from": "^4.0.0",
-        "rimraf": "^2.6.3",
-        "signal-exit": "^3.0.2",
-        "spawn-wrap": "^1.4.2",
-        "test-exclude": "^5.2.3",
-        "uuid": "^3.3.2",
-        "yargs": "^13.2.2",
-        "yargs-parser": "^13.0.0"
       }
     },
     "object-assign": {
@@ -19367,12 +17143,6 @@
       "integrity": "sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc=",
       "dev": true
     },
-    "os-homedir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
-      "dev": true
-    },
     "os-shim": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/os-shim/-/os-shim-0.1.3.tgz",
@@ -19409,18 +17179,6 @@
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
       "dev": true
     },
-    "package-hash": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/package-hash/-/package-hash-3.0.0.tgz",
-      "integrity": "sha512-lOtmukMDVvtkL84rJHI7dpTYq+0rli8N2wlnqUcBuDWCfVhRUfOmnR9SsoHFMLpACvEV60dX7rd0rFaYDZI+FA==",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "^4.1.15",
-        "hasha": "^3.0.0",
-        "lodash.flattendeep": "^4.4.0",
-        "release-zalgo": "^1.0.0"
-      }
-    },
     "pako": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
@@ -19456,16 +17214,6 @@
         "evp_bytestokey": "^1.0.0",
         "pbkdf2": "^3.0.3",
         "safe-buffer": "^5.1.1"
-      }
-    },
-    "parse-json": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
-      "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
-      "dev": true,
-      "requires": {
-        "error-ex": "^1.3.1",
-        "json-parse-better-errors": "^1.0.1"
       }
     },
     "path-browserify": {
@@ -19508,29 +17256,6 @@
       "version": "0.11.15",
       "resolved": "https://registry.npmjs.org/path-platform/-/path-platform-0.11.15.tgz",
       "integrity": "sha1-6GQhf3TDaFDwhSt43Hv31KVyG/I=",
-      "dev": true
-    },
-    "path-type": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
-      "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
-      "dev": true,
-      "requires": {
-        "pify": "^3.0.0"
-      },
-      "dependencies": {
-        "pify": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-          "dev": true
-        }
-      }
-    },
-    "pathval": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
-      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
       "dev": true
     },
     "pbkdf2": {
@@ -20014,27 +17739,6 @@
         }
       }
     },
-    "read-pkg": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
-      "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
-      "dev": true,
-      "requires": {
-        "load-json-file": "^4.0.0",
-        "normalize-package-data": "^2.3.2",
-        "path-type": "^3.0.0"
-      }
-    },
-    "read-pkg-up": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-4.0.0.tgz",
-      "integrity": "sha512-6etQSH7nJGsK0RbG/2TeDzZFa8shjQ1um+SwQQ5cwKy0dhSXdOncEhb1CPpvQG4h7FyOV6EB6YlV0yJvZQNAkA==",
-      "dev": true,
-      "requires": {
-        "find-up": "^3.0.0",
-        "read-pkg": "^3.0.0"
-      }
-    },
     "readable-stream": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.1.0.tgz",
@@ -20063,15 +17767,6 @@
             "util-deprecate": "^1.0.1"
           }
         }
-      }
-    },
-    "readdirp": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.5.0.tgz",
-      "integrity": "sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==",
-      "dev": true,
-      "requires": {
-        "picomatch": "^2.2.1"
       }
     },
     "regenerate": {
@@ -20153,25 +17848,10 @@
       "integrity": "sha512-Xw5/Zx6iWSCMJUXwXVOjySjH8Xli4hVFL9QQFvkl1qEmFBG94J+QUI9emnoctOCD3285f1jNV+QWV9eDYwIdfQ==",
       "dev": true
     },
-    "release-zalgo": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/release-zalgo/-/release-zalgo-1.0.0.tgz",
-      "integrity": "sha1-CXALflB0Mpc5Mw5TXFqQ+2eFFzA=",
-      "dev": true,
-      "requires": {
-        "es6-error": "^4.0.1"
-      }
-    },
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
-      "dev": true
-    },
-    "require-main-filename": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
-      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
       "dev": true
     },
     "resolve": {
@@ -20282,21 +17962,6 @@
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
       "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-      "dev": true
-    },
-    "serialize-javascript": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-5.0.1.tgz",
-      "integrity": "sha512-SaaNal9imEO737H2c05Og0/8LUXG7EnsZyMa8MzkmuHoELfT6txuj0cMqRj6zfPKnmQ1yasR4PCJc8x+M4JSPA==",
-      "dev": true,
-      "requires": {
-        "randombytes": "^2.1.0"
-      }
-    },
-    "set-blocking": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
       "dev": true
     },
     "sha.js": {
@@ -20466,52 +18131,6 @@
         "concat-stream": "^1.4.7",
         "os-shim": "^0.1.2"
       }
-    },
-    "spawn-wrap": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/spawn-wrap/-/spawn-wrap-1.4.3.tgz",
-      "integrity": "sha512-IgB8md0QW/+tWqcavuFgKYR/qIRvJkRLPJDFaoXtLLUaVcCDK0+HeFTkmQHj3eprcYhc+gOl0aEA1w7qZlYezw==",
-      "dev": true,
-      "requires": {
-        "foreground-child": "^1.5.6",
-        "mkdirp": "^0.5.0",
-        "os-homedir": "^1.0.1",
-        "rimraf": "^2.6.2",
-        "signal-exit": "^3.0.2",
-        "which": "^1.3.0"
-      }
-    },
-    "spdx-correct": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.1.tgz",
-      "integrity": "sha512-cOYcUWwhCuHCXi49RhFRCyJEK3iPj1Ziz9DpViV3tbZOwXD49QzIN3MpOLJNxh2qwq2lJJZaKMVw9qNi4jTC0w==",
-      "dev": true,
-      "requires": {
-        "spdx-expression-parse": "^3.0.0",
-        "spdx-license-ids": "^3.0.0"
-      }
-    },
-    "spdx-exceptions": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
-      "integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A==",
-      "dev": true
-    },
-    "spdx-expression-parse": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
-      "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
-      "dev": true,
-      "requires": {
-        "spdx-exceptions": "^2.1.0",
-        "spdx-license-ids": "^3.0.0"
-      }
-    },
-    "spdx-license-ids": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.9.tgz",
-      "integrity": "sha512-Ki212dKK4ogX+xDo4CtOZBVIwhsKBEfsEEcwmJfLQzirgc2jIWdzg40Unxz/HzEUqM1WFzVlQSMF9kZZ2HboLQ==",
-      "dev": true
     },
     "sprintf-js": {
       "version": "1.0.3",
@@ -20764,12 +18383,6 @@
         "ansi-regex": "^3.0.0"
       }
     },
-    "strip-bom": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
-      "dev": true
-    },
     "strip-final-newline": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
@@ -20847,18 +18460,6 @@
             "ansi-regex": "^4.1.0"
           }
         }
-      }
-    },
-    "test-exclude": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-5.2.3.tgz",
-      "integrity": "sha512-M+oxtseCFO3EDtAaGH7iiej3CBkzXqFMbzqYAACdzKui4eZA+pq3tZEwChvOdNfa7xxy8BfbmgJSIr43cC/+2g==",
-      "dev": true,
-      "requires": {
-        "glob": "^7.1.3",
-        "minimatch": "^3.0.4",
-        "read-pkg-up": "^4.0.0",
-        "require-main-filename": "^2.0.0"
       }
     },
     "text-table": {
@@ -21123,12 +18724,6 @@
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
       "dev": true
     },
-    "uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-      "dev": true
-    },
     "v8-to-istanbul": {
       "version": "9.1.3",
       "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.1.3.tgz",
@@ -21146,16 +18741,6 @@
           "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
           "dev": true
         }
-      }
-    },
-    "validate-npm-package-license": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
-      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
-      "dev": true,
-      "requires": {
-        "spdx-correct": "^3.0.0",
-        "spdx-expression-parse": "^3.0.0"
       }
     },
     "vm-browserify": {
@@ -21211,12 +18796,6 @@
         "is-symbol": "^1.0.3"
       }
     },
-    "which-module": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
-      "dev": true
-    },
     "which-typed-array": {
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.7.tgz",
@@ -21231,65 +18810,11 @@
         "is-typed-array": "^1.1.7"
       }
     },
-    "wide-align": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
-      "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
-      "dev": true,
-      "requires": {
-        "string-width": "^1.0.2 || 2"
-      }
-    },
     "word-wrap": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
       "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
       "dev": true
-    },
-    "workerpool": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.1.0.tgz",
-      "integrity": "sha512-toV7q9rWNYha963Pl/qyeZ6wG+3nnsyvolaNUS8+R5Wtw6qJPTxIlOP1ZSvcGhEJw+l3HMMmtiNo9Gl61G4GVg==",
-      "dev": true
-    },
-    "wrap-ansi": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
-      "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
-      "dev": true,
-      "requires": {
-        "ansi-styles": "^3.2.0",
-        "string-width": "^3.0.0",
-        "strip-ansi": "^5.0.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-          "dev": true
-        },
-        "string-width": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-          "dev": true,
-          "requires": {
-            "emoji-regex": "^7.0.1",
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^5.1.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^4.1.0"
-          }
-        }
-      }
     },
     "wrappy": {
       "version": "1.0.2",
@@ -21306,17 +18831,6 @@
         "mkdirp": "^0.5.1"
       }
     },
-    "write-file-atomic": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.3.tgz",
-      "integrity": "sha512-GaETH5wwsX+GcnzhPgKcKjJ6M2Cq3/iZp1WyY/X1CSqrW+jVNM9Y7D8EC2sM4ZG/V8wZlSniJnCKWPmBYAucRQ==",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "^4.1.11",
-        "imurmurhash": "^0.1.4",
-        "signal-exit": "^3.0.2"
-      }
-    },
     "xmlchars": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
@@ -21329,99 +18843,11 @@
       "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
       "dev": true
     },
-    "y18n": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
-      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
-      "dev": true
-    },
     "yallist": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
       "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
       "dev": true
-    },
-    "yargs": {
-      "version": "13.3.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
-      "integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
-      "dev": true,
-      "requires": {
-        "cliui": "^5.0.0",
-        "find-up": "^3.0.0",
-        "get-caller-file": "^2.0.1",
-        "require-directory": "^2.1.1",
-        "require-main-filename": "^2.0.0",
-        "set-blocking": "^2.0.0",
-        "string-width": "^3.0.0",
-        "which-module": "^2.0.0",
-        "y18n": "^4.0.0",
-        "yargs-parser": "^13.1.2"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-          "dev": true
-        },
-        "string-width": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-          "dev": true,
-          "requires": {
-            "emoji-regex": "^7.0.1",
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^5.1.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^4.1.0"
-          }
-        }
-      }
-    },
-    "yargs-parser": {
-      "version": "13.1.2",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
-      "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
-      "dev": true,
-      "requires": {
-        "camelcase": "^5.0.0",
-        "decamelize": "^1.2.0"
-      }
-    },
-    "yargs-unparser": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
-      "integrity": "sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==",
-      "dev": true,
-      "requires": {
-        "camelcase": "^6.0.0",
-        "decamelize": "^4.0.0",
-        "flat": "^5.0.2",
-        "is-plain-obj": "^2.1.0"
-      },
-      "dependencies": {
-        "camelcase": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
-          "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
-          "dev": true
-        },
-        "decamelize": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
-          "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
-          "dev": true
-        }
-      }
     },
     "yocto-queue": {
       "version": "0.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "colors": "^1.1.2",
         "docco": "^0.8.0",
         "eslint": "^5.14.1",
+        "jest": "^29.7.0",
         "mocha": "^8.0.0",
         "nyc": "^14.1.1",
         "pre-commit": "^1.2.2",
@@ -116,29 +117,6 @@
         "type": "opencollective",
         "url": "https://opencollective.com/babel"
       }
-    },
-    "node_modules/@babel/core/node_modules/debug": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-      "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
-      "dev": true,
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@babel/core/node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
     },
     "node_modules/@babel/core/node_modules/semver": {
       "version": "6.3.0",
@@ -270,29 +248,6 @@
         "@babel/core": "^7.4.0-0"
       }
     },
-    "node_modules/@babel/helper-define-polyfill-provider/node_modules/debug": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-      "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
-      "dev": true,
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@babel/helper-define-polyfill-provider/node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
-    },
     "node_modules/@babel/helper-define-polyfill-provider/node_modules/semver": {
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
@@ -408,9 +363,9 @@
       }
     },
     "node_modules/@babel/helper-plugin-utils": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.14.5.tgz",
-      "integrity": "sha512-/37qQCE3K0vvZKwoK4XU/irIJQdIfCJuhU5eKnNxpFDsOkgFaUAwbv+RYw6eYgsC0E4hS7r5KqGULUogqui0fQ==",
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.22.5.tgz",
+      "integrity": "sha512-uLls06UVKgFG9QD4OeFYLEGteMIAa5kpTPcFL28yuCIIzsf6ZyKZMllKVOCZFhiZ5ptnwX4mtKdWCBE/uT4amg==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
@@ -481,10 +436,19 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.22.5.tgz",
+      "integrity": "sha512-mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.15.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz",
-      "integrity": "sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==",
+      "version": "7.22.20",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
+      "integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
@@ -543,9 +507,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.16.2",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.16.2.tgz",
-      "integrity": "sha512-RUVpT0G2h6rOZwqLDTrKk7ksNv7YpAilTnYe1/Q+eDjxEceRMKVWbCsX7t8h6C1qCFi/1Y8WZjcEPBAFG27GPw==",
+      "version": "7.23.0",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.0.tgz",
+      "integrity": "sha512-vvPKKdMemU85V9WE/l5wZEmImpCtLqbnTvqDS2U1fJ96KrxoW7KrXhNsNCblQlg8Ck4b85yxdTyelsMUgFUXiw==",
       "dev": true,
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -846,6 +810,18 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/plugin-syntax-bigint": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-bigint/-/plugin-syntax-bigint-7.8.3.tgz",
+      "integrity": "sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
     "node_modules/@babel/plugin-syntax-class-properties": {
       "version": "7.12.13",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.12.13.tgz",
@@ -897,6 +873,18 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/plugin-syntax-import-meta": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.10.4.tgz",
+      "integrity": "sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
     "node_modules/@babel/plugin-syntax-json-strings": {
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz",
@@ -904,6 +892,21 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-jsx": {
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.22.5.tgz",
+      "integrity": "sha512-gvyP4hZrgrs/wWMaocvxZ44Hw0b3W8Pe+cMxc8V1ULQ07oh8VNbIRaoD1LRZVTvD+0nieDKjfgKg89sD7rrKrg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.22.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
@@ -1003,6 +1006,21 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-typescript": {
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.22.5.tgz",
+      "integrity": "sha512-1mS2o03i7t1c6VzH6fdQ3OA8tcEIxwG18zIPRp+UY1Ihv6W+XZzBCVxExF9upussPXJ0xE9XRHwMoNs1ep/nRQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.22.5"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1693,41 +1711,25 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/traverse/node_modules/debug": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-      "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
-      "dev": true,
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@babel/traverse/node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
-    },
     "node_modules/@babel/types": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.16.0.tgz",
-      "integrity": "sha512-PJgg/k3SdLsGb3hhisFvtLOw5ts113klrpLuIPtCJIU+BB24fqq6lf8RWqKJEjzqXR9AEH1rIb5XTqwBHB+kQg==",
+      "version": "7.23.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.0.tgz",
+      "integrity": "sha512-0oIyUfKoI3mSqMvsxBdclDwxXKXAUA8v/apZbc+iSyARYou1o8ZGDxbUYyLFoW2arqS2jDGqJuZvv1d/io1axg==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.15.7",
+        "@babel/helper-string-parser": "^7.22.5",
+        "@babel/helper-validator-identifier": "^7.22.20",
         "to-fast-properties": "^2.0.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
+      "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
+      "dev": true
     },
     "node_modules/@bergos/jsonparse": {
       "version": "1.4.1",
@@ -1763,6 +1765,983 @@
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
+      "integrity": "sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==",
+      "dev": true,
+      "dependencies": {
+        "camelcase": "^5.3.1",
+        "find-up": "^4.1.0",
+        "get-package-type": "^0.1.0",
+        "js-yaml": "^3.13.1",
+        "resolve-from": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dev": true,
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dev": true,
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dev": true,
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
+      "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jest/console": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/console/-/console-29.7.0.tgz",
+      "integrity": "sha512-5Ni4CU7XHQi32IJ398EEP4RrB8eV09sXP2ROqD4bksHrnTree52PsxvX8tpL8LvTZ3pFzXyPbNQReSN41CAhOg==",
+      "dev": true,
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/console/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@jest/console/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@jest/console/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/@jest/console/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/@jest/console/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jest/console/node_modules/slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jest/console/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jest/core": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/core/-/core-29.7.0.tgz",
+      "integrity": "sha512-n7aeXWKMnGtDA48y8TLWJPJmLmmZ642Ceo78cYWEpiD7FzDgmNDV/GCVRorPABdXLJZ/9wzzgZAlHjXjxDHGsg==",
+      "dev": true,
+      "dependencies": {
+        "@jest/console": "^29.7.0",
+        "@jest/reporters": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.0.0",
+        "ci-info": "^3.2.0",
+        "exit": "^0.1.2",
+        "graceful-fs": "^4.2.9",
+        "jest-changed-files": "^29.7.0",
+        "jest-config": "^29.7.0",
+        "jest-haste-map": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-regex-util": "^29.6.3",
+        "jest-resolve": "^29.7.0",
+        "jest-resolve-dependencies": "^29.7.0",
+        "jest-runner": "^29.7.0",
+        "jest-runtime": "^29.7.0",
+        "jest-snapshot": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "jest-watcher": "^29.7.0",
+        "micromatch": "^4.0.4",
+        "pretty-format": "^29.7.0",
+        "slash": "^3.0.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@jest/core/node_modules/ansi-escapes": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+      "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+      "dev": true,
+      "dependencies": {
+        "type-fest": "^0.21.3"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@jest/core/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jest/core/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@jest/core/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@jest/core/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/@jest/core/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/@jest/core/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jest/core/node_modules/slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jest/core/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jest/core/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jest/environment": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.7.0.tgz",
+      "integrity": "sha512-aQIfHDq33ExsN4jP1NWGXhxgQ/wixs60gDiKO+XVMd8Mn0NWPWgc34ZQDTb2jKaUWQ7MuwoitXAsN2XVXNMpAw==",
+      "dev": true,
+      "dependencies": {
+        "@jest/fake-timers": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "jest-mock": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/expect": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-29.7.0.tgz",
+      "integrity": "sha512-8uMeAMycttpva3P1lBHB8VciS9V0XAr3GymPpipdyQXbBcuhkLQOSe8E/p92RyAdToS6ZD1tFkX+CkhoECE0dQ==",
+      "dev": true,
+      "dependencies": {
+        "expect": "^29.7.0",
+        "jest-snapshot": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/expect-utils": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.7.0.tgz",
+      "integrity": "sha512-GlsNBWiFQFCVi9QVSx7f5AgMeLxe9YCCs5PuP2O2LdjDAA8Jh9eX7lA1Jq/xdXw3Wb3hyvlFNfZIfcRetSzYcA==",
+      "dev": true,
+      "dependencies": {
+        "jest-get-type": "^29.6.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/fake-timers": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.7.0.tgz",
+      "integrity": "sha512-q4DH1Ha4TTFPdxLsqDXK1d3+ioSL7yL5oCMJZgDYm6i+6CygW5E5xVr/D1HdsGxjt1ZWSfUAs9OxSB/BNelWrQ==",
+      "dev": true,
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@sinonjs/fake-timers": "^10.0.2",
+        "@types/node": "*",
+        "jest-message-util": "^29.7.0",
+        "jest-mock": "^29.7.0",
+        "jest-util": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/globals": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.7.0.tgz",
+      "integrity": "sha512-mpiz3dutLbkW2MNFubUGUEVLkTGiqW6yLVTA+JbP6fI6J5iL9Y0Nlg8k95pcF8ctKwCS7WVxteBs29hhfAotzQ==",
+      "dev": true,
+      "dependencies": {
+        "@jest/environment": "^29.7.0",
+        "@jest/expect": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "jest-mock": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/reporters": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-29.7.0.tgz",
+      "integrity": "sha512-DApq0KJbJOEzAFYjHADNNxAE3KbhxQB1y5Kplb5Waqw6zVbuWatSnMjE5gs8FUgEPmNsnZA3NCWl9NG0ia04Pg==",
+      "dev": true,
+      "dependencies": {
+        "@bcoe/v8-coverage": "^0.2.3",
+        "@jest/console": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@jridgewell/trace-mapping": "^0.3.18",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "collect-v8-coverage": "^1.0.0",
+        "exit": "^0.1.2",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.2.9",
+        "istanbul-lib-coverage": "^3.0.0",
+        "istanbul-lib-instrument": "^6.0.0",
+        "istanbul-lib-report": "^3.0.0",
+        "istanbul-lib-source-maps": "^4.0.0",
+        "istanbul-reports": "^3.1.3",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-worker": "^29.7.0",
+        "slash": "^3.0.0",
+        "string-length": "^4.0.1",
+        "strip-ansi": "^6.0.0",
+        "v8-to-istanbul": "^9.0.1"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@jest/reporters/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jest/reporters/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@jest/reporters/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@jest/reporters/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/@jest/reporters/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/@jest/reporters/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jest/reporters/node_modules/istanbul-lib-coverage": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.0.tgz",
+      "integrity": "sha512-eOeJ5BHCmHYvQK7xt9GkdHuzuCGS1Y6g9Gvnx3Ym33fz/HpLRYxiS0wHNr+m/MBC8B647Xt608vCDEvhl9c6Mw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jest/reporters/node_modules/istanbul-lib-instrument": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.1.tgz",
+      "integrity": "sha512-EAMEJBsYuyyztxMxW3g7ugGPkrZsV57v0Hmv3mm1uQsmB+QnZuepg731CRaIgeUVSdmsTngOkSnauNF8p7FIhA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/core": "^7.12.3",
+        "@babel/parser": "^7.14.7",
+        "@istanbuljs/schema": "^0.1.2",
+        "istanbul-lib-coverage": "^3.2.0",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@jest/reporters/node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@jest/reporters/node_modules/istanbul-lib-source-maps": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.1.tgz",
+      "integrity": "sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0",
+        "source-map": "^0.6.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@jest/reporters/node_modules/istanbul-reports": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.1.6.tgz",
+      "integrity": "sha512-TLgnMkKg3iTDsQ9PbPTdpfAK2DzjF9mqUG7RMgcQl8oFjad8ob4laGxv5XV5U9MAfx8D6tSJiUyuAwzLicaxlg==",
+      "dev": true,
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jest/reporters/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@jest/reporters/node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@jest/reporters/node_modules/semver": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@jest/reporters/node_modules/slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jest/reporters/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@jest/reporters/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jest/reporters/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jest/reporters/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
+    },
+    "node_modules/@jest/schemas": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
+      "dev": true,
+      "dependencies": {
+        "@sinclair/typebox": "^0.27.8"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/source-map": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-29.6.3.tgz",
+      "integrity": "sha512-MHjT95QuipcPrpLM+8JMSzFx6eHp5Bm+4XeFDJlwsvVBjmKNiIAvasGK2fxz2WbGRlnvqehFbh07MMa7n3YJnw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.18",
+        "callsites": "^3.0.0",
+        "graceful-fs": "^4.2.9"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/test-result": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-29.7.0.tgz",
+      "integrity": "sha512-Fdx+tv6x1zlkJPcWXmMDAG2HBnaR9XPSd5aDWQVsfrZmLVT3lU1cwyxLgRmXR9yrq4NBoEm9BMsfgFzTQAbJYA==",
+      "dev": true,
+      "dependencies": {
+        "@jest/console": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "collect-v8-coverage": "^1.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/test-sequencer": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-29.7.0.tgz",
+      "integrity": "sha512-GQwJ5WZVrKnOJuiYiAF52UNUJXgTZx1NHjFSEB0qEMmSZKAkdMoIzw/Cj6x6NF4AvV23AUqDpFzQkN/eYCYTxw==",
+      "dev": true,
+      "dependencies": {
+        "@jest/test-result": "^29.7.0",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.7.0",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/test-sequencer/node_modules/slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jest/transform": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.7.0.tgz",
+      "integrity": "sha512-ok/BTPFzFKVMwO5eOHRrvnBVHdRy9IrsrW1GpMaQ9MCnilNLXQKmAX8s1YXDFaai9xJpac2ySzV0YeRRECr2Vw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/core": "^7.11.6",
+        "@jest/types": "^29.6.3",
+        "@jridgewell/trace-mapping": "^0.3.18",
+        "babel-plugin-istanbul": "^6.1.1",
+        "chalk": "^4.0.0",
+        "convert-source-map": "^2.0.0",
+        "fast-json-stable-stringify": "^2.1.0",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.7.0",
+        "jest-regex-util": "^29.6.3",
+        "jest-util": "^29.7.0",
+        "micromatch": "^4.0.4",
+        "pirates": "^4.0.4",
+        "slash": "^3.0.0",
+        "write-file-atomic": "^4.0.2"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/transform/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@jest/transform/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@jest/transform/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/@jest/transform/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/@jest/transform/node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true
+    },
+    "node_modules/@jest/transform/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jest/transform/node_modules/slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jest/transform/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jest/transform/node_modules/write-file-atomic": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.2.tgz",
+      "integrity": "sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==",
+      "dev": true,
+      "dependencies": {
+        "imurmurhash": "^0.1.4",
+        "signal-exit": "^3.0.7"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@jest/types": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
+      "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
+      "dev": true,
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "@types/istanbul-reports": "^3.0.0",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.8",
+        "chalk": "^4.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/types/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@jest/types/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@jest/types/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/@jest/types/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/@jest/types/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jest/types/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz",
+      "integrity": "sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.4.15",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
+      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
+      "dev": true
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.20",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.20.tgz",
+      "integrity": "sha512-R8LcPeWZol2zR8mmH3JeKQ6QRCFb7XgUhV9ZlGhHLGyg4wpPiPZNQOOWhFZhxKw8u//yTbNGI42Bx/3paXEQ+Q==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
     "node_modules/@nicolo-ribaudo/chokidar-2": {
@@ -1805,6 +2784,80 @@
         "node": ">=v12.22.12"
       }
     },
+    "node_modules/@sinclair/typebox": {
+      "version": "0.27.8",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
+      "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
+      "dev": true
+    },
+    "node_modules/@sinonjs/commons": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.0.tgz",
+      "integrity": "sha512-jXBtWAF4vmdNmZgD5FoKsVLv3rPgDnLgPbU84LIJ3otV44vJlDRokVng5v8NFJdCf/da9legHcKaRuZs4L7faA==",
+      "dev": true,
+      "dependencies": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "node_modules/@sinonjs/fake-timers": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.3.0.tgz",
+      "integrity": "sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.0"
+      }
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.3",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.3.tgz",
+      "integrity": "sha512-54fjTSeSHwfan8AyHWrKbfBWiEUrNTZsUwPTDSNaaP1QDQIZbeNUg3a59E9D+375MzUw/x1vx2/0F5LBz+AeYA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.6.6",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.6.tgz",
+      "integrity": "sha512-66BXMKb/sUWbMdBNdMvajU7i/44RkrA3z/Yt1c7R5xejt8qh84iU54yUWCtm0QwGJlDcf/gg4zd/x4mpLAlb/w==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.3.tgz",
+      "integrity": "sha512-ciwyCLeuRfxboZ4isgdNZi/tkt06m8Tw6uGbBSBgWrnnZGNXiEyM27xc/PjXGQLqlZ6ylbgHMnm7ccF9tCkOeQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.20.3",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.20.3.tgz",
+      "integrity": "sha512-Lsh766rGEFbaxMIDH7Qa+Yha8cMVI3qAK6CHt3OR0YfxOIn5Z54iHiyDRycHrBqeIiqGa20Kpsv1cavfBKkRSw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.20.7"
+      }
+    },
+    "node_modules/@types/graceful-fs": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.8.tgz",
+      "integrity": "sha512-NhRH7YzWq8WiNKVavKPBmtLYZHxNY19Hh+az28O/phfp68CF45pMFud+ZzJ8ewnxnC5smIdF3dqFeiSUQ5I+pw==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/http-link-header": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@types/http-link-header/-/http-link-header-1.0.3.tgz",
@@ -1812,6 +2865,30 @@
       "dev": true,
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@types/istanbul-lib-coverage": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.5.tgz",
+      "integrity": "sha512-zONci81DZYCZjiLe0r6equvZut0b+dBRPBN5kBDjsONnutYNtJMoWQ9uR2RkL1gLG9NMTzvf+29e5RFfPbeKhQ==",
+      "dev": true
+    },
+    "node_modules/@types/istanbul-lib-report": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.2.tgz",
+      "integrity": "sha512-8toY6FgdltSdONav1XtUHl4LN1yTmLza+EuDazb/fEmRNCwjyqNVIQWs2IfC74IqjHkREs/nQ2FWq5kZU9IC0w==",
+      "dev": true,
+      "dependencies": {
+        "@types/istanbul-lib-coverage": "*"
+      }
+    },
+    "node_modules/@types/istanbul-reports": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.3.tgz",
+      "integrity": "sha512-1nESsePMBlf0RPRffLZi5ujYh7IH1BWL4y9pr+Bn3cJBdxz+RTP8bUFljLz9HvzhhOSWKdyBZ4DIivdL6rvgZg==",
+      "dev": true,
+      "dependencies": {
+        "@types/istanbul-lib-report": "*"
       }
     },
     "node_modules/@types/json-stable-stringify": {
@@ -1860,6 +2937,27 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/stack-utils": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.2.tgz",
+      "integrity": "sha512-g7CK9nHdwjK2n0ymT2CW698FuWJRIx+RP6embAzZ2Qi8/ilIrA1Imt2LVSeHUzKvpoi7BhmmQcXz95eS0f2JXw==",
+      "dev": true
+    },
+    "node_modules/@types/yargs": {
+      "version": "17.0.28",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.28.tgz",
+      "integrity": "sha512-N3e3fkS86hNhtk6BEnc0rj3zcehaxx8QWhCROJkqpl5Zaoi7nAic3jH8q94jVD3zu5LGk+PUB6KAiDmimYOEQw==",
+      "dev": true,
+      "dependencies": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "node_modules/@types/yargs-parser": {
+      "version": "21.0.1",
+      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.1.tgz",
+      "integrity": "sha512-axdPBuLuEJt0c4yI5OZssC19K2Mq1uKdrfZBzuxLvaztgqUtFYZUNw7lETExPYJR9jdEoIg4mb7RQKRQzOkeGQ==",
+      "dev": true
     },
     "node_modules/@ungap/promise-all-settled": {
       "version": "1.1.2",
@@ -2105,6 +3203,106 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/babel-jest": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.7.0.tgz",
+      "integrity": "sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg==",
+      "dev": true,
+      "dependencies": {
+        "@jest/transform": "^29.7.0",
+        "@types/babel__core": "^7.1.14",
+        "babel-plugin-istanbul": "^6.1.1",
+        "babel-preset-jest": "^29.6.3",
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.9",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.8.0"
+      }
+    },
+    "node_modules/babel-jest/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/babel-jest/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/babel-jest/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/babel-jest/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/babel-jest/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/babel-jest/node_modules/slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/babel-jest/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/babel-plugin-dynamic-import-node": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.3.tgz",
@@ -2112,6 +3310,85 @@
       "dev": true,
       "dependencies": {
         "object.assign": "^4.1.0"
+      }
+    },
+    "node_modules/babel-plugin-istanbul": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-6.1.1.tgz",
+      "integrity": "sha512-Y1IQok9821cC9onCx5otgFfRm7Lm+I+wwxOx738M/WLPZ9Q42m4IG5W0FNX8WLL2gYMZo3JkuXIH2DOpWM+qwA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@istanbuljs/load-nyc-config": "^1.0.0",
+        "@istanbuljs/schema": "^0.1.2",
+        "istanbul-lib-instrument": "^5.0.4",
+        "test-exclude": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/babel-plugin-istanbul/node_modules/istanbul-lib-coverage": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.0.tgz",
+      "integrity": "sha512-eOeJ5BHCmHYvQK7xt9GkdHuzuCGS1Y6g9Gvnx3Ym33fz/HpLRYxiS0wHNr+m/MBC8B647Xt608vCDEvhl9c6Mw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/babel-plugin-istanbul/node_modules/istanbul-lib-instrument": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-5.2.1.tgz",
+      "integrity": "sha512-pzqtp31nLv/XFOzXGuvhCb8qhjmTVo5vjVk19XE4CRlSWz0KoeJ3bw9XsA7nOp9YBf4qHjwBxkDzKcME/J29Yg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/core": "^7.12.3",
+        "@babel/parser": "^7.14.7",
+        "@istanbuljs/schema": "^0.1.2",
+        "istanbul-lib-coverage": "^3.2.0",
+        "semver": "^6.3.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/babel-plugin-istanbul/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/babel-plugin-istanbul/node_modules/test-exclude": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
+      "integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
+      "dev": true,
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^7.1.4",
+        "minimatch": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/babel-plugin-jest-hoist": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-29.6.3.tgz",
+      "integrity": "sha512-ESAc/RJvGTFEzRwOTT4+lNDk/GNHMkKbNzsvT0qKRfDyyYTskxB5rnU2njIDYVxXCBHHEI1c0YwHob3WaYujOg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/template": "^7.3.3",
+        "@babel/types": "^7.3.3",
+        "@types/babel__core": "^7.1.14",
+        "@types/babel__traverse": "^7.0.6"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/babel-plugin-polyfill-corejs2": {
@@ -2160,6 +3437,45 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/babel-preset-current-node-syntax": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.0.1.tgz",
+      "integrity": "sha512-M7LQ0bxarkxQoN+vz5aJPsLBn77n8QgTFmo8WK0/44auK2xlCXrYcUxHFxgU7qW5Yzw/CjmLRK2uJzaCd7LvqQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/plugin-syntax-async-generators": "^7.8.4",
+        "@babel/plugin-syntax-bigint": "^7.8.3",
+        "@babel/plugin-syntax-class-properties": "^7.8.3",
+        "@babel/plugin-syntax-import-meta": "^7.8.3",
+        "@babel/plugin-syntax-json-strings": "^7.8.3",
+        "@babel/plugin-syntax-logical-assignment-operators": "^7.8.3",
+        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
+        "@babel/plugin-syntax-numeric-separator": "^7.8.3",
+        "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
+        "@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
+        "@babel/plugin-syntax-optional-chaining": "^7.8.3",
+        "@babel/plugin-syntax-top-level-await": "^7.8.3"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/babel-preset-jest": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-29.6.3.tgz",
+      "integrity": "sha512-0B3bhxR6snWXJZtR/RliHTDPRgn1sNHOR0yVtq/IiQFyuOVjFS+wuio/R4gSNkyYmKmJB4wGZv2NZanmKmTnNA==",
+      "dev": true,
+      "dependencies": {
+        "babel-plugin-jest-hoist": "^29.6.3",
+        "babel-preset-current-node-syntax": "^1.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
       }
     },
     "node_modules/balanced-match": {
@@ -2471,6 +3787,15 @@
         "url": "https://opencollective.com/browserslist"
       }
     },
+    "node_modules/bser": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
+      "integrity": "sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==",
+      "dev": true,
+      "dependencies": {
+        "node-int64": "^0.4.0"
+      }
+    },
     "node_modules/buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.2.1.tgz",
@@ -2614,6 +3939,15 @@
         "node": ">=4"
       }
     },
+    "node_modules/char-regex": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
+      "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/chardet": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
@@ -2664,6 +3998,21 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/ci-info": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
+      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/cipher-base": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
@@ -2673,6 +4022,12 @@
         "inherits": "^2.0.1",
         "safe-buffer": "^5.0.1"
       }
+    },
+    "node_modules/cjs-module-lexer": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.3.tgz",
+      "integrity": "sha512-0TNiGstbQmCFwt4akjjBg5pLRTSyj/PkWQ1ZoO2zntmg9yLqSRxwEa4iCfQLGjqhiqBfOJa7W/E8wfGrTDmlZQ==",
+      "dev": true
     },
     "node_modules/cli-cursor": {
       "version": "2.1.0",
@@ -2751,6 +4106,22 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/co": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "integrity": "sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==",
+      "dev": true,
+      "engines": {
+        "iojs": ">= 1.0.0",
+        "node": ">= 0.12.0"
+      }
+    },
+    "node_modules/collect-v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-lHl4d5/ONEbLlJvaJNtsF/Lz+WvB07u2ycqTYbdrq7UypDXailES4valYb2eWiJFxZlVmpGekfqoxQhzyFdT4Q==",
+      "dev": true
     },
     "node_modules/color-convert": {
       "version": "1.9.3",
@@ -2975,6 +4346,97 @@
         "sha.js": "^2.4.8"
       }
     },
+    "node_modules/create-jest": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/create-jest/-/create-jest-29.7.0.tgz",
+      "integrity": "sha512-Adz2bdH0Vq3F53KEMJOoftQFutWCukm6J24wbPWRO4k1kMY7gS7ds/uoJkNuV8wDCtWWnuwGcJwpWcih+zEW1Q==",
+      "dev": true,
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "chalk": "^4.0.0",
+        "exit": "^0.1.2",
+        "graceful-fs": "^4.2.9",
+        "jest-config": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "prompts": "^2.0.1"
+      },
+      "bin": {
+        "create-jest": "bin/create-jest.js"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/create-jest/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/create-jest/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/create-jest/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/create-jest/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/create-jest/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/create-jest/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/cross-fetch": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
@@ -3028,6 +4490,23 @@
       "integrity": "sha512-Vy4dx7gquTeMcQR/hDkYLGUnwVil6vk4FOOct+djUnHOUWt+zJPJAaRIXaAFkPXtJjvlY7o3rfRu0/3hpnwoUA==",
       "dev": true
     },
+    "node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/decamelize": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
@@ -3035,6 +4514,20 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/dedent": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.5.1.tgz",
+      "integrity": "sha512-+LxW+KLWxu3HW3M2w2ympwtqPrqYRzU8fqi6Fhd18fBALe15blJPI/I4+UHveMVG6lJqB4JNd4UG0S5cnVHwIg==",
+      "dev": true,
+      "peerDependencies": {
+        "babel-plugin-macros": "^3.1.0"
+      },
+      "peerDependenciesMeta": {
+        "babel-plugin-macros": {
+          "optional": true
+        }
       }
     },
     "node_modules/deep-eql": {
@@ -3054,6 +4547,15 @@
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
       "dev": true
+    },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/default-require-extensions": {
       "version": "2.0.0",
@@ -3110,6 +4612,15 @@
         "minimalistic-assert": "^1.0.0"
       }
     },
+    "node_modules/detect-newline": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
+      "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/detective": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/detective/-/detective-5.2.0.tgz",
@@ -3134,6 +4645,15 @@
       "dev": true,
       "engines": {
         "node": ">=0.3.1"
+      }
+    },
+    "node_modules/diff-sequences": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
+      "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
+      "dev": true,
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/diffie-hellman": {
@@ -3259,6 +4779,18 @@
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
       "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
       "dev": true
+    },
+    "node_modules/emittery": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.13.1.tgz",
+      "integrity": "sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/emittery?sponsor=1"
+      }
     },
     "node_modules/emoji-regex": {
       "version": "7.0.3",
@@ -3434,29 +4966,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/eslint/node_modules/debug": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-      "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
-      "dev": true,
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/eslint/node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
-    },
     "node_modules/espree": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/espree/-/espree-5.0.1.tgz",
@@ -3571,6 +5080,149 @@
         "safe-buffer": "^5.1.1"
       }
     },
+    "node_modules/execa": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.0",
+        "human-signals": "^2.1.0",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.1",
+        "onetime": "^5.1.2",
+        "signal-exit": "^3.0.3",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/execa/node_modules/cross-spawn": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "dev": true,
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/execa/node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/execa/node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/execa/node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "dev": true,
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/execa/node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/execa/node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/execa/node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/execa/node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/exit": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+      "integrity": "sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/expect": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-29.7.0.tgz",
+      "integrity": "sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==",
+      "dev": true,
+      "dependencies": {
+        "@jest/expect-utils": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "jest-matcher-utils": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
     "node_modules/external-editor": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
@@ -3608,6 +5260,15 @@
       "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
       "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
       "dev": true
+    },
+    "node_modules/fb-watchman": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.2.tgz",
+      "integrity": "sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==",
+      "dev": true,
+      "dependencies": {
+        "bser": "2.1.1"
+      }
     },
     "node_modules/figures": {
       "version": "2.0.0",
@@ -3825,6 +5486,27 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/get-package-type": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
+      "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/get-symbol-description": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.0.tgz",
@@ -3883,9 +5565,9 @@
       }
     },
     "node_modules/graceful-fs": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
-      "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true
     },
     "node_modules/growl": {
@@ -4069,6 +5751,15 @@
       "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=",
       "dev": true
     },
+    "node_modules/human-signals": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.17.0"
+      }
+    },
     "node_modules/iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -4124,6 +5815,83 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/import-local": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.1.0.tgz",
+      "integrity": "sha512-ASB07uLtnDs1o6EHjKpX34BKYDSqnFerfTOJL2HvMqF70LnxpjkzDB8J44oT9pu4AMPkQwf8jl6szgvNd2tRIg==",
+      "dev": true,
+      "dependencies": {
+        "pkg-dir": "^4.2.0",
+        "resolve-cwd": "^3.0.0"
+      },
+      "bin": {
+        "import-local-fixture": "fixtures/cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/import-local/node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dev": true,
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/import-local/node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dev": true,
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/import-local/node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dev": true,
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/import-local/node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/import-local/node_modules/pkg-dir": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+      "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+      "dev": true,
+      "dependencies": {
+        "find-up": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/imurmurhash": {
@@ -4356,6 +6124,15 @@
       "dev": true,
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/is-generator-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
+      "integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/is-generator-function": {
@@ -4657,29 +6434,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/istanbul-lib-source-maps/node_modules/debug": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-      "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
-      "dev": true,
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/istanbul-lib-source-maps/node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
-    },
     "node_modules/istanbul-lib-source-maps/node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -4699,6 +6453,1863 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/jest": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz",
+      "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
+      "dev": true,
+      "dependencies": {
+        "@jest/core": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "import-local": "^3.0.2",
+        "jest-cli": "^29.7.0"
+      },
+      "bin": {
+        "jest": "bin/jest.js"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-changed-files": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-29.7.0.tgz",
+      "integrity": "sha512-fEArFiwf1BpQ+4bXSprcDc3/x4HSzL4al2tozwVpDFpsxALjLYdyiIK4e5Vz66GQJIbXJ82+35PtysofptNX2w==",
+      "dev": true,
+      "dependencies": {
+        "execa": "^5.0.0",
+        "jest-util": "^29.7.0",
+        "p-limit": "^3.1.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-changed-files/node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/jest-circus": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-29.7.0.tgz",
+      "integrity": "sha512-3E1nCMgipcTkCocFwM90XXQab9bS+GMsjdpmPrlelaxwD93Ad8iVEjX/vvHPdLPnFf+L40u+5+iutRdA1N9myw==",
+      "dev": true,
+      "dependencies": {
+        "@jest/environment": "^29.7.0",
+        "@jest/expect": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "co": "^4.6.0",
+        "dedent": "^1.0.0",
+        "is-generator-fn": "^2.0.0",
+        "jest-each": "^29.7.0",
+        "jest-matcher-utils": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-runtime": "^29.7.0",
+        "jest-snapshot": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "p-limit": "^3.1.0",
+        "pretty-format": "^29.7.0",
+        "pure-rand": "^6.0.0",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-circus/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-circus/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/jest-circus/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/jest-circus/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/jest-circus/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-circus/node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/jest-circus/node_modules/slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-circus/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-cli": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-29.7.0.tgz",
+      "integrity": "sha512-OVVobw2IubN/GSYsxETi+gOe7Ka59EFMR/twOU3Jb2GnKKeMGJB5SGUUrEz3SFVmJASUdZUzy83sLNNQ2gZslg==",
+      "dev": true,
+      "dependencies": {
+        "@jest/core": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "chalk": "^4.0.0",
+        "create-jest": "^29.7.0",
+        "exit": "^0.1.2",
+        "import-local": "^3.0.2",
+        "jest-config": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "yargs": "^17.3.1"
+      },
+      "bin": {
+        "jest": "bin/jest.js"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-cli/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-cli/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-cli/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/jest-cli/node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/jest-cli/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/jest-cli/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/jest-cli/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/jest-cli/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-cli/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-cli/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-cli/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-cli/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-cli/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/jest-cli/node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/jest-cli/node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/jest-cli/node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/jest-config": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-29.7.0.tgz",
+      "integrity": "sha512-uXbpfeQ7R6TZBqI3/TxCU4q4ttk3u0PJeC+E0zbfSoSjq6bJ7buBPxzQPL0ifrkY4DNu4JUdk0ImlBUYi840eQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/core": "^7.11.6",
+        "@jest/test-sequencer": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "babel-jest": "^29.7.0",
+        "chalk": "^4.0.0",
+        "ci-info": "^3.2.0",
+        "deepmerge": "^4.2.2",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.2.9",
+        "jest-circus": "^29.7.0",
+        "jest-environment-node": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "jest-regex-util": "^29.6.3",
+        "jest-resolve": "^29.7.0",
+        "jest-runner": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "micromatch": "^4.0.4",
+        "parse-json": "^5.2.0",
+        "pretty-format": "^29.7.0",
+        "slash": "^3.0.0",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "@types/node": "*",
+        "ts-node": ">=9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "ts-node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-config/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-config/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/jest-config/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/jest-config/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/jest-config/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-config/node_modules/parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/jest-config/node_modules/slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-config/node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/jest-config/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-diff": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.7.0.tgz",
+      "integrity": "sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "diff-sequences": "^29.6.3",
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-diff/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-diff/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/jest-diff/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/jest-diff/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/jest-diff/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-diff/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-docblock": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-29.7.0.tgz",
+      "integrity": "sha512-q617Auw3A612guyaFgsbFeYpNP5t2aoUNLwBUbc/0kD1R4t9ixDbyFTHd1nok4epoVFpr7PmeWHrhvuV3XaJ4g==",
+      "dev": true,
+      "dependencies": {
+        "detect-newline": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-each": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-29.7.0.tgz",
+      "integrity": "sha512-gns+Er14+ZrEoC5fhOfYCY1LOHHr0TI+rQUHZS8Ttw2l7gl+80eHc/gFf2Ktkw0+SIACDTeWvpFcv3B04VembQ==",
+      "dev": true,
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "chalk": "^4.0.0",
+        "jest-get-type": "^29.6.3",
+        "jest-util": "^29.7.0",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-each/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-each/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/jest-each/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/jest-each/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/jest-each/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-each/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-environment-node": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-29.7.0.tgz",
+      "integrity": "sha512-DOSwCRqXirTOyheM+4d5YZOrWcdu0LNZ87ewUoywbcb2XR4wKgqiG8vNeYwhjFMbEkfju7wx2GYH0P2gevGvFw==",
+      "dev": true,
+      "dependencies": {
+        "@jest/environment": "^29.7.0",
+        "@jest/fake-timers": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "jest-mock": "^29.7.0",
+        "jest-util": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-get-type": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.6.3.tgz",
+      "integrity": "sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==",
+      "dev": true,
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-haste-map": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.7.0.tgz",
+      "integrity": "sha512-fP8u2pyfqx0K1rGn1R9pyE0/KTn+G7PxktWidOBTqFPLYX0b9ksaMFkhK5vrS3DVun09pckLdlx90QthlW7AmA==",
+      "dev": true,
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@types/graceful-fs": "^4.1.3",
+        "@types/node": "*",
+        "anymatch": "^3.0.3",
+        "fb-watchman": "^2.0.0",
+        "graceful-fs": "^4.2.9",
+        "jest-regex-util": "^29.6.3",
+        "jest-util": "^29.7.0",
+        "jest-worker": "^29.7.0",
+        "micromatch": "^4.0.4",
+        "walker": "^1.0.8"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "^2.3.2"
+      }
+    },
+    "node_modules/jest-leak-detector": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-29.7.0.tgz",
+      "integrity": "sha512-kYA8IJcSYtST2BY9I+SMC32nDpBT3J2NvWJx8+JCuCdl/CR1I4EKUJROiP8XtCcxqgTTBGJNdbB1A8XRKbTetw==",
+      "dev": true,
+      "dependencies": {
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-matcher-utils": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.7.0.tgz",
+      "integrity": "sha512-sBkD+Xi9DtcChsI3L3u0+N0opgPYnCRPtGcQYrgXmR+hmt/fYfWAL0xRXYU8eWOdfuLgBe0YCW3AFtnRLagq/g==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "jest-diff": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-matcher-utils/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-matcher-utils/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/jest-matcher-utils/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/jest-matcher-utils/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/jest-matcher-utils/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-matcher-utils/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-message-util": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.7.0.tgz",
+      "integrity": "sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.12.13",
+        "@jest/types": "^29.6.3",
+        "@types/stack-utils": "^2.0.0",
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.9",
+        "micromatch": "^4.0.4",
+        "pretty-format": "^29.7.0",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-message-util/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-message-util/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/jest-message-util/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/jest-message-util/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/jest-message-util/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-message-util/node_modules/slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-message-util/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-mock": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.7.0.tgz",
+      "integrity": "sha512-ITOMZn+UkYS4ZFh83xYAOzWStloNzJFO2s8DWrE4lhtGD+AorgnbkiKERe4wQVBydIGPx059g6riW5Btp6Llnw==",
+      "dev": true,
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "jest-util": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-pnp-resolver": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
+      "integrity": "sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      },
+      "peerDependencies": {
+        "jest-resolve": "*"
+      },
+      "peerDependenciesMeta": {
+        "jest-resolve": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-regex-util": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-29.6.3.tgz",
+      "integrity": "sha512-KJJBsRCyyLNWCNBOvZyRDnAIfUiRJ8v+hOBQYGn8gDyF3UegwiP4gwRR3/SDa42g1YbVycTidUF3rKjyLFDWbg==",
+      "dev": true,
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-resolve": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-29.7.0.tgz",
+      "integrity": "sha512-IOVhZSrg+UvVAshDSDtHyFCCBUl/Q3AAJv8iZ6ZjnZ74xzvwuzLXid9IIIPgTnY62SJjfuupMKZsZQRsCvxEgA==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.7.0",
+        "jest-pnp-resolver": "^1.2.2",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "resolve": "^1.20.0",
+        "resolve.exports": "^2.0.0",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-resolve-dependencies": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-29.7.0.tgz",
+      "integrity": "sha512-un0zD/6qxJ+S0et7WxeI3H5XSe9lTBBR7bOHCHXkKR6luG5mwDDlIzVQ0V5cZCuoTgEdcdwzTghYkTWfubi+nA==",
+      "dev": true,
+      "dependencies": {
+        "jest-regex-util": "^29.6.3",
+        "jest-snapshot": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-resolve/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-resolve/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/jest-resolve/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/jest-resolve/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/jest-resolve/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-resolve/node_modules/slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-resolve/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-runner": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-29.7.0.tgz",
+      "integrity": "sha512-fsc4N6cPCAahybGBfTRcq5wFR6fpLznMg47sY5aDpsoejOcVYFb07AHuSnR0liMcPTgBsA3ZJL6kFOjPdoNipQ==",
+      "dev": true,
+      "dependencies": {
+        "@jest/console": "^29.7.0",
+        "@jest/environment": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "emittery": "^0.13.1",
+        "graceful-fs": "^4.2.9",
+        "jest-docblock": "^29.7.0",
+        "jest-environment-node": "^29.7.0",
+        "jest-haste-map": "^29.7.0",
+        "jest-leak-detector": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-resolve": "^29.7.0",
+        "jest-runtime": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-watcher": "^29.7.0",
+        "jest-worker": "^29.7.0",
+        "p-limit": "^3.1.0",
+        "source-map-support": "0.5.13"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-runner/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-runner/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/jest-runner/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/jest-runner/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/jest-runner/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-runner/node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/jest-runner/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/jest-runner/node_modules/source-map-support": {
+      "version": "0.5.13",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
+      "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
+      "dev": true,
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/jest-runner/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-runtime": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-29.7.0.tgz",
+      "integrity": "sha512-gUnLjgwdGqW7B4LvOIkbKs9WGbn+QLqRQQ9juC6HndeDiezIwhDP+mhMwHWCEcfQ5RUXa6OPnFF8BJh5xegwwQ==",
+      "dev": true,
+      "dependencies": {
+        "@jest/environment": "^29.7.0",
+        "@jest/fake-timers": "^29.7.0",
+        "@jest/globals": "^29.7.0",
+        "@jest/source-map": "^29.6.3",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "cjs-module-lexer": "^1.0.0",
+        "collect-v8-coverage": "^1.0.0",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-mock": "^29.7.0",
+        "jest-regex-util": "^29.6.3",
+        "jest-resolve": "^29.7.0",
+        "jest-snapshot": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "slash": "^3.0.0",
+        "strip-bom": "^4.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-runtime/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-runtime/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/jest-runtime/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/jest-runtime/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/jest-runtime/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-runtime/node_modules/slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-runtime/node_modules/strip-bom": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
+      "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-runtime/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-snapshot": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-29.7.0.tgz",
+      "integrity": "sha512-Rm0BMWtxBcioHr1/OX5YCP8Uov4riHvKPknOGs804Zg9JGZgmIBkbtlxJC/7Z4msKYVbIJtfU+tKb8xlYNfdkw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/core": "^7.11.6",
+        "@babel/generator": "^7.7.2",
+        "@babel/plugin-syntax-jsx": "^7.7.2",
+        "@babel/plugin-syntax-typescript": "^7.7.2",
+        "@babel/types": "^7.3.3",
+        "@jest/expect-utils": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "babel-preset-current-node-syntax": "^1.0.0",
+        "chalk": "^4.0.0",
+        "expect": "^29.7.0",
+        "graceful-fs": "^4.2.9",
+        "jest-diff": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "jest-matcher-utils": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "natural-compare": "^1.4.0",
+        "pretty-format": "^29.7.0",
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-snapshot/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-snapshot/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/jest-snapshot/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/jest-snapshot/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/jest-snapshot/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-snapshot/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/jest-snapshot/node_modules/semver": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/jest-snapshot/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-snapshot/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
+    },
+    "node_modules/jest-util": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
+      "integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
+      "dev": true,
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "ci-info": "^3.2.0",
+        "graceful-fs": "^4.2.9",
+        "picomatch": "^2.2.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-util/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-util/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/jest-util/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/jest-util/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/jest-util/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-util/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-validate": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-29.7.0.tgz",
+      "integrity": "sha512-ZB7wHqaRGVw/9hST/OuFUReG7M8vKeq0/J2egIGLdvjHCmYqGARhzXmtgi+gVeZ5uXFF219aOc3Ls2yLg27tkw==",
+      "dev": true,
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "camelcase": "^6.2.0",
+        "chalk": "^4.0.0",
+        "jest-get-type": "^29.6.3",
+        "leven": "^3.1.0",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-validate/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-validate/node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/jest-validate/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/jest-validate/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/jest-validate/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/jest-validate/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-validate/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-watcher": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-29.7.0.tgz",
+      "integrity": "sha512-49Fg7WXkU3Vl2h6LbLtMQ/HyB6rXSIX7SqvBLQmssRBGN9I0PNvPmAmCWSOY6SOvrjhI/F7/bGAv9RtnsPA03g==",
+      "dev": true,
+      "dependencies": {
+        "@jest/test-result": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.0.0",
+        "emittery": "^0.13.1",
+        "jest-util": "^29.7.0",
+        "string-length": "^4.0.1"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-watcher/node_modules/ansi-escapes": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+      "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+      "dev": true,
+      "dependencies": {
+        "type-fest": "^0.21.3"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/jest-watcher/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-watcher/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/jest-watcher/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/jest-watcher/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/jest-watcher/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-watcher/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-worker": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.7.0.tgz",
+      "integrity": "sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*",
+        "jest-util": "^29.7.0",
+        "merge-stream": "^2.0.0",
+        "supports-color": "^8.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-worker/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-worker/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
     "node_modules/js-tokens": {
@@ -4736,6 +8347,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
       "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+      "dev": true
+    },
+    "node_modules/json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "dev": true
     },
     "node_modules/json-schema-traverse": {
@@ -4888,6 +8505,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/kleur": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
+      "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/labeled-stream-splicer": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/labeled-stream-splicer/-/labeled-stream-splicer-2.0.2.tgz",
@@ -4896,6 +8522,15 @@
       "dependencies": {
         "inherits": "^2.0.1",
         "stream-splicer": "^2.0.0"
+      }
+    },
+    "node_modules/leven": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
+      "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/levn": {
@@ -4910,6 +8545,12 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true
     },
     "node_modules/load-json-file": {
       "version": "4.0.0",
@@ -5077,6 +8718,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/makeerror": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.12.tgz",
+      "integrity": "sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==",
+      "dev": true,
+      "dependencies": {
+        "tmpl": "1.0.5"
+      }
+    },
     "node_modules/marked": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/marked/-/marked-2.1.3.tgz",
@@ -5116,6 +8766,25 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "dev": true
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
+      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "dev": true,
+      "dependencies": {
+        "braces": "^3.0.2",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
       }
     },
     "node_modules/miller-rabin": {
@@ -5665,6 +9334,12 @@
         "safe-buffer": "~5.1.0"
       }
     },
+    "node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
+    },
     "node_modules/mute-stream": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
@@ -5734,14 +9409,11 @@
         }
       }
     },
-    "node_modules/node-modules-regexp": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz",
-      "integrity": "sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
+    "node_modules/node-int64": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
+      "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
+      "dev": true
     },
     "node_modules/node-releases": {
       "version": "2.0.1",
@@ -5768,6 +9440,27 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm-run-path": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+      "dev": true,
+      "dependencies": {
+        "path-key": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/npm-run-path/node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/nyc": {
@@ -6136,9 +9829,9 @@
       "dev": true
     },
     "node_modules/picomatch": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
-      "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
       "dev": true,
       "engines": {
         "node": ">=8.6"
@@ -6157,13 +9850,10 @@
       }
     },
     "node_modules/pirates": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.1.tgz",
-      "integrity": "sha512-WuNqLTbMI3tmfef2TKxlQmAiLHKtFhlsCZnPIpuv2Ow0RDVO8lfy1Opf4NUzlMXLjPl+Men7AuVdX6TA+s+uGA==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.6.tgz",
+      "integrity": "sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==",
       "dev": true,
-      "dependencies": {
-        "node-modules-regexp": "^1.0.0"
-      },
       "engines": {
         "node": ">= 6"
       }
@@ -6224,6 +9914,32 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/process": {
       "version": "0.11.10",
       "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
@@ -6253,6 +9969,19 @@
       "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-1.1.6.tgz",
       "integrity": "sha1-zQTv9G9clcOn0EVZHXm14+AfEtc=",
       "dev": true
+    },
+    "node_modules/prompts": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
+      "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
+      "dev": true,
+      "dependencies": {
+        "kleur": "^3.0.3",
+        "sisteransi": "^1.0.5"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/pseudomap": {
       "version": "1.0.2",
@@ -6288,6 +10017,22 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/pure-rand": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.0.4.tgz",
+      "integrity": "sha512-LA0Y9kxMYv47GIPJy6MI84fqTd2HmYZI83W/kM/SkKfDlajnZYfmXFTxkbY+xSBPkLJxltMa9hIkmdc29eguMA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ]
     },
     "node_modules/querystring": {
       "version": "0.2.0",
@@ -6612,6 +10357,12 @@
         "ieee754": "^1.2.1"
       }
     },
+    "node_modules/react-is": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
+      "dev": true
+    },
     "node_modules/read-only-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/read-only-stream/-/read-only-stream-2.0.0.tgz",
@@ -6863,6 +10614,27 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/resolve-cwd": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
+      "integrity": "sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==",
+      "dev": true,
+      "dependencies": {
+        "resolve-from": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/resolve-cwd/node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -6870,6 +10642,15 @@
       "dev": true,
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/resolve.exports": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-2.0.2.tgz",
+      "integrity": "sha512-X2UW6Nw3n/aMgDVy+0rSqgHlv39WZAlZrXCdnbyEiKm17DSqHX4MmQMaST3FbeWR5FTuRcUwYAziZajji0Y7mg==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/restore-cursor": {
@@ -7066,9 +10847,9 @@
       }
     },
     "node_modules/signal-exit": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
-      "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true
     },
     "node_modules/simple-concat": {
@@ -7090,6 +10871,12 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/sisteransi": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
+      "dev": true
     },
     "node_modules/slash": {
       "version": "2.0.0",
@@ -7256,6 +11043,27 @@
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
+    "node_modules/stack-utils": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
+      "integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
+      "dev": true,
+      "dependencies": {
+        "escape-string-regexp": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/stack-utils/node_modules/escape-string-regexp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+      "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/stream-browserify": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-3.0.0.tgz",
@@ -7416,6 +11224,40 @@
         "safe-buffer": "~5.2.0"
       }
     },
+    "node_modules/string-length": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
+      "integrity": "sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==",
+      "dev": true,
+      "dependencies": {
+        "char-regex": "^1.0.2",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/string-length/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-length/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/string-width": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
@@ -7474,6 +11316,15 @@
       "dev": true,
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/strip-json-comments": {
@@ -7656,6 +11507,12 @@
         "node": ">=0.6.0"
       }
     },
+    "node_modules/tmpl": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
+      "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
+      "dev": true
+    },
     "node_modules/to-fast-properties": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
@@ -7714,6 +11571,18 @@
       "dev": true,
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/typedarray": {
@@ -7884,6 +11753,26 @@
         "uuid": "bin/uuid"
       }
     },
+    "node_modules/v8-to-istanbul": {
+      "version": "9.1.3",
+      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.1.3.tgz",
+      "integrity": "sha512-9lDD+EVI2fjFsMWXc6dy5JJzBsVTcQ2fVkfBvncZ6xJWG9wtBhOldG+mHkSL0+V1K/xgZz0JDO5UT5hFwHUghg==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.12",
+        "@types/istanbul-lib-coverage": "^2.0.1",
+        "convert-source-map": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.12.0"
+      }
+    },
+    "node_modules/v8-to-istanbul/node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true
+    },
     "node_modules/validate-npm-package-license": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
@@ -7899,6 +11788,15 @@
       "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.2.tgz",
       "integrity": "sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==",
       "dev": true
+    },
+    "node_modules/walker": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.8.tgz",
+      "integrity": "sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==",
+      "dev": true,
+      "dependencies": {
+        "makeerror": "1.0.12"
+      }
     },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
@@ -8270,21 +12168,6 @@
         "source-map": "^0.5.0"
       },
       "dependencies": {
-        "debug": {
-          "version": "4.3.2",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
-          "dev": true,
-          "requires": {
-            "ms": "2.1.2"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
-        },
         "semver": {
           "version": "6.3.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
@@ -8383,21 +12266,6 @@
         "semver": "^6.1.2"
       },
       "dependencies": {
-        "debug": {
-          "version": "4.3.2",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
-          "dev": true,
-          "requires": {
-            "ms": "2.1.2"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
-        },
         "semver": {
           "version": "6.3.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
@@ -8488,9 +12356,9 @@
       }
     },
     "@babel/helper-plugin-utils": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.14.5.tgz",
-      "integrity": "sha512-/37qQCE3K0vvZKwoK4XU/irIJQdIfCJuhU5eKnNxpFDsOkgFaUAwbv+RYw6eYgsC0E4hS7r5KqGULUogqui0fQ==",
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.22.5.tgz",
+      "integrity": "sha512-uLls06UVKgFG9QD4OeFYLEGteMIAa5kpTPcFL28yuCIIzsf6ZyKZMllKVOCZFhiZ5ptnwX4mtKdWCBE/uT4amg==",
       "dev": true
     },
     "@babel/helper-remap-async-to-generator": {
@@ -8543,10 +12411,16 @@
         "@babel/types": "^7.16.0"
       }
     },
+    "@babel/helper-string-parser": {
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.22.5.tgz",
+      "integrity": "sha512-mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw==",
+      "dev": true
+    },
     "@babel/helper-validator-identifier": {
-      "version": "7.15.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz",
-      "integrity": "sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==",
+      "version": "7.22.20",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
+      "integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==",
       "dev": true
     },
     "@babel/helper-validator-option": {
@@ -8590,9 +12464,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.16.2",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.16.2.tgz",
-      "integrity": "sha512-RUVpT0G2h6rOZwqLDTrKk7ksNv7YpAilTnYe1/Q+eDjxEceRMKVWbCsX7t8h6C1qCFi/1Y8WZjcEPBAFG27GPw==",
+      "version": "7.23.0",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.0.tgz",
+      "integrity": "sha512-vvPKKdMemU85V9WE/l5wZEmImpCtLqbnTvqDS2U1fJ96KrxoW7KrXhNsNCblQlg8Ck4b85yxdTyelsMUgFUXiw==",
       "dev": true
     },
     "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": {
@@ -8782,6 +12656,15 @@
         "@babel/helper-plugin-utils": "^7.8.0"
       }
     },
+    "@babel/plugin-syntax-bigint": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-bigint/-/plugin-syntax-bigint-7.8.3.tgz",
+      "integrity": "sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      }
+    },
     "@babel/plugin-syntax-class-properties": {
       "version": "7.12.13",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.12.13.tgz",
@@ -8818,6 +12701,15 @@
         "@babel/helper-plugin-utils": "^7.8.3"
       }
     },
+    "@babel/plugin-syntax-import-meta": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.10.4.tgz",
+      "integrity": "sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      }
+    },
     "@babel/plugin-syntax-json-strings": {
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz",
@@ -8825,6 +12717,15 @@
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.8.0"
+      }
+    },
+    "@babel/plugin-syntax-jsx": {
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.22.5.tgz",
+      "integrity": "sha512-gvyP4hZrgrs/wWMaocvxZ44Hw0b3W8Pe+cMxc8V1ULQ07oh8VNbIRaoD1LRZVTvD+0nieDKjfgKg89sD7rrKrg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.22.5"
       }
     },
     "@babel/plugin-syntax-logical-assignment-operators": {
@@ -8897,6 +12798,15 @@
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.14.5"
+      }
+    },
+    "@babel/plugin-syntax-typescript": {
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.22.5.tgz",
+      "integrity": "sha512-1mS2o03i7t1c6VzH6fdQ3OA8tcEIxwG18zIPRp+UY1Ihv6W+XZzBCVxExF9upussPXJ0xE9XRHwMoNs1ep/nRQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.22.5"
       }
     },
     "@babel/plugin-transform-arrow-functions": {
@@ -9362,34 +13272,24 @@
         "@babel/types": "^7.16.0",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.3.2",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
-          "dev": true,
-          "requires": {
-            "ms": "2.1.2"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
-        }
       }
     },
     "@babel/types": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.16.0.tgz",
-      "integrity": "sha512-PJgg/k3SdLsGb3hhisFvtLOw5ts113klrpLuIPtCJIU+BB24fqq6lf8RWqKJEjzqXR9AEH1rIb5XTqwBHB+kQg==",
+      "version": "7.23.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.0.tgz",
+      "integrity": "sha512-0oIyUfKoI3mSqMvsxBdclDwxXKXAUA8v/apZbc+iSyARYou1o8ZGDxbUYyLFoW2arqS2jDGqJuZvv1d/io1axg==",
       "dev": true,
       "requires": {
-        "@babel/helper-validator-identifier": "^7.15.7",
+        "@babel/helper-string-parser": "^7.22.5",
+        "@babel/helper-validator-identifier": "^7.22.20",
         "to-fast-properties": "^2.0.0"
       }
+    },
+    "@bcoe/v8-coverage": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
+      "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
+      "dev": true
     },
     "@bergos/jsonparse": {
       "version": "1.4.1",
@@ -9410,6 +13310,741 @@
             "ieee754": "^1.2.1"
           }
         }
+      }
+    },
+    "@istanbuljs/load-nyc-config": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
+      "integrity": "sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==",
+      "dev": true,
+      "requires": {
+        "camelcase": "^5.3.1",
+        "find-up": "^4.1.0",
+        "get-package-type": "^0.1.0",
+        "js-yaml": "^3.13.1",
+        "resolve-from": "^5.0.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^5.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^4.1.0"
+          }
+        },
+        "p-locate": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.2.0"
+          }
+        },
+        "path-exists": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+          "dev": true
+        },
+        "resolve-from": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+          "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+          "dev": true
+        }
+      }
+    },
+    "@istanbuljs/schema": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
+      "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
+      "dev": true
+    },
+    "@jest/console": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/console/-/console-29.7.0.tgz",
+      "integrity": "sha512-5Ni4CU7XHQi32IJ398EEP4RrB8eV09sXP2ROqD4bksHrnTree52PsxvX8tpL8LvTZ3pFzXyPbNQReSN41CAhOg==",
+      "dev": true,
+      "requires": {
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "slash": "^3.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "slash": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+          "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "@jest/core": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/core/-/core-29.7.0.tgz",
+      "integrity": "sha512-n7aeXWKMnGtDA48y8TLWJPJmLmmZ642Ceo78cYWEpiD7FzDgmNDV/GCVRorPABdXLJZ/9wzzgZAlHjXjxDHGsg==",
+      "dev": true,
+      "requires": {
+        "@jest/console": "^29.7.0",
+        "@jest/reporters": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.0.0",
+        "ci-info": "^3.2.0",
+        "exit": "^0.1.2",
+        "graceful-fs": "^4.2.9",
+        "jest-changed-files": "^29.7.0",
+        "jest-config": "^29.7.0",
+        "jest-haste-map": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-regex-util": "^29.6.3",
+        "jest-resolve": "^29.7.0",
+        "jest-resolve-dependencies": "^29.7.0",
+        "jest-runner": "^29.7.0",
+        "jest-runtime": "^29.7.0",
+        "jest-snapshot": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "jest-watcher": "^29.7.0",
+        "micromatch": "^4.0.4",
+        "pretty-format": "^29.7.0",
+        "slash": "^3.0.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "dependencies": {
+        "ansi-escapes": {
+          "version": "4.3.2",
+          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+          "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+          "dev": true,
+          "requires": {
+            "type-fest": "^0.21.3"
+          }
+        },
+        "ansi-regex": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "slash": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+          "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.1"
+          }
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "@jest/environment": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.7.0.tgz",
+      "integrity": "sha512-aQIfHDq33ExsN4jP1NWGXhxgQ/wixs60gDiKO+XVMd8Mn0NWPWgc34ZQDTb2jKaUWQ7MuwoitXAsN2XVXNMpAw==",
+      "dev": true,
+      "requires": {
+        "@jest/fake-timers": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "jest-mock": "^29.7.0"
+      }
+    },
+    "@jest/expect": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-29.7.0.tgz",
+      "integrity": "sha512-8uMeAMycttpva3P1lBHB8VciS9V0XAr3GymPpipdyQXbBcuhkLQOSe8E/p92RyAdToS6ZD1tFkX+CkhoECE0dQ==",
+      "dev": true,
+      "requires": {
+        "expect": "^29.7.0",
+        "jest-snapshot": "^29.7.0"
+      }
+    },
+    "@jest/expect-utils": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.7.0.tgz",
+      "integrity": "sha512-GlsNBWiFQFCVi9QVSx7f5AgMeLxe9YCCs5PuP2O2LdjDAA8Jh9eX7lA1Jq/xdXw3Wb3hyvlFNfZIfcRetSzYcA==",
+      "dev": true,
+      "requires": {
+        "jest-get-type": "^29.6.3"
+      }
+    },
+    "@jest/fake-timers": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.7.0.tgz",
+      "integrity": "sha512-q4DH1Ha4TTFPdxLsqDXK1d3+ioSL7yL5oCMJZgDYm6i+6CygW5E5xVr/D1HdsGxjt1ZWSfUAs9OxSB/BNelWrQ==",
+      "dev": true,
+      "requires": {
+        "@jest/types": "^29.6.3",
+        "@sinonjs/fake-timers": "^10.0.2",
+        "@types/node": "*",
+        "jest-message-util": "^29.7.0",
+        "jest-mock": "^29.7.0",
+        "jest-util": "^29.7.0"
+      }
+    },
+    "@jest/globals": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.7.0.tgz",
+      "integrity": "sha512-mpiz3dutLbkW2MNFubUGUEVLkTGiqW6yLVTA+JbP6fI6J5iL9Y0Nlg8k95pcF8ctKwCS7WVxteBs29hhfAotzQ==",
+      "dev": true,
+      "requires": {
+        "@jest/environment": "^29.7.0",
+        "@jest/expect": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "jest-mock": "^29.7.0"
+      }
+    },
+    "@jest/reporters": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-29.7.0.tgz",
+      "integrity": "sha512-DApq0KJbJOEzAFYjHADNNxAE3KbhxQB1y5Kplb5Waqw6zVbuWatSnMjE5gs8FUgEPmNsnZA3NCWl9NG0ia04Pg==",
+      "dev": true,
+      "requires": {
+        "@bcoe/v8-coverage": "^0.2.3",
+        "@jest/console": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@jridgewell/trace-mapping": "^0.3.18",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "collect-v8-coverage": "^1.0.0",
+        "exit": "^0.1.2",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.2.9",
+        "istanbul-lib-coverage": "^3.0.0",
+        "istanbul-lib-instrument": "^6.0.0",
+        "istanbul-lib-report": "^3.0.0",
+        "istanbul-lib-source-maps": "^4.0.0",
+        "istanbul-reports": "^3.1.3",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-worker": "^29.7.0",
+        "slash": "^3.0.0",
+        "string-length": "^4.0.1",
+        "strip-ansi": "^6.0.0",
+        "v8-to-istanbul": "^9.0.1"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "istanbul-lib-coverage": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.0.tgz",
+          "integrity": "sha512-eOeJ5BHCmHYvQK7xt9GkdHuzuCGS1Y6g9Gvnx3Ym33fz/HpLRYxiS0wHNr+m/MBC8B647Xt608vCDEvhl9c6Mw==",
+          "dev": true
+        },
+        "istanbul-lib-instrument": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.1.tgz",
+          "integrity": "sha512-EAMEJBsYuyyztxMxW3g7ugGPkrZsV57v0Hmv3mm1uQsmB+QnZuepg731CRaIgeUVSdmsTngOkSnauNF8p7FIhA==",
+          "dev": true,
+          "requires": {
+            "@babel/core": "^7.12.3",
+            "@babel/parser": "^7.14.7",
+            "@istanbuljs/schema": "^0.1.2",
+            "istanbul-lib-coverage": "^3.2.0",
+            "semver": "^7.5.4"
+          }
+        },
+        "istanbul-lib-report": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+          "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+          "dev": true,
+          "requires": {
+            "istanbul-lib-coverage": "^3.0.0",
+            "make-dir": "^4.0.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "istanbul-lib-source-maps": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.1.tgz",
+          "integrity": "sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==",
+          "dev": true,
+          "requires": {
+            "debug": "^4.1.1",
+            "istanbul-lib-coverage": "^3.0.0",
+            "source-map": "^0.6.1"
+          }
+        },
+        "istanbul-reports": {
+          "version": "3.1.6",
+          "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.1.6.tgz",
+          "integrity": "sha512-TLgnMkKg3iTDsQ9PbPTdpfAK2DzjF9mqUG7RMgcQl8oFjad8ob4laGxv5XV5U9MAfx8D6tSJiUyuAwzLicaxlg==",
+          "dev": true,
+          "requires": {
+            "html-escaper": "^2.0.0",
+            "istanbul-lib-report": "^3.0.0"
+          }
+        },
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "dev": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "make-dir": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+          "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+          "dev": true,
+          "requires": {
+            "semver": "^7.5.3"
+          }
+        },
+        "semver": {
+          "version": "7.5.4",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+          "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "slash": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+          "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.1"
+          }
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+          "dev": true
+        }
+      }
+    },
+    "@jest/schemas": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
+      "dev": true,
+      "requires": {
+        "@sinclair/typebox": "^0.27.8"
+      }
+    },
+    "@jest/source-map": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-29.6.3.tgz",
+      "integrity": "sha512-MHjT95QuipcPrpLM+8JMSzFx6eHp5Bm+4XeFDJlwsvVBjmKNiIAvasGK2fxz2WbGRlnvqehFbh07MMa7n3YJnw==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/trace-mapping": "^0.3.18",
+        "callsites": "^3.0.0",
+        "graceful-fs": "^4.2.9"
+      }
+    },
+    "@jest/test-result": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-29.7.0.tgz",
+      "integrity": "sha512-Fdx+tv6x1zlkJPcWXmMDAG2HBnaR9XPSd5aDWQVsfrZmLVT3lU1cwyxLgRmXR9yrq4NBoEm9BMsfgFzTQAbJYA==",
+      "dev": true,
+      "requires": {
+        "@jest/console": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "collect-v8-coverage": "^1.0.0"
+      }
+    },
+    "@jest/test-sequencer": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-29.7.0.tgz",
+      "integrity": "sha512-GQwJ5WZVrKnOJuiYiAF52UNUJXgTZx1NHjFSEB0qEMmSZKAkdMoIzw/Cj6x6NF4AvV23AUqDpFzQkN/eYCYTxw==",
+      "dev": true,
+      "requires": {
+        "@jest/test-result": "^29.7.0",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.7.0",
+        "slash": "^3.0.0"
+      },
+      "dependencies": {
+        "slash": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+          "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+          "dev": true
+        }
+      }
+    },
+    "@jest/transform": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.7.0.tgz",
+      "integrity": "sha512-ok/BTPFzFKVMwO5eOHRrvnBVHdRy9IrsrW1GpMaQ9MCnilNLXQKmAX8s1YXDFaai9xJpac2ySzV0YeRRECr2Vw==",
+      "dev": true,
+      "requires": {
+        "@babel/core": "^7.11.6",
+        "@jest/types": "^29.6.3",
+        "@jridgewell/trace-mapping": "^0.3.18",
+        "babel-plugin-istanbul": "^6.1.1",
+        "chalk": "^4.0.0",
+        "convert-source-map": "^2.0.0",
+        "fast-json-stable-stringify": "^2.1.0",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.7.0",
+        "jest-regex-util": "^29.6.3",
+        "jest-util": "^29.7.0",
+        "micromatch": "^4.0.4",
+        "pirates": "^4.0.4",
+        "slash": "^3.0.0",
+        "write-file-atomic": "^4.0.2"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "convert-source-map": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+          "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "slash": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+          "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
+        "write-file-atomic": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.2.tgz",
+          "integrity": "sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==",
+          "dev": true,
+          "requires": {
+            "imurmurhash": "^0.1.4",
+            "signal-exit": "^3.0.7"
+          }
+        }
+      }
+    },
+    "@jest/types": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
+      "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
+      "dev": true,
+      "requires": {
+        "@jest/schemas": "^29.6.3",
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "@types/istanbul-reports": "^3.0.0",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.8",
+        "chalk": "^4.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "@jridgewell/resolve-uri": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz",
+      "integrity": "sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==",
+      "dev": true
+    },
+    "@jridgewell/sourcemap-codec": {
+      "version": "1.4.15",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
+      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
+      "dev": true
+    },
+    "@jridgewell/trace-mapping": {
+      "version": "0.3.20",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.20.tgz",
+      "integrity": "sha512-R8LcPeWZol2zR8mmH3JeKQ6QRCFb7XgUhV9ZlGhHLGyg4wpPiPZNQOOWhFZhxKw8u//yTbNGI42Bx/3paXEQ+Q==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
     "@nicolo-ribaudo/chokidar-2": {
@@ -9446,6 +14081,80 @@
         "xmlchars": "^2.2.0"
       }
     },
+    "@sinclair/typebox": {
+      "version": "0.27.8",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
+      "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
+      "dev": true
+    },
+    "@sinonjs/commons": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.0.tgz",
+      "integrity": "sha512-jXBtWAF4vmdNmZgD5FoKsVLv3rPgDnLgPbU84LIJ3otV44vJlDRokVng5v8NFJdCf/da9legHcKaRuZs4L7faA==",
+      "dev": true,
+      "requires": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "@sinonjs/fake-timers": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.3.0.tgz",
+      "integrity": "sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^3.0.0"
+      }
+    },
+    "@types/babel__core": {
+      "version": "7.20.3",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.3.tgz",
+      "integrity": "sha512-54fjTSeSHwfan8AyHWrKbfBWiEUrNTZsUwPTDSNaaP1QDQIZbeNUg3a59E9D+375MzUw/x1vx2/0F5LBz+AeYA==",
+      "dev": true,
+      "requires": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "@types/babel__generator": {
+      "version": "7.6.6",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.6.tgz",
+      "integrity": "sha512-66BXMKb/sUWbMdBNdMvajU7i/44RkrA3z/Yt1c7R5xejt8qh84iU54yUWCtm0QwGJlDcf/gg4zd/x4mpLAlb/w==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "@types/babel__template": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.3.tgz",
+      "integrity": "sha512-ciwyCLeuRfxboZ4isgdNZi/tkt06m8Tw6uGbBSBgWrnnZGNXiEyM27xc/PjXGQLqlZ6ylbgHMnm7ccF9tCkOeQ==",
+      "dev": true,
+      "requires": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "@types/babel__traverse": {
+      "version": "7.20.3",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.20.3.tgz",
+      "integrity": "sha512-Lsh766rGEFbaxMIDH7Qa+Yha8cMVI3qAK6CHt3OR0YfxOIn5Z54iHiyDRycHrBqeIiqGa20Kpsv1cavfBKkRSw==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.20.7"
+      }
+    },
+    "@types/graceful-fs": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.8.tgz",
+      "integrity": "sha512-NhRH7YzWq8WiNKVavKPBmtLYZHxNY19Hh+az28O/phfp68CF45pMFud+ZzJ8ewnxnC5smIdF3dqFeiSUQ5I+pw==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/http-link-header": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@types/http-link-header/-/http-link-header-1.0.3.tgz",
@@ -9453,6 +14162,30 @@
       "dev": true,
       "requires": {
         "@types/node": "*"
+      }
+    },
+    "@types/istanbul-lib-coverage": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.5.tgz",
+      "integrity": "sha512-zONci81DZYCZjiLe0r6equvZut0b+dBRPBN5kBDjsONnutYNtJMoWQ9uR2RkL1gLG9NMTzvf+29e5RFfPbeKhQ==",
+      "dev": true
+    },
+    "@types/istanbul-lib-report": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.2.tgz",
+      "integrity": "sha512-8toY6FgdltSdONav1XtUHl4LN1yTmLza+EuDazb/fEmRNCwjyqNVIQWs2IfC74IqjHkREs/nQ2FWq5kZU9IC0w==",
+      "dev": true,
+      "requires": {
+        "@types/istanbul-lib-coverage": "*"
+      }
+    },
+    "@types/istanbul-reports": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.3.tgz",
+      "integrity": "sha512-1nESsePMBlf0RPRffLZi5ujYh7IH1BWL4y9pr+Bn3cJBdxz+RTP8bUFljLz9HvzhhOSWKdyBZ4DIivdL6rvgZg==",
+      "dev": true,
+      "requires": {
+        "@types/istanbul-lib-report": "*"
       }
     },
     "@types/json-stable-stringify": {
@@ -9501,6 +14234,27 @@
       "requires": {
         "@types/node": "*"
       }
+    },
+    "@types/stack-utils": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.2.tgz",
+      "integrity": "sha512-g7CK9nHdwjK2n0ymT2CW698FuWJRIx+RP6embAzZ2Qi8/ilIrA1Imt2LVSeHUzKvpoi7BhmmQcXz95eS0f2JXw==",
+      "dev": true
+    },
+    "@types/yargs": {
+      "version": "17.0.28",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.28.tgz",
+      "integrity": "sha512-N3e3fkS86hNhtk6BEnc0rj3zcehaxx8QWhCROJkqpl5Zaoi7nAic3jH8q94jVD3zu5LGk+PUB6KAiDmimYOEQw==",
+      "dev": true,
+      "requires": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "@types/yargs-parser": {
+      "version": "21.0.1",
+      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.1.tgz",
+      "integrity": "sha512-axdPBuLuEJt0c4yI5OZssC19K2Mq1uKdrfZBzuxLvaztgqUtFYZUNw7lETExPYJR9jdEoIg4mb7RQKRQzOkeGQ==",
+      "dev": true
     },
     "@ungap/promise-all-settled": {
       "version": "1.1.2",
@@ -9698,6 +14452,78 @@
       "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==",
       "dev": true
     },
+    "babel-jest": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.7.0.tgz",
+      "integrity": "sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg==",
+      "dev": true,
+      "requires": {
+        "@jest/transform": "^29.7.0",
+        "@types/babel__core": "^7.1.14",
+        "babel-plugin-istanbul": "^6.1.1",
+        "babel-preset-jest": "^29.6.3",
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.9",
+        "slash": "^3.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "slash": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+          "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
     "babel-plugin-dynamic-import-node": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.3.tgz",
@@ -9705,6 +14531,69 @@
       "dev": true,
       "requires": {
         "object.assign": "^4.1.0"
+      }
+    },
+    "babel-plugin-istanbul": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-6.1.1.tgz",
+      "integrity": "sha512-Y1IQok9821cC9onCx5otgFfRm7Lm+I+wwxOx738M/WLPZ9Q42m4IG5W0FNX8WLL2gYMZo3JkuXIH2DOpWM+qwA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@istanbuljs/load-nyc-config": "^1.0.0",
+        "@istanbuljs/schema": "^0.1.2",
+        "istanbul-lib-instrument": "^5.0.4",
+        "test-exclude": "^6.0.0"
+      },
+      "dependencies": {
+        "istanbul-lib-coverage": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.0.tgz",
+          "integrity": "sha512-eOeJ5BHCmHYvQK7xt9GkdHuzuCGS1Y6g9Gvnx3Ym33fz/HpLRYxiS0wHNr+m/MBC8B647Xt608vCDEvhl9c6Mw==",
+          "dev": true
+        },
+        "istanbul-lib-instrument": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-5.2.1.tgz",
+          "integrity": "sha512-pzqtp31nLv/XFOzXGuvhCb8qhjmTVo5vjVk19XE4CRlSWz0KoeJ3bw9XsA7nOp9YBf4qHjwBxkDzKcME/J29Yg==",
+          "dev": true,
+          "requires": {
+            "@babel/core": "^7.12.3",
+            "@babel/parser": "^7.14.7",
+            "@istanbuljs/schema": "^0.1.2",
+            "istanbul-lib-coverage": "^3.2.0",
+            "semver": "^6.3.0"
+          }
+        },
+        "semver": {
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+          "dev": true
+        },
+        "test-exclude": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
+          "integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
+          "dev": true,
+          "requires": {
+            "@istanbuljs/schema": "^0.1.2",
+            "glob": "^7.1.4",
+            "minimatch": "^3.0.4"
+          }
+        }
+      }
+    },
+    "babel-plugin-jest-hoist": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-29.6.3.tgz",
+      "integrity": "sha512-ESAc/RJvGTFEzRwOTT4+lNDk/GNHMkKbNzsvT0qKRfDyyYTskxB5rnU2njIDYVxXCBHHEI1c0YwHob3WaYujOg==",
+      "dev": true,
+      "requires": {
+        "@babel/template": "^7.3.3",
+        "@babel/types": "^7.3.3",
+        "@types/babel__core": "^7.1.14",
+        "@types/babel__traverse": "^7.0.6"
       }
     },
     "babel-plugin-polyfill-corejs2": {
@@ -9743,6 +14632,36 @@
       "dev": true,
       "requires": {
         "@babel/helper-define-polyfill-provider": "^0.2.4"
+      }
+    },
+    "babel-preset-current-node-syntax": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.0.1.tgz",
+      "integrity": "sha512-M7LQ0bxarkxQoN+vz5aJPsLBn77n8QgTFmo8WK0/44auK2xlCXrYcUxHFxgU7qW5Yzw/CjmLRK2uJzaCd7LvqQ==",
+      "dev": true,
+      "requires": {
+        "@babel/plugin-syntax-async-generators": "^7.8.4",
+        "@babel/plugin-syntax-bigint": "^7.8.3",
+        "@babel/plugin-syntax-class-properties": "^7.8.3",
+        "@babel/plugin-syntax-import-meta": "^7.8.3",
+        "@babel/plugin-syntax-json-strings": "^7.8.3",
+        "@babel/plugin-syntax-logical-assignment-operators": "^7.8.3",
+        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
+        "@babel/plugin-syntax-numeric-separator": "^7.8.3",
+        "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
+        "@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
+        "@babel/plugin-syntax-optional-chaining": "^7.8.3",
+        "@babel/plugin-syntax-top-level-await": "^7.8.3"
+      }
+    },
+    "babel-preset-jest": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-29.6.3.tgz",
+      "integrity": "sha512-0B3bhxR6snWXJZtR/RliHTDPRgn1sNHOR0yVtq/IiQFyuOVjFS+wuio/R4gSNkyYmKmJB4wGZv2NZanmKmTnNA==",
+      "dev": true,
+      "requires": {
+        "babel-plugin-jest-hoist": "^29.6.3",
+        "babel-preset-current-node-syntax": "^1.0.0"
       }
     },
     "balanced-match": {
@@ -10016,6 +14935,15 @@
         "picocolors": "^1.0.0"
       }
     },
+    "bser": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
+      "integrity": "sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==",
+      "dev": true,
+      "requires": {
+        "node-int64": "^0.4.0"
+      }
+    },
     "buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.2.1.tgz",
@@ -10127,6 +15055,12 @@
         "supports-color": "^5.3.0"
       }
     },
+    "char-regex": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
+      "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
+      "dev": true
+    },
     "chardet": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
@@ -10168,6 +15102,12 @@
         }
       }
     },
+    "ci-info": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
+      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
+      "dev": true
+    },
     "cipher-base": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
@@ -10177,6 +15117,12 @@
         "inherits": "^2.0.1",
         "safe-buffer": "^5.0.1"
       }
+    },
+    "cjs-module-lexer": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.3.tgz",
+      "integrity": "sha512-0TNiGstbQmCFwt4akjjBg5pLRTSyj/PkWQ1ZoO2zntmg9yLqSRxwEa4iCfQLGjqhiqBfOJa7W/E8wfGrTDmlZQ==",
+      "dev": true
     },
     "cli-cursor": {
       "version": "2.1.0",
@@ -10242,6 +15188,18 @@
         "kind-of": "^6.0.2",
         "shallow-clone": "^3.0.0"
       }
+    },
+    "co": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "integrity": "sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==",
+      "dev": true
+    },
+    "collect-v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-lHl4d5/ONEbLlJvaJNtsF/Lz+WvB07u2ycqTYbdrq7UypDXailES4valYb2eWiJFxZlVmpGekfqoxQhzyFdT4Q==",
+      "dev": true
     },
     "color-convert": {
       "version": "1.9.3",
@@ -10457,6 +15415,72 @@
         "sha.js": "^2.4.8"
       }
     },
+    "create-jest": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/create-jest/-/create-jest-29.7.0.tgz",
+      "integrity": "sha512-Adz2bdH0Vq3F53KEMJOoftQFutWCukm6J24wbPWRO4k1kMY7gS7ds/uoJkNuV8wDCtWWnuwGcJwpWcih+zEW1Q==",
+      "dev": true,
+      "requires": {
+        "@jest/types": "^29.6.3",
+        "chalk": "^4.0.0",
+        "exit": "^0.1.2",
+        "graceful-fs": "^4.2.9",
+        "jest-config": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "prompts": "^2.0.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
     "cross-fetch": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
@@ -10504,11 +15528,27 @@
       "integrity": "sha512-Vy4dx7gquTeMcQR/hDkYLGUnwVil6vk4FOOct+djUnHOUWt+zJPJAaRIXaAFkPXtJjvlY7o3rfRu0/3hpnwoUA==",
       "dev": true
     },
+    "debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dev": true,
+      "requires": {
+        "ms": "2.1.2"
+      }
+    },
     "decamelize": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
       "dev": true
+    },
+    "dedent": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.5.1.tgz",
+      "integrity": "sha512-+LxW+KLWxu3HW3M2w2ympwtqPrqYRzU8fqi6Fhd18fBALe15blJPI/I4+UHveMVG6lJqB4JNd4UG0S5cnVHwIg==",
+      "dev": true,
+      "requires": {}
     },
     "deep-eql": {
       "version": "3.0.1",
@@ -10523,6 +15563,12 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+      "dev": true
+    },
+    "deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
       "dev": true
     },
     "default-require-extensions": {
@@ -10571,6 +15617,12 @@
         "minimalistic-assert": "^1.0.0"
       }
     },
+    "detect-newline": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
+      "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
+      "dev": true
+    },
     "detective": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/detective/-/detective-5.2.0.tgz",
@@ -10586,6 +15638,12 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
       "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
+      "dev": true
+    },
+    "diff-sequences": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
+      "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
       "dev": true
     },
     "diffie-hellman": {
@@ -10705,6 +15763,12 @@
         }
       }
     },
+    "emittery": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.13.1.tgz",
+      "integrity": "sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==",
+      "dev": true
+    },
     "emoji-regex": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
@@ -10819,23 +15883,6 @@
         "strip-json-comments": "^2.0.1",
         "table": "^5.2.3",
         "text-table": "^0.2.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.3.2",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
-          "dev": true,
-          "requires": {
-            "ms": "2.1.2"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
-        }
       }
     },
     "eslint-scope": {
@@ -10947,6 +15994,106 @@
         "safe-buffer": "^5.1.1"
       }
     },
+    "execa": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.0",
+        "human-signals": "^2.1.0",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.1",
+        "onetime": "^5.1.2",
+        "signal-exit": "^3.0.3",
+        "strip-final-newline": "^2.0.0"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+          "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+          "dev": true,
+          "requires": {
+            "path-key": "^3.1.0",
+            "shebang-command": "^2.0.0",
+            "which": "^2.0.1"
+          }
+        },
+        "is-stream": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+          "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+          "dev": true
+        },
+        "mimic-fn": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+          "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+          "dev": true
+        },
+        "onetime": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+          "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+          "dev": true,
+          "requires": {
+            "mimic-fn": "^2.1.0"
+          }
+        },
+        "path-key": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+          "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+          "dev": true
+        },
+        "shebang-command": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+          "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+          "dev": true,
+          "requires": {
+            "shebang-regex": "^3.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+          "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+          "dev": true
+        },
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
+      }
+    },
+    "exit": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+      "integrity": "sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==",
+      "dev": true
+    },
+    "expect": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-29.7.0.tgz",
+      "integrity": "sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==",
+      "dev": true,
+      "requires": {
+        "@jest/expect-utils": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "jest-matcher-utils": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0"
+      }
+    },
     "external-editor": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
@@ -10981,6 +16128,15 @@
       "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
       "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
       "dev": true
+    },
+    "fb-watchman": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.2.tgz",
+      "integrity": "sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==",
+      "dev": true,
+      "requires": {
+        "bser": "2.1.1"
+      }
     },
     "figures": {
       "version": "2.0.0",
@@ -11157,6 +16313,18 @@
         "has-symbols": "^1.0.1"
       }
     },
+    "get-package-type": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
+      "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
+      "dev": true
+    },
+    "get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "dev": true
+    },
     "get-symbol-description": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.0.tgz",
@@ -11197,9 +16365,9 @@
       "dev": true
     },
     "graceful-fs": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
-      "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true
     },
     "growl": {
@@ -11340,6 +16508,12 @@
       "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=",
       "dev": true
     },
+    "human-signals": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+      "dev": true
+    },
     "iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -11369,6 +16543,61 @@
       "requires": {
         "parent-module": "^1.0.0",
         "resolve-from": "^4.0.0"
+      }
+    },
+    "import-local": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.1.0.tgz",
+      "integrity": "sha512-ASB07uLtnDs1o6EHjKpX34BKYDSqnFerfTOJL2HvMqF70LnxpjkzDB8J44oT9pu4AMPkQwf8jl6szgvNd2tRIg==",
+      "dev": true,
+      "requires": {
+        "pkg-dir": "^4.2.0",
+        "resolve-cwd": "^3.0.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^5.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^4.1.0"
+          }
+        },
+        "p-locate": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.2.0"
+          }
+        },
+        "path-exists": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+          "dev": true
+        },
+        "pkg-dir": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+          "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+          "dev": true,
+          "requires": {
+            "find-up": "^4.0.0"
+          }
+        }
       }
     },
     "imurmurhash": {
@@ -11546,6 +16775,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
       "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "dev": true
+    },
+    "is-generator-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
+      "integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==",
       "dev": true
     },
     "is-generator-function": {
@@ -11758,21 +16993,6 @@
         "source-map": "^0.6.1"
       },
       "dependencies": {
-        "debug": {
-          "version": "4.3.2",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
-          "dev": true,
-          "requires": {
-            "ms": "2.1.2"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
-        },
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -11788,6 +17008,1369 @@
       "dev": true,
       "requires": {
         "html-escaper": "^2.0.0"
+      }
+    },
+    "jest": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz",
+      "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
+      "dev": true,
+      "requires": {
+        "@jest/core": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "import-local": "^3.0.2",
+        "jest-cli": "^29.7.0"
+      }
+    },
+    "jest-changed-files": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-29.7.0.tgz",
+      "integrity": "sha512-fEArFiwf1BpQ+4bXSprcDc3/x4HSzL4al2tozwVpDFpsxALjLYdyiIK4e5Vz66GQJIbXJ82+35PtysofptNX2w==",
+      "dev": true,
+      "requires": {
+        "execa": "^5.0.0",
+        "jest-util": "^29.7.0",
+        "p-limit": "^3.1.0"
+      },
+      "dependencies": {
+        "p-limit": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+          "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+          "dev": true,
+          "requires": {
+            "yocto-queue": "^0.1.0"
+          }
+        }
+      }
+    },
+    "jest-circus": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-29.7.0.tgz",
+      "integrity": "sha512-3E1nCMgipcTkCocFwM90XXQab9bS+GMsjdpmPrlelaxwD93Ad8iVEjX/vvHPdLPnFf+L40u+5+iutRdA1N9myw==",
+      "dev": true,
+      "requires": {
+        "@jest/environment": "^29.7.0",
+        "@jest/expect": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "co": "^4.6.0",
+        "dedent": "^1.0.0",
+        "is-generator-fn": "^2.0.0",
+        "jest-each": "^29.7.0",
+        "jest-matcher-utils": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-runtime": "^29.7.0",
+        "jest-snapshot": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "p-limit": "^3.1.0",
+        "pretty-format": "^29.7.0",
+        "pure-rand": "^6.0.0",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.3"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "p-limit": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+          "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+          "dev": true,
+          "requires": {
+            "yocto-queue": "^0.1.0"
+          }
+        },
+        "slash": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+          "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "jest-cli": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-29.7.0.tgz",
+      "integrity": "sha512-OVVobw2IubN/GSYsxETi+gOe7Ka59EFMR/twOU3Jb2GnKKeMGJB5SGUUrEz3SFVmJASUdZUzy83sLNNQ2gZslg==",
+      "dev": true,
+      "requires": {
+        "@jest/core": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "chalk": "^4.0.0",
+        "create-jest": "^29.7.0",
+        "exit": "^0.1.2",
+        "import-local": "^3.0.2",
+        "jest-config": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "yargs": "^17.3.1"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "cliui": {
+          "version": "8.0.1",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+          "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+          "dev": true,
+          "requires": {
+            "string-width": "^4.2.0",
+            "strip-ansi": "^6.0.1",
+            "wrap-ansi": "^7.0.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+          "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.1"
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.1"
+          }
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
+        "wrap-ansi": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+          "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.0.0",
+            "string-width": "^4.1.0",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "y18n": {
+          "version": "5.0.8",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+          "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+          "dev": true
+        },
+        "yargs": {
+          "version": "17.7.2",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+          "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+          "dev": true,
+          "requires": {
+            "cliui": "^8.0.1",
+            "escalade": "^3.1.1",
+            "get-caller-file": "^2.0.5",
+            "require-directory": "^2.1.1",
+            "string-width": "^4.2.3",
+            "y18n": "^5.0.5",
+            "yargs-parser": "^21.1.1"
+          }
+        },
+        "yargs-parser": {
+          "version": "21.1.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+          "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+          "dev": true
+        }
+      }
+    },
+    "jest-config": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-29.7.0.tgz",
+      "integrity": "sha512-uXbpfeQ7R6TZBqI3/TxCU4q4ttk3u0PJeC+E0zbfSoSjq6bJ7buBPxzQPL0ifrkY4DNu4JUdk0ImlBUYi840eQ==",
+      "dev": true,
+      "requires": {
+        "@babel/core": "^7.11.6",
+        "@jest/test-sequencer": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "babel-jest": "^29.7.0",
+        "chalk": "^4.0.0",
+        "ci-info": "^3.2.0",
+        "deepmerge": "^4.2.2",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.2.9",
+        "jest-circus": "^29.7.0",
+        "jest-environment-node": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "jest-regex-util": "^29.6.3",
+        "jest-resolve": "^29.7.0",
+        "jest-runner": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "micromatch": "^4.0.4",
+        "parse-json": "^5.2.0",
+        "pretty-format": "^29.7.0",
+        "slash": "^3.0.0",
+        "strip-json-comments": "^3.1.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "parse-json": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+          "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "error-ex": "^1.3.1",
+            "json-parse-even-better-errors": "^2.3.0",
+            "lines-and-columns": "^1.1.6"
+          }
+        },
+        "slash": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+          "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+          "dev": true
+        },
+        "strip-json-comments": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+          "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "jest-diff": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.7.0.tgz",
+      "integrity": "sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==",
+      "dev": true,
+      "requires": {
+        "chalk": "^4.0.0",
+        "diff-sequences": "^29.6.3",
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "jest-docblock": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-29.7.0.tgz",
+      "integrity": "sha512-q617Auw3A612guyaFgsbFeYpNP5t2aoUNLwBUbc/0kD1R4t9ixDbyFTHd1nok4epoVFpr7PmeWHrhvuV3XaJ4g==",
+      "dev": true,
+      "requires": {
+        "detect-newline": "^3.0.0"
+      }
+    },
+    "jest-each": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-29.7.0.tgz",
+      "integrity": "sha512-gns+Er14+ZrEoC5fhOfYCY1LOHHr0TI+rQUHZS8Ttw2l7gl+80eHc/gFf2Ktkw0+SIACDTeWvpFcv3B04VembQ==",
+      "dev": true,
+      "requires": {
+        "@jest/types": "^29.6.3",
+        "chalk": "^4.0.0",
+        "jest-get-type": "^29.6.3",
+        "jest-util": "^29.7.0",
+        "pretty-format": "^29.7.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "jest-environment-node": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-29.7.0.tgz",
+      "integrity": "sha512-DOSwCRqXirTOyheM+4d5YZOrWcdu0LNZ87ewUoywbcb2XR4wKgqiG8vNeYwhjFMbEkfju7wx2GYH0P2gevGvFw==",
+      "dev": true,
+      "requires": {
+        "@jest/environment": "^29.7.0",
+        "@jest/fake-timers": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "jest-mock": "^29.7.0",
+        "jest-util": "^29.7.0"
+      }
+    },
+    "jest-get-type": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.6.3.tgz",
+      "integrity": "sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==",
+      "dev": true
+    },
+    "jest-haste-map": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.7.0.tgz",
+      "integrity": "sha512-fP8u2pyfqx0K1rGn1R9pyE0/KTn+G7PxktWidOBTqFPLYX0b9ksaMFkhK5vrS3DVun09pckLdlx90QthlW7AmA==",
+      "dev": true,
+      "requires": {
+        "@jest/types": "^29.6.3",
+        "@types/graceful-fs": "^4.1.3",
+        "@types/node": "*",
+        "anymatch": "^3.0.3",
+        "fb-watchman": "^2.0.0",
+        "fsevents": "^2.3.2",
+        "graceful-fs": "^4.2.9",
+        "jest-regex-util": "^29.6.3",
+        "jest-util": "^29.7.0",
+        "jest-worker": "^29.7.0",
+        "micromatch": "^4.0.4",
+        "walker": "^1.0.8"
+      }
+    },
+    "jest-leak-detector": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-29.7.0.tgz",
+      "integrity": "sha512-kYA8IJcSYtST2BY9I+SMC32nDpBT3J2NvWJx8+JCuCdl/CR1I4EKUJROiP8XtCcxqgTTBGJNdbB1A8XRKbTetw==",
+      "dev": true,
+      "requires": {
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      }
+    },
+    "jest-matcher-utils": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.7.0.tgz",
+      "integrity": "sha512-sBkD+Xi9DtcChsI3L3u0+N0opgPYnCRPtGcQYrgXmR+hmt/fYfWAL0xRXYU8eWOdfuLgBe0YCW3AFtnRLagq/g==",
+      "dev": true,
+      "requires": {
+        "chalk": "^4.0.0",
+        "jest-diff": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "jest-message-util": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.7.0.tgz",
+      "integrity": "sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.12.13",
+        "@jest/types": "^29.6.3",
+        "@types/stack-utils": "^2.0.0",
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.9",
+        "micromatch": "^4.0.4",
+        "pretty-format": "^29.7.0",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.3"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "slash": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+          "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "jest-mock": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.7.0.tgz",
+      "integrity": "sha512-ITOMZn+UkYS4ZFh83xYAOzWStloNzJFO2s8DWrE4lhtGD+AorgnbkiKERe4wQVBydIGPx059g6riW5Btp6Llnw==",
+      "dev": true,
+      "requires": {
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "jest-util": "^29.7.0"
+      }
+    },
+    "jest-pnp-resolver": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
+      "integrity": "sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==",
+      "dev": true,
+      "requires": {}
+    },
+    "jest-regex-util": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-29.6.3.tgz",
+      "integrity": "sha512-KJJBsRCyyLNWCNBOvZyRDnAIfUiRJ8v+hOBQYGn8gDyF3UegwiP4gwRR3/SDa42g1YbVycTidUF3rKjyLFDWbg==",
+      "dev": true
+    },
+    "jest-resolve": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-29.7.0.tgz",
+      "integrity": "sha512-IOVhZSrg+UvVAshDSDtHyFCCBUl/Q3AAJv8iZ6ZjnZ74xzvwuzLXid9IIIPgTnY62SJjfuupMKZsZQRsCvxEgA==",
+      "dev": true,
+      "requires": {
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.7.0",
+        "jest-pnp-resolver": "^1.2.2",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "resolve": "^1.20.0",
+        "resolve.exports": "^2.0.0",
+        "slash": "^3.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "slash": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+          "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "jest-resolve-dependencies": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-29.7.0.tgz",
+      "integrity": "sha512-un0zD/6qxJ+S0et7WxeI3H5XSe9lTBBR7bOHCHXkKR6luG5mwDDlIzVQ0V5cZCuoTgEdcdwzTghYkTWfubi+nA==",
+      "dev": true,
+      "requires": {
+        "jest-regex-util": "^29.6.3",
+        "jest-snapshot": "^29.7.0"
+      }
+    },
+    "jest-runner": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-29.7.0.tgz",
+      "integrity": "sha512-fsc4N6cPCAahybGBfTRcq5wFR6fpLznMg47sY5aDpsoejOcVYFb07AHuSnR0liMcPTgBsA3ZJL6kFOjPdoNipQ==",
+      "dev": true,
+      "requires": {
+        "@jest/console": "^29.7.0",
+        "@jest/environment": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "emittery": "^0.13.1",
+        "graceful-fs": "^4.2.9",
+        "jest-docblock": "^29.7.0",
+        "jest-environment-node": "^29.7.0",
+        "jest-haste-map": "^29.7.0",
+        "jest-leak-detector": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-resolve": "^29.7.0",
+        "jest-runtime": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-watcher": "^29.7.0",
+        "jest-worker": "^29.7.0",
+        "p-limit": "^3.1.0",
+        "source-map-support": "0.5.13"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "p-limit": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+          "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+          "dev": true,
+          "requires": {
+            "yocto-queue": "^0.1.0"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        },
+        "source-map-support": {
+          "version": "0.5.13",
+          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
+          "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
+          "dev": true,
+          "requires": {
+            "buffer-from": "^1.0.0",
+            "source-map": "^0.6.0"
+          }
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "jest-runtime": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-29.7.0.tgz",
+      "integrity": "sha512-gUnLjgwdGqW7B4LvOIkbKs9WGbn+QLqRQQ9juC6HndeDiezIwhDP+mhMwHWCEcfQ5RUXa6OPnFF8BJh5xegwwQ==",
+      "dev": true,
+      "requires": {
+        "@jest/environment": "^29.7.0",
+        "@jest/fake-timers": "^29.7.0",
+        "@jest/globals": "^29.7.0",
+        "@jest/source-map": "^29.6.3",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "cjs-module-lexer": "^1.0.0",
+        "collect-v8-coverage": "^1.0.0",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-mock": "^29.7.0",
+        "jest-regex-util": "^29.6.3",
+        "jest-resolve": "^29.7.0",
+        "jest-snapshot": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "slash": "^3.0.0",
+        "strip-bom": "^4.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "slash": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+          "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+          "dev": true
+        },
+        "strip-bom": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
+          "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "jest-snapshot": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-29.7.0.tgz",
+      "integrity": "sha512-Rm0BMWtxBcioHr1/OX5YCP8Uov4riHvKPknOGs804Zg9JGZgmIBkbtlxJC/7Z4msKYVbIJtfU+tKb8xlYNfdkw==",
+      "dev": true,
+      "requires": {
+        "@babel/core": "^7.11.6",
+        "@babel/generator": "^7.7.2",
+        "@babel/plugin-syntax-jsx": "^7.7.2",
+        "@babel/plugin-syntax-typescript": "^7.7.2",
+        "@babel/types": "^7.3.3",
+        "@jest/expect-utils": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "babel-preset-current-node-syntax": "^1.0.0",
+        "chalk": "^4.0.0",
+        "expect": "^29.7.0",
+        "graceful-fs": "^4.2.9",
+        "jest-diff": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "jest-matcher-utils": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "natural-compare": "^1.4.0",
+        "pretty-format": "^29.7.0",
+        "semver": "^7.5.3"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "dev": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "semver": {
+          "version": "7.5.4",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+          "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+          "dev": true
+        }
+      }
+    },
+    "jest-util": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
+      "integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
+      "dev": true,
+      "requires": {
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "ci-info": "^3.2.0",
+        "graceful-fs": "^4.2.9",
+        "picomatch": "^2.2.3"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "jest-validate": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-29.7.0.tgz",
+      "integrity": "sha512-ZB7wHqaRGVw/9hST/OuFUReG7M8vKeq0/J2egIGLdvjHCmYqGARhzXmtgi+gVeZ5uXFF219aOc3Ls2yLg27tkw==",
+      "dev": true,
+      "requires": {
+        "@jest/types": "^29.6.3",
+        "camelcase": "^6.2.0",
+        "chalk": "^4.0.0",
+        "jest-get-type": "^29.6.3",
+        "leven": "^3.1.0",
+        "pretty-format": "^29.7.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "camelcase": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+          "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+          "dev": true
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "jest-watcher": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-29.7.0.tgz",
+      "integrity": "sha512-49Fg7WXkU3Vl2h6LbLtMQ/HyB6rXSIX7SqvBLQmssRBGN9I0PNvPmAmCWSOY6SOvrjhI/F7/bGAv9RtnsPA03g==",
+      "dev": true,
+      "requires": {
+        "@jest/test-result": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.0.0",
+        "emittery": "^0.13.1",
+        "jest-util": "^29.7.0",
+        "string-length": "^4.0.1"
+      },
+      "dependencies": {
+        "ansi-escapes": {
+          "version": "4.3.2",
+          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+          "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+          "dev": true,
+          "requires": {
+            "type-fest": "^0.21.3"
+          }
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "jest-worker": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.7.0.tgz",
+      "integrity": "sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "jest-util": "^29.7.0",
+        "merge-stream": "^2.0.0",
+        "supports-color": "^8.0.0"
+      },
+      "dependencies": {
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "8.1.1",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+          "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
       }
     },
     "js-tokens": {
@@ -11816,6 +18399,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
       "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+      "dev": true
+    },
+    "json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "dev": true
     },
     "json-schema-traverse": {
@@ -11930,6 +18519,12 @@
       "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
       "dev": true
     },
+    "kleur": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
+      "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
+      "dev": true
+    },
     "labeled-stream-splicer": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/labeled-stream-splicer/-/labeled-stream-splicer-2.0.2.tgz",
@@ -11940,6 +18535,12 @@
         "stream-splicer": "^2.0.0"
       }
     },
+    "leven": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
+      "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
+      "dev": true
+    },
     "levn": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
@@ -11949,6 +18550,12 @@
         "prelude-ls": "~1.1.2",
         "type-check": "~0.3.2"
       }
+    },
+    "lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true
     },
     "load-json-file": {
       "version": "4.0.0",
@@ -12084,6 +18691,15 @@
         "semver": "^5.6.0"
       }
     },
+    "makeerror": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.12.tgz",
+      "integrity": "sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==",
+      "dev": true,
+      "requires": {
+        "tmpl": "1.0.5"
+      }
+    },
     "marked": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/marked/-/marked-2.1.3.tgz",
@@ -12116,6 +18732,22 @@
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
           "dev": true
         }
+      }
+    },
+    "merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "dev": true
+    },
+    "micromatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
+      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "dev": true,
+      "requires": {
+        "braces": "^3.0.2",
+        "picomatch": "^2.3.1"
       }
     },
     "miller-rabin": {
@@ -12532,6 +19164,12 @@
         }
       }
     },
+    "ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
+    },
     "mute-stream": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
@@ -12581,10 +19219,10 @@
         "whatwg-url": "^5.0.0"
       }
     },
-    "node-modules-regexp": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz",
-      "integrity": "sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA=",
+    "node-int64": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
+      "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
       "dev": true
     },
     "node-releases": {
@@ -12610,6 +19248,23 @@
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "dev": true
+    },
+    "npm-run-path": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+      "dev": true,
+      "requires": {
+        "path-key": "^3.0.0"
+      },
+      "dependencies": {
+        "path-key": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+          "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+          "dev": true
+        }
+      }
     },
     "nyc": {
       "version": "14.1.1",
@@ -12898,9 +19553,9 @@
       "dev": true
     },
     "picomatch": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
-      "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
       "dev": true
     },
     "pify": {
@@ -12910,13 +19565,10 @@
       "dev": true
     },
     "pirates": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.1.tgz",
-      "integrity": "sha512-WuNqLTbMI3tmfef2TKxlQmAiLHKtFhlsCZnPIpuv2Ow0RDVO8lfy1Opf4NUzlMXLjPl+Men7AuVdX6TA+s+uGA==",
-      "dev": true,
-      "requires": {
-        "node-modules-regexp": "^1.0.0"
-      }
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.6.tgz",
+      "integrity": "sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==",
+      "dev": true
     },
     "pkg-dir": {
       "version": "3.0.0",
@@ -12966,6 +19618,25 @@
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
       "dev": true
     },
+    "pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
+      "requires": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+          "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+          "dev": true
+        }
+      }
+    },
     "process": {
       "version": "0.11.10",
       "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
@@ -12989,6 +19660,16 @@
       "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-1.1.6.tgz",
       "integrity": "sha1-zQTv9G9clcOn0EVZHXm14+AfEtc=",
       "dev": true
+    },
+    "prompts": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
+      "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
+      "dev": true,
+      "requires": {
+        "kleur": "^3.0.3",
+        "sisteransi": "^1.0.5"
+      }
     },
     "pseudomap": {
       "version": "1.0.2",
@@ -13022,6 +19703,12 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "dev": true
+    },
+    "pure-rand": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.0.4.tgz",
+      "integrity": "sha512-LA0Y9kxMYv47GIPJy6MI84fqTd2HmYZI83W/kM/SkKfDlajnZYfmXFTxkbY+xSBPkLJxltMa9hIkmdc29eguMA==",
       "dev": true
     },
     "querystring": {
@@ -13280,6 +19967,12 @@
         }
       }
     },
+    "react-is": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
+      "dev": true
+    },
     "read-only-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/read-only-stream/-/read-only-stream-2.0.0.tgz",
@@ -13491,10 +20184,33 @@
         "path-parse": "^1.0.6"
       }
     },
+    "resolve-cwd": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
+      "integrity": "sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==",
+      "dev": true,
+      "requires": {
+        "resolve-from": "^5.0.0"
+      },
+      "dependencies": {
+        "resolve-from": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+          "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+          "dev": true
+        }
+      }
+    },
     "resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true
+    },
+    "resolve.exports": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-2.0.2.tgz",
+      "integrity": "sha512-X2UW6Nw3n/aMgDVy+0rSqgHlv39WZAlZrXCdnbyEiKm17DSqHX4MmQMaST3FbeWR5FTuRcUwYAziZajji0Y7mg==",
       "dev": true
     },
     "restore-cursor": {
@@ -13644,15 +20360,21 @@
       }
     },
     "signal-exit": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
-      "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true
     },
     "simple-concat": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
       "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "dev": true
+    },
+    "sisteransi": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
       "dev": true
     },
     "slash": {
@@ -13796,6 +20518,23 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
+    },
+    "stack-utils": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
+      "integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "^2.0.0"
+      },
+      "dependencies": {
+        "escape-string-regexp": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+          "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+          "dev": true
+        }
+      }
     },
     "stream-browserify": {
       "version": "3.0.0",
@@ -13959,6 +20698,33 @@
         "safe-buffer": "~5.2.0"
       }
     },
+    "string-length": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
+      "integrity": "sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==",
+      "dev": true,
+      "requires": {
+        "char-regex": "^1.0.2",
+        "strip-ansi": "^6.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.1"
+          }
+        }
+      }
+    },
     "string-width": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
@@ -14002,6 +20768,12 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
       "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+      "dev": true
+    },
+    "strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
       "dev": true
     },
     "strip-json-comments": {
@@ -14161,6 +20933,12 @@
         "os-tmpdir": "~1.0.2"
       }
     },
+    "tmpl": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
+      "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
+      "dev": true
+    },
     "to-fast-properties": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
@@ -14207,6 +20985,12 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
       "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true
+    },
+    "type-fest": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
       "dev": true
     },
     "typedarray": {
@@ -14345,6 +21129,25 @@
       "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
       "dev": true
     },
+    "v8-to-istanbul": {
+      "version": "9.1.3",
+      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.1.3.tgz",
+      "integrity": "sha512-9lDD+EVI2fjFsMWXc6dy5JJzBsVTcQ2fVkfBvncZ6xJWG9wtBhOldG+mHkSL0+V1K/xgZz0JDO5UT5hFwHUghg==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/trace-mapping": "^0.3.12",
+        "@types/istanbul-lib-coverage": "^2.0.1",
+        "convert-source-map": "^2.0.0"
+      },
+      "dependencies": {
+        "convert-source-map": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+          "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+          "dev": true
+        }
+      }
+    },
     "validate-npm-package-license": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
@@ -14360,6 +21163,15 @@
       "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.2.tgz",
       "integrity": "sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==",
       "dev": true
+    },
+    "walker": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.8.tgz",
+      "integrity": "sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==",
+      "dev": true,
+      "requires": {
+        "makeerror": "1.0.12"
+      }
     },
     "webidl-conversions": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "colors": "^1.1.2",
     "docco": "^0.8.0",
     "eslint": "^5.14.1",
+    "jest": "^29.7.0",
     "mocha": "^8.0.0",
     "nyc": "^14.1.1",
     "pre-commit": "^1.2.2",
@@ -52,8 +53,7 @@
     "build": "npm run build:node && npm run build:browser",
     "build:node": "babel src -d lib",
     "build:browser": "rm -rf browser && mkdir browser && browserify -s N3 lib/index.js | uglifyjs > browser/n3.min.js",
-    "test": "nyc npm run mocha",
-    "mocha": "mocha",
+    "test": "jest",
     "lint": "eslint src perf test spec",
     "prepare": "npm run build",
     "spec": "npm run spec-turtle && npm run spec-ntriples && npm run spec-nquads && npm run spec-trig",
@@ -79,5 +79,9 @@
   "pre-commit": [
     "lint",
     "test"
-  ]
+  
+  ],
+  "jest": {
+    "testMatch": ["**/test/*-test.js"]
+  }
 }

--- a/package.json
+++ b/package.json
@@ -35,14 +35,10 @@
     "@rdfjs/data-model": "^1",
     "arrayify-stream": "^1.0.0",
     "browserify": "^17.0.0",
-    "chai": "^4.0.2",
-    "chai-things": "^0.2.0",
     "colors": "^1.1.2",
     "docco": "^0.8.0",
     "eslint": "^5.14.1",
     "jest": "^29.7.0",
-    "mocha": "^8.0.0",
-    "nyc": "^14.1.1",
     "pre-commit": "^1.2.2",
     "rdf-isomorphic": "^1.3.1",
     "rdf-test-suite": "^1.25.0",
@@ -79,13 +75,14 @@
   "pre-commit": [
     "lint",
     "test"
-  
   ],
   "jest": {
-    "testMatch": ["**/test/*-test.js"],
+    "testMatch": [
+      "**/test/*-test.js"
+    ],
     "collectCoverage": true,
     "coverageReporters": [
-      "json-summary", 
+      "json-summary",
       "text",
       "lcov"
     ],

--- a/package.json
+++ b/package.json
@@ -82,6 +82,20 @@
   
   ],
   "jest": {
-    "testMatch": ["**/test/*-test.js"]
+    "testMatch": ["**/test/*-test.js"],
+    "collectCoverage": true,
+    "coverageReporters": [
+      "json-summary", 
+      "text",
+      "lcov"
+    ],
+    "coverageThreshold": {
+      "global": {
+        "branches": 100,
+        "functions": 100,
+        "lines": 100,
+        "statements": 100
+      }
+    }
   }
 }

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -5,6 +5,7 @@
     before: true,
     after: true,
     beforeEach: true,
+    beforeAll: true,
     afterEach: true,
     expect: true,
   },

--- a/test/BlankNode-test.js
+++ b/test/BlankNode-test.js
@@ -3,77 +3,83 @@ import { BlankNode, Term } from '../src/';
 describe('BlankNode', () => {
   describe('The BlankNode module', () => {
     it('should be a function', () => {
-      BlankNode.should.be.a('function');
+      expect(BlankNode).toBeInstanceOf(Function);
     });
 
     it('should be a BlankNode constructor', () => {
-      new BlankNode().should.be.an.instanceof(BlankNode);
+      expect(new BlankNode()).toBeInstanceOf(BlankNode);
     });
 
     it('should be a Term constructor', () => {
-      new BlankNode().should.be.an.instanceof(Term);
+      expect(new BlankNode()).toBeInstanceOf(Term);
     });
   });
 
   describe('A BlankNode instance created from a name', () => {
     let blankNode;
-    before(() => { blankNode = new BlankNode('b1'); });
+    beforeAll(() => { blankNode = new BlankNode('b1'); });
 
     it('should be a BlankNode', () => {
-      blankNode.should.be.an.instanceof(BlankNode);
+      expect(blankNode).toBeInstanceOf(BlankNode);
     });
 
     it('should be a Term', () => {
-      blankNode.should.be.an.instanceof(Term);
+      expect(blankNode).toBeInstanceOf(Term);
     });
 
     it('should have term type "BlankNode"', () => {
-      blankNode.termType.should.equal('BlankNode');
+      expect(blankNode.termType).toBe('BlankNode');
     });
 
     it('should have the name as value', () => {
-      blankNode.should.have.property('value', 'b1');
+      expect(blankNode).toHaveProperty('value', 'b1');
     });
 
     it('should have "_:name" as id', () => {
-      blankNode.should.have.property('id', '_:b1');
+      expect(blankNode).toHaveProperty('id', '_:b1');
     });
 
     it('should equal a BlankNode instance with the same name', () => {
-      blankNode.equals(new BlankNode('b1')).should.be.true;
+      expect(blankNode.equals(new BlankNode('b1'))).toBe(true);
     });
 
     it('should equal an object with the same term type and value', () => {
-      blankNode.equals({
+      expect(blankNode.equals({
         termType: 'BlankNode',
         value: 'b1',
-      }).should.be.true;
+      })).toBe(true);
     });
 
     it('should not equal a falsy object', () => {
-      blankNode.equals(null).should.be.false;
+      expect(blankNode.equals(null)).toBe(false);
     });
 
     it('should not equal a BlankNode instance with another name', () => {
-      blankNode.equals(new BlankNode('b2')).should.be.false;
+      expect(blankNode.equals(new BlankNode('b2'))).toBe(false);
     });
 
-    it('should not equal an object with the same term type but a different value', () => {
-      blankNode.equals({
-        termType: 'BlankNode',
-        value: 'b2',
-      }).should.be.false;
-    });
+    it(
+      'should not equal an object with the same term type but a different value',
+      () => {
+        expect(blankNode.equals({
+          termType: 'BlankNode',
+          value: 'b2',
+        })).toBe(false);
+      }
+    );
 
-    it('should not equal an object with a different term type but the same value', () => {
-      blankNode.equals({
-        termType: 'NamedNode',
-        value: 'b1',
-      }).should.be.false;
-    });
+    it(
+      'should not equal an object with a different term type but the same value',
+      () => {
+        expect(blankNode.equals({
+          termType: 'NamedNode',
+          value: 'b1',
+        })).toBe(false);
+      }
+    );
 
     it('should provide a JSON representation', () => {
-      blankNode.toJSON().should.deep.equal({
+      expect(blankNode.toJSON()).toEqual({
         termType: 'BlankNode',
         value: 'b1',
       });

--- a/test/DefaultGraph-test.js
+++ b/test/DefaultGraph-test.js
@@ -3,64 +3,64 @@ import { DefaultGraph, Term } from '../src/';
 describe('DefaultGraph', () => {
   describe('The DefaultGraph module', () => {
     it('should be a function', () => {
-      DefaultGraph.should.be.a('function');
+      expect(DefaultGraph).toBeInstanceOf(Function);
     });
 
     it('should be a DefaultGraph constructor', () => {
-      new DefaultGraph().should.be.an.instanceof(DefaultGraph);
+      expect(new DefaultGraph()).toBeInstanceOf(DefaultGraph);
     });
 
     it('should be a Term constructor', () => {
-      new DefaultGraph().should.be.an.instanceof(Term);
+      expect(new DefaultGraph()).toBeInstanceOf(Term);
     });
   });
 
   describe('A DefaultGraph instance', () => {
     let defaultGraph;
-    before(() => { defaultGraph = new DefaultGraph(); });
+    beforeAll(() => { defaultGraph = new DefaultGraph(); });
 
     it('should be a DefaultGraph', () => {
-      defaultGraph.should.be.an.instanceof(DefaultGraph);
+      expect(defaultGraph).toBeInstanceOf(DefaultGraph);
     });
 
     it('should be a Term', () => {
-      defaultGraph.should.be.an.instanceof(Term);
+      expect(defaultGraph).toBeInstanceOf(Term);
     });
 
     it('should have term type "DefaultGraph"', () => {
-      defaultGraph.termType.should.equal('DefaultGraph');
+      expect(defaultGraph.termType).toBe('DefaultGraph');
     });
 
     it('should have the empty string as value', () => {
-      defaultGraph.should.have.property('value', '');
+      expect(defaultGraph).toHaveProperty('value', '');
     });
 
     it('should have the empty string as id', () => {
-      defaultGraph.should.have.property('id', '');
+      expect(defaultGraph).toHaveProperty('id', '');
     });
 
     it('should equal another DefaultGraph instance', () => {
-      defaultGraph.equals(new DefaultGraph()).should.be.true;
+      expect(defaultGraph.equals(new DefaultGraph())).toBe(true);
     });
 
     it('should equal an object with the same term type', () => {
-      defaultGraph.equals({
+      expect(defaultGraph.equals({
         termType: 'DefaultGraph',
-      }).should.be.true;
+      })).toBe(true);
     });
 
     it('should not equal a falsy object', () => {
-      defaultGraph.equals(null).should.be.false;
+      expect(defaultGraph.equals(null)).toBe(false);
     });
 
     it('should not equal an object with a different term type', () => {
-      defaultGraph.equals({
+      expect(defaultGraph.equals({
         termType: 'Literal',
-      }).should.be.false;
+      })).toBe(false);
     });
 
     it('should provide a JSON representation', () => {
-      defaultGraph.toJSON().should.deep.equal({
+      expect(defaultGraph.toJSON()).toEqual({
         termType: 'DefaultGraph',
         value: '',
       });

--- a/test/Literal-test.js
+++ b/test/Literal-test.js
@@ -3,111 +3,123 @@ import { Literal, NamedNode, Term } from '../src/';
 describe('Literal', () => {
   describe('The Literal module', () => {
     it('should be a function', () => {
-      Literal.should.be.a('function');
+      expect(Literal).toBeInstanceOf(Function);
     });
 
     it('should be a Literal constructor', () => {
-      new Literal().should.be.an.instanceof(Literal);
+      expect(new Literal()).toBeInstanceOf(Literal);
     });
 
     it('should be a Term constructor', () => {
-      new Literal().should.be.an.instanceof(Term);
+      expect(new Literal()).toBeInstanceOf(Term);
     });
   });
 
   describe('A Literal instance created from the empty string without language or datatype', () => {
     let literal;
-    before(() => { literal = new Literal('""'); });
+    beforeAll(() => { literal = new Literal('""'); });
 
     it('should be a Literal', () => {
-      literal.should.be.an.instanceof(Literal);
+      expect(literal).toBeInstanceOf(Literal);
     });
 
     it('should be a Term', () => {
-      literal.should.be.an.instanceof(Term);
+      expect(literal).toBeInstanceOf(Term);
     });
 
     it('should have term type "Literal"', () => {
-      literal.termType.should.equal('Literal');
+      expect(literal.termType).toBe('Literal');
     });
 
     it('should have the empty string as value', () => {
-      literal.should.have.property('value', '');
+      expect(literal).toHaveProperty('value', '');
     });
 
     it('should have the empty string as language', () => {
-      literal.should.have.property('language', '');
+      expect(literal).toHaveProperty('language', '');
     });
 
     it('should have xsd:string as datatype', () => {
-      literal.should.have.property('datatype');
-      literal.datatype.should.be.an.instanceof(NamedNode);
-      literal.datatype.value.should.equal('http://www.w3.org/2001/XMLSchema#string');
+      expect(literal).toHaveProperty('datatype');
+      expect(literal.datatype).toBeInstanceOf(NamedNode);
+      expect(literal.datatype.value).toBe('http://www.w3.org/2001/XMLSchema#string');
     });
 
     it('should have the quoted empty string as id', () => {
-      literal.should.have.property('id', '""');
+      expect(literal).toHaveProperty('id', '""');
     });
 
     it('should equal a Literal instance with the same value', () => {
-      literal.equals(new Literal('""')).should.be.true;
+      expect(literal.equals(new Literal('""'))).toBe(true);
     });
 
-    it('should equal an object with the same term type, value, language, and datatype', () => {
-      literal.equals({
-        termType: 'Literal',
-        value: '',
-        language: '',
-        datatype: { value: 'http://www.w3.org/2001/XMLSchema#string', termType: 'NamedNode' },
-      }).should.be.true;
-    });
+    it(
+      'should equal an object with the same term type, value, language, and datatype',
+      () => {
+        expect(literal.equals({
+          termType: 'Literal',
+          value: '',
+          language: '',
+          datatype: { value: 'http://www.w3.org/2001/XMLSchema#string', termType: 'NamedNode' },
+        })).toBe(true);
+      }
+    );
 
     it('should not equal a falsy object', () => {
-      literal.equals(null).should.be.false;
+      expect(literal.equals(null)).toBe(false);
     });
 
     it('should not equal a Literal instance with a non-empty value', () => {
-      literal.equals(new Literal('"x"')).should.be.false;
+      expect(literal.equals(new Literal('"x"'))).toBe(false);
     });
 
-    it('should not equal an object with the same term type but a different value', () => {
-      literal.equals({
-        termType: 'Literal',
-        value: 'x',
-        language: '',
-        datatype: { value: 'http://www.w3.org/2001/XMLSchema#string', termType: 'NamedNode' },
-      }).should.be.false;
-    });
+    it(
+      'should not equal an object with the same term type but a different value',
+      () => {
+        expect(literal.equals({
+          termType: 'Literal',
+          value: 'x',
+          language: '',
+          datatype: { value: 'http://www.w3.org/2001/XMLSchema#string', termType: 'NamedNode' },
+        })).toBe(false);
+      }
+    );
 
-    it('should not equal an object with the same term type but a different language', () => {
-      literal.equals({
-        termType: 'Literal',
-        value: '',
-        language: 'en',
-        datatype: { value: 'http://www.w3.org/2001/XMLSchema#string', termType: 'NamedNode' },
-      }).should.be.false;
-    });
+    it(
+      'should not equal an object with the same term type but a different language',
+      () => {
+        expect(literal.equals({
+          termType: 'Literal',
+          value: '',
+          language: 'en',
+          datatype: { value: 'http://www.w3.org/2001/XMLSchema#string', termType: 'NamedNode' },
+        })).toBe(false);
+      }
+    );
 
-    it('should not equal an object with the same term type but a different datatype', () => {
-      literal.equals({
-        termType: 'Literal',
-        value: '',
-        language: '',
-        datatype: { value: 'other', termType: 'NamedNode' },
-      }).should.be.false;
-    });
+    it(
+      'should not equal an object with the same term type but a different datatype',
+      () => {
+        expect(literal.equals({
+          termType: 'Literal',
+          value: '',
+          language: '',
+          datatype: { value: 'other', termType: 'NamedNode' },
+        })).toBe(false);
+      }
+    );
 
     it('should not equal an object with a different term type', () => {
-      literal.equals({
+      expect(literal.equals({
         termType: 'NamedNode',
         value: '',
         language: '',
         datatype: { value: 'http://www.w3.org/2001/XMLSchema#string', termType: 'NamedNode' },
-      }).should.be.false;
+      })).toBe(false);
     });
 
     it('should provide a JSON representation', () => {
-      literal.toJSON().should.deep.equal({
+      expect(literal.toJSON()).toEqual({
         termType: 'Literal',
         value: '',
         language: '',
@@ -121,97 +133,109 @@ describe('Literal', () => {
 
   describe('A Literal instance created from a string without language or datatype', () => {
     let literal;
-    before(() => { literal = new Literal('"my @^^ string"'); });
+    beforeAll(() => { literal = new Literal('"my @^^ string"'); });
 
     it('should be a Literal', () => {
-      literal.should.be.an.instanceof(Literal);
+      expect(literal).toBeInstanceOf(Literal);
     });
 
     it('should be a Term', () => {
-      literal.should.be.an.instanceof(Term);
+      expect(literal).toBeInstanceOf(Term);
     });
 
     it('should have term type "Literal"', () => {
-      literal.termType.should.equal('Literal');
+      expect(literal.termType).toBe('Literal');
     });
 
     it('should have the text value as value', () => {
-      literal.should.have.property('value', 'my @^^ string');
+      expect(literal).toHaveProperty('value', 'my @^^ string');
     });
 
     it('should have the empty string as language', () => {
-      literal.should.have.property('language', '');
+      expect(literal).toHaveProperty('language', '');
     });
 
     it('should have xsd:string as datatype', () => {
-      literal.should.have.property('datatype');
-      literal.datatype.should.be.an.instanceof(NamedNode);
-      literal.datatype.value.should.equal('http://www.w3.org/2001/XMLSchema#string');
+      expect(literal).toHaveProperty('datatype');
+      expect(literal.datatype).toBeInstanceOf(NamedNode);
+      expect(literal.datatype.value).toBe('http://www.w3.org/2001/XMLSchema#string');
     });
 
     it('should have the quoted string as id', () => {
-      literal.should.have.property('id', '"my @^^ string"');
+      expect(literal).toHaveProperty('id', '"my @^^ string"');
     });
 
     it('should equal a Literal instance with the same value', () => {
-      literal.equals(new Literal('"my @^^ string"')).should.be.true;
+      expect(literal.equals(new Literal('"my @^^ string"'))).toBe(true);
     });
 
-    it('should equal an object with the same term type, value, language, and datatype', () => {
-      literal.equals({
-        termType: 'Literal',
-        value: 'my @^^ string',
-        language: '',
-        datatype: { value: 'http://www.w3.org/2001/XMLSchema#string', termType: 'NamedNode' },
-      }).should.be.true;
-    });
+    it(
+      'should equal an object with the same term type, value, language, and datatype',
+      () => {
+        expect(literal.equals({
+          termType: 'Literal',
+          value: 'my @^^ string',
+          language: '',
+          datatype: { value: 'http://www.w3.org/2001/XMLSchema#string', termType: 'NamedNode' },
+        })).toBe(true);
+      }
+    );
 
     it('should not equal a falsy object', () => {
-      literal.equals(null).should.be.false;
+      expect(literal.equals(null)).toBe(false);
     });
 
     it('should not equal a Literal instance with another value', () => {
-      literal.equals(new Literal('"other string"')).should.be.false;
+      expect(literal.equals(new Literal('"other string"'))).toBe(false);
     });
 
-    it('should not equal an object with the same term type but a different value', () => {
-      literal.equals({
-        termType: 'Literal',
-        value: 'other string',
-        language: '',
-        datatype: { value: 'http://www.w3.org/2001/XMLSchema#string', termType: 'NamedNode' },
-      }).should.be.false;
-    });
+    it(
+      'should not equal an object with the same term type but a different value',
+      () => {
+        expect(literal.equals({
+          termType: 'Literal',
+          value: 'other string',
+          language: '',
+          datatype: { value: 'http://www.w3.org/2001/XMLSchema#string', termType: 'NamedNode' },
+        })).toBe(false);
+      }
+    );
 
-    it('should not equal an object with the same term type but a different language', () => {
-      literal.equals({
-        termType: 'Literal',
-        value: 'my @^^ string',
-        language: 'en',
-        datatype: { value: 'http://www.w3.org/2001/XMLSchema#string', termType: 'NamedNode' },
-      }).should.be.false;
-    });
+    it(
+      'should not equal an object with the same term type but a different language',
+      () => {
+        expect(literal.equals({
+          termType: 'Literal',
+          value: 'my @^^ string',
+          language: 'en',
+          datatype: { value: 'http://www.w3.org/2001/XMLSchema#string', termType: 'NamedNode' },
+        })).toBe(false);
+      }
+    );
 
-    it('should not equal an object with the same term type but a different datatype', () => {
-      literal.equals({
-        termType: 'Literal',
-        value: 'my @^^ string',
-        language: '',
-        datatype: { value: 'other', termType: 'NamedNode' },
-      }).should.be.false;
-    });
+    it(
+      'should not equal an object with the same term type but a different datatype',
+      () => {
+        expect(literal.equals({
+          termType: 'Literal',
+          value: 'my @^^ string',
+          language: '',
+          datatype: { value: 'other', termType: 'NamedNode' },
+        })).toBe(false);
+      }
+    );
 
     it('should not equal an object with a different term type', () => {
-      literal.equals({
+      expect(literal.equals({
         termType: 'NamedNode',
         value: 'my @^^ string',
         language: '',
         datatype: { value: 'http://www.w3.org/2001/XMLSchema#string', termType: 'NamedNode' },
-      }).should.be.false;
+      })).toBe(false);
     });
 
     it('should provide a JSON representation', () => {
-      literal.toJSON().should.deep.equal({
+      expect(literal.toJSON()).toEqual({
         termType: 'Literal',
         value: 'my @^^ string',
         language: '',
@@ -225,97 +249,109 @@ describe('Literal', () => {
 
   describe('A Literal instance created from the empty string with a language', () => {
     let literal;
-    before(() => { literal = new Literal('""@en-us'); });
+    beforeAll(() => { literal = new Literal('""@en-us'); });
 
     it('should be a Literal', () => {
-      literal.should.be.an.instanceof(Literal);
+      expect(literal).toBeInstanceOf(Literal);
     });
 
     it('should be a Term', () => {
-      literal.should.be.an.instanceof(Term);
+      expect(literal).toBeInstanceOf(Term);
     });
 
     it('should have term type "Literal"', () => {
-      literal.termType.should.equal('Literal');
+      expect(literal.termType).toBe('Literal');
     });
 
     it('should have the empty string as value', () => {
-      literal.should.have.property('value', '');
+      expect(literal).toHaveProperty('value', '');
     });
 
     it('should have the language tag as language', () => {
-      literal.should.have.property('language', 'en-us');
+      expect(literal).toHaveProperty('language', 'en-us');
     });
 
     it('should have rdf:langString as datatype', () => {
-      literal.should.have.property('datatype');
-      literal.datatype.should.be.an.instanceof(NamedNode);
-      literal.datatype.value.should.equal('http://www.w3.org/1999/02/22-rdf-syntax-ns#langString');
+      expect(literal).toHaveProperty('datatype');
+      expect(literal.datatype).toBeInstanceOf(NamedNode);
+      expect(literal.datatype.value).toBe('http://www.w3.org/1999/02/22-rdf-syntax-ns#langString');
     });
 
     it('should have the quoted empty string as id', () => {
-      literal.should.have.property('id', '""@en-us');
+      expect(literal).toHaveProperty('id', '""@en-us');
     });
 
     it('should equal a Literal instance with the same value', () => {
-      literal.equals(new Literal('""@en-us')).should.be.true;
+      expect(literal.equals(new Literal('""@en-us'))).toBe(true);
     });
 
-    it('should equal an object with the same term type, value, language, and datatype', () => {
-      literal.equals({
-        termType: 'Literal',
-        value: '',
-        language: 'en-us',
-        datatype: { value: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#langString', termType: 'NamedNode' },
-      }).should.be.true;
-    });
+    it(
+      'should equal an object with the same term type, value, language, and datatype',
+      () => {
+        expect(literal.equals({
+          termType: 'Literal',
+          value: '',
+          language: 'en-us',
+          datatype: { value: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#langString', termType: 'NamedNode' },
+        })).toBe(true);
+      }
+    );
 
     it('should not equal a falsy object', () => {
-      literal.equals(null).should.be.false;
+      expect(literal.equals(null)).toBe(false);
     });
 
     it('should not equal a Literal instance with a non-empty value', () => {
-      literal.equals(new Literal('"x"')).should.be.false;
+      expect(literal.equals(new Literal('"x"'))).toBe(false);
     });
 
-    it('should not equal an object with the same term type but a different value', () => {
-      literal.equals({
-        termType: 'Literal',
-        value: 'x',
-        language: 'en-us',
-        datatype: { value: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#langString', termType: 'NamedNode' },
-      }).should.be.false;
-    });
+    it(
+      'should not equal an object with the same term type but a different value',
+      () => {
+        expect(literal.equals({
+          termType: 'Literal',
+          value: 'x',
+          language: 'en-us',
+          datatype: { value: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#langString', termType: 'NamedNode' },
+        })).toBe(false);
+      }
+    );
 
-    it('should not equal an object with the same term type but a different language', () => {
-      literal.equals({
-        termType: 'Literal',
-        value: '',
-        language: '',
-        datatype: { value: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#langString', termType: 'NamedNode' },
-      }).should.be.false;
-    });
+    it(
+      'should not equal an object with the same term type but a different language',
+      () => {
+        expect(literal.equals({
+          termType: 'Literal',
+          value: '',
+          language: '',
+          datatype: { value: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#langString', termType: 'NamedNode' },
+        })).toBe(false);
+      }
+    );
 
-    it('should not equal an object with the same term type but a different datatype', () => {
-      literal.equals({
-        termType: 'Literal',
-        value: '',
-        language: 'en-us',
-        datatype: { value: 'other', termType: 'NamedNode' },
-      }).should.be.false;
-    });
+    it(
+      'should not equal an object with the same term type but a different datatype',
+      () => {
+        expect(literal.equals({
+          termType: 'Literal',
+          value: '',
+          language: 'en-us',
+          datatype: { value: 'other', termType: 'NamedNode' },
+        })).toBe(false);
+      }
+    );
 
     it('should not equal an object with a different term type', () => {
-      literal.equals({
+      expect(literal.equals({
         termType: 'NamedNode',
         value: '',
         language: 'en-us',
         datatype: { value: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#langString', termType: 'NamedNode' },
-      }).should.be.false;
+      })).toBe(false);
     });
 
     it('should provide a JSON representation', () => {
-      literal.toJSON().should.deep.equal({
+      expect(literal.toJSON()).toEqual({
         termType: 'Literal',
         value: '',
         language: 'en-us',
@@ -329,97 +365,109 @@ describe('Literal', () => {
 
   describe('A Literal instance created from a string without language or datatype', () => {
     let literal;
-    before(() => { literal = new Literal('"my @^^ string"@en-us'); });
+    beforeAll(() => { literal = new Literal('"my @^^ string"@en-us'); });
 
     it('should be a Literal', () => {
-      literal.should.be.an.instanceof(Literal);
+      expect(literal).toBeInstanceOf(Literal);
     });
 
     it('should be a Term', () => {
-      literal.should.be.an.instanceof(Term);
+      expect(literal).toBeInstanceOf(Term);
     });
 
     it('should have term type "Literal"', () => {
-      literal.termType.should.equal('Literal');
+      expect(literal.termType).toBe('Literal');
     });
 
     it('should have the text value as value', () => {
-      literal.should.have.property('value', 'my @^^ string');
+      expect(literal).toHaveProperty('value', 'my @^^ string');
     });
 
     it('should have the language tag as language', () => {
-      literal.should.have.property('language', 'en-us');
+      expect(literal).toHaveProperty('language', 'en-us');
     });
 
     it('should have rdf:langString as datatype', () => {
-      literal.should.have.property('datatype');
-      literal.datatype.should.be.an.instanceof(NamedNode);
-      literal.datatype.value.should.equal('http://www.w3.org/1999/02/22-rdf-syntax-ns#langString');
+      expect(literal).toHaveProperty('datatype');
+      expect(literal.datatype).toBeInstanceOf(NamedNode);
+      expect(literal.datatype.value).toBe('http://www.w3.org/1999/02/22-rdf-syntax-ns#langString');
     });
 
     it('should have the quoted string as id', () => {
-      literal.should.have.property('id', '"my @^^ string"@en-us');
+      expect(literal).toHaveProperty('id', '"my @^^ string"@en-us');
     });
 
     it('should equal a Literal instance with the same value', () => {
-      literal.equals(new Literal('"my @^^ string"@en-us')).should.be.true;
+      expect(literal.equals(new Literal('"my @^^ string"@en-us'))).toBe(true);
     });
 
-    it('should equal an object with the same term type, value, language, and datatype', () => {
-      literal.equals({
-        termType: 'Literal',
-        value: 'my @^^ string',
-        language: 'en-us',
-        datatype: { value: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#langString', termType: 'NamedNode' },
-      }).should.be.true;
-    });
+    it(
+      'should equal an object with the same term type, value, language, and datatype',
+      () => {
+        expect(literal.equals({
+          termType: 'Literal',
+          value: 'my @^^ string',
+          language: 'en-us',
+          datatype: { value: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#langString', termType: 'NamedNode' },
+        })).toBe(true);
+      }
+    );
 
     it('should not equal a falsy object', () => {
-      literal.equals(null).should.be.false;
+      expect(literal.equals(null)).toBe(false);
     });
 
     it('should not equal a Literal instance with another value', () => {
-      literal.equals(new Literal('"other string"')).should.be.false;
+      expect(literal.equals(new Literal('"other string"'))).toBe(false);
     });
 
-    it('should not equal an object with the same term type but a different value', () => {
-      literal.equals({
-        termType: 'Literal',
-        value: 'other string',
-        language: 'en-us',
-        datatype: { value: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#langString', termType: 'NamedNode' },
-      }).should.be.false;
-    });
+    it(
+      'should not equal an object with the same term type but a different value',
+      () => {
+        expect(literal.equals({
+          termType: 'Literal',
+          value: 'other string',
+          language: 'en-us',
+          datatype: { value: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#langString', termType: 'NamedNode' },
+        })).toBe(false);
+      }
+    );
 
-    it('should not equal an object with the same term type but a different language', () => {
-      literal.equals({
-        termType: 'Literal',
-        value: 'my @^^ string',
-        language: 'fr',
-        datatype: { value: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#langString', termType: 'NamedNode' },
-      }).should.be.false;
-    });
+    it(
+      'should not equal an object with the same term type but a different language',
+      () => {
+        expect(literal.equals({
+          termType: 'Literal',
+          value: 'my @^^ string',
+          language: 'fr',
+          datatype: { value: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#langString', termType: 'NamedNode' },
+        })).toBe(false);
+      }
+    );
 
-    it('should not equal an object with the same term type but a different datatype', () => {
-      literal.equals({
-        termType: 'Literal',
-        value: 'my @^^ string',
-        language: 'en-us',
-        datatype: { value: 'other', termType: 'NamedNode' },
-      }).should.be.false;
-    });
+    it(
+      'should not equal an object with the same term type but a different datatype',
+      () => {
+        expect(literal.equals({
+          termType: 'Literal',
+          value: 'my @^^ string',
+          language: 'en-us',
+          datatype: { value: 'other', termType: 'NamedNode' },
+        })).toBe(false);
+      }
+    );
 
     it('should not equal an object with a different term type', () => {
-      literal.equals({
+      expect(literal.equals({
         termType: 'NamedNode',
         value: 'my @^^ string',
         language: 'en-us',
         datatype: { value: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#langString', termType: 'NamedNode' },
-      }).should.be.false;
+      })).toBe(false);
     });
 
     it('should provide a JSON representation', () => {
-      literal.toJSON().should.deep.equal({
+      expect(literal.toJSON()).toEqual({
         termType: 'Literal',
         value: 'my @^^ string',
         language: 'en-us',
@@ -433,97 +481,109 @@ describe('Literal', () => {
 
   describe('A Literal instance created from the empty string with a datatype', () => {
     let literal;
-    before(() => { literal = new Literal('""^^http://example.org/types#type'); });
+    beforeAll(() => { literal = new Literal('""^^http://example.org/types#type'); });
 
     it('should be a Literal', () => {
-      literal.should.be.an.instanceof(Literal);
+      expect(literal).toBeInstanceOf(Literal);
     });
 
     it('should be a Term', () => {
-      literal.should.be.an.instanceof(Term);
+      expect(literal).toBeInstanceOf(Term);
     });
 
     it('should have term type "Literal"', () => {
-      literal.termType.should.equal('Literal');
+      expect(literal.termType).toBe('Literal');
     });
 
     it('should have the empty string as value', () => {
-      literal.should.have.property('value', '');
+      expect(literal).toHaveProperty('value', '');
     });
 
     it('should have the empty string as language', () => {
-      literal.should.have.property('language', '');
+      expect(literal).toHaveProperty('language', '');
     });
 
     it('should have the datatype', () => {
-      literal.should.have.property('datatype');
-      literal.datatype.should.be.an.instanceof(NamedNode);
-      literal.datatype.value.should.equal('http://example.org/types#type');
+      expect(literal).toHaveProperty('datatype');
+      expect(literal.datatype).toBeInstanceOf(NamedNode);
+      expect(literal.datatype.value).toBe('http://example.org/types#type');
     });
 
     it('should have the quoted empty string as id', () => {
-      literal.should.have.property('id', '""^^http://example.org/types#type');
+      expect(literal).toHaveProperty('id', '""^^http://example.org/types#type');
     });
 
     it('should equal a Literal instance with the same value', () => {
-      literal.equals(new Literal('""^^http://example.org/types#type')).should.be.true;
+      expect(literal.equals(new Literal('""^^http://example.org/types#type'))).toBe(true);
     });
 
-    it('should equal an object with the same term type, value, language, and datatype', () => {
-      literal.equals({
-        termType: 'Literal',
-        value: '',
-        language: '',
-        datatype: { value: 'http://example.org/types#type', termType: 'NamedNode' },
-      }).should.be.true;
-    });
+    it(
+      'should equal an object with the same term type, value, language, and datatype',
+      () => {
+        expect(literal.equals({
+          termType: 'Literal',
+          value: '',
+          language: '',
+          datatype: { value: 'http://example.org/types#type', termType: 'NamedNode' },
+        })).toBe(true);
+      }
+    );
 
     it('should not equal a falsy object', () => {
-      literal.equals(null).should.be.false;
+      expect(literal.equals(null)).toBe(false);
     });
 
     it('should not equal a Literal instance with a non-empty value', () => {
-      literal.equals(new Literal('"x"^^http://example.org/types#type')).should.be.false;
+      expect(literal.equals(new Literal('"x"^^http://example.org/types#type'))).toBe(false);
     });
 
-    it('should not equal an object with the same term type but a different value', () => {
-      literal.equals({
-        termType: 'Literal',
-        value: 'x',
-        language: '',
-        datatype: { value: 'http://example.org/types#type', termType: 'NamedNode' },
-      }).should.be.false;
-    });
+    it(
+      'should not equal an object with the same term type but a different value',
+      () => {
+        expect(literal.equals({
+          termType: 'Literal',
+          value: 'x',
+          language: '',
+          datatype: { value: 'http://example.org/types#type', termType: 'NamedNode' },
+        })).toBe(false);
+      }
+    );
 
-    it('should not equal an object with the same term type but a different language', () => {
-      literal.equals({
-        termType: 'Literal',
-        value: '',
-        language: 'en',
-        datatype: { value: 'http://example.org/types#type', termType: 'NamedNode' },
-      }).should.be.false;
-    });
+    it(
+      'should not equal an object with the same term type but a different language',
+      () => {
+        expect(literal.equals({
+          termType: 'Literal',
+          value: '',
+          language: 'en',
+          datatype: { value: 'http://example.org/types#type', termType: 'NamedNode' },
+        })).toBe(false);
+      }
+    );
 
-    it('should not equal an object with the same term type but a different datatype', () => {
-      literal.equals({
-        termType: 'Literal',
-        value: '',
-        language: '',
-        datatype: { value: 'other', termType: 'NamedNode' },
-      }).should.be.false;
-    });
+    it(
+      'should not equal an object with the same term type but a different datatype',
+      () => {
+        expect(literal.equals({
+          termType: 'Literal',
+          value: '',
+          language: '',
+          datatype: { value: 'other', termType: 'NamedNode' },
+        })).toBe(false);
+      }
+    );
 
     it('should not equal an object with a different term type', () => {
-      literal.equals({
+      expect(literal.equals({
         termType: 'NamedNode',
         value: '',
         language: '',
         datatype: { value: 'http://example.org/types#type', termType: 'NamedNode' },
-      }).should.be.false;
+      })).toBe(false);
     });
 
     it('should provide a JSON representation', () => {
-      literal.toJSON().should.deep.equal({
+      expect(literal.toJSON()).toEqual({
         termType: 'Literal',
         value: '',
         language: '',
@@ -537,97 +597,115 @@ describe('Literal', () => {
 
   describe('A Literal instance created from a string with a datatype', () => {
     let literal;
-    before(() => { literal = new Literal('"my @^^ string"^^http://example.org/types#type'); });
+    beforeAll(
+      () => { literal = new Literal('"my @^^ string"^^http://example.org/types#type'); }
+    );
 
     it('should be a Literal', () => {
-      literal.should.be.an.instanceof(Literal);
+      expect(literal).toBeInstanceOf(Literal);
     });
 
     it('should be a Term', () => {
-      literal.should.be.an.instanceof(Term);
+      expect(literal).toBeInstanceOf(Term);
     });
 
     it('should have term type "Literal"', () => {
-      literal.termType.should.equal('Literal');
+      expect(literal.termType).toBe('Literal');
     });
 
     it('should have the text value as value', () => {
-      literal.should.have.property('value', 'my @^^ string');
+      expect(literal).toHaveProperty('value', 'my @^^ string');
     });
 
     it('should have the empty string as language', () => {
-      literal.should.have.property('language', '');
+      expect(literal).toHaveProperty('language', '');
     });
 
     it('should have the datatype', () => {
-      literal.should.have.property('datatype');
-      literal.datatype.should.be.an.instanceof(NamedNode);
-      literal.datatype.value.should.equal('http://example.org/types#type');
+      expect(literal).toHaveProperty('datatype');
+      expect(literal.datatype).toBeInstanceOf(NamedNode);
+      expect(literal.datatype.value).toBe('http://example.org/types#type');
     });
 
     it('should have the quoted string as id', () => {
-      literal.should.have.property('id', '"my @^^ string"^^http://example.org/types#type');
+      expect(literal).toHaveProperty('id', '"my @^^ string"^^http://example.org/types#type');
     });
 
     it('should equal a Literal instance with the same value', () => {
-      literal.equals(new Literal('"my @^^ string"^^http://example.org/types#type')).should.be.true;
+      expect(
+        literal.equals(new Literal('"my @^^ string"^^http://example.org/types#type'))
+      ).toBe(true);
     });
 
-    it('should equal an object with the same term type, value, language, and datatype', () => {
-      literal.equals({
-        termType: 'Literal',
-        value: 'my @^^ string',
-        language: '',
-        datatype: { value: 'http://example.org/types#type', termType: 'NamedNode' },
-      }).should.be.true;
-    });
+    it(
+      'should equal an object with the same term type, value, language, and datatype',
+      () => {
+        expect(literal.equals({
+          termType: 'Literal',
+          value: 'my @^^ string',
+          language: '',
+          datatype: { value: 'http://example.org/types#type', termType: 'NamedNode' },
+        })).toBe(true);
+      }
+    );
 
     it('should not equal a falsy object', () => {
-      literal.equals(null).should.be.false;
+      expect(literal.equals(null)).toBe(false);
     });
 
     it('should not equal a Literal instance with another value', () => {
-      literal.equals(new Literal('"other string"^^http://example.org/types#type')).should.be.false;
+      expect(
+        literal.equals(new Literal('"other string"^^http://example.org/types#type'))
+      ).toBe(false);
     });
 
-    it('should not equal an object with the same term type but a different value', () => {
-      literal.equals({
-        termType: 'Literal',
-        value: 'other string',
-        language: '',
-        datatype: { value: 'http://example.org/types#type', termType: 'NamedNode' },
-      }).should.be.false;
-    });
+    it(
+      'should not equal an object with the same term type but a different value',
+      () => {
+        expect(literal.equals({
+          termType: 'Literal',
+          value: 'other string',
+          language: '',
+          datatype: { value: 'http://example.org/types#type', termType: 'NamedNode' },
+        })).toBe(false);
+      }
+    );
 
-    it('should not equal an object with the same term type but a different language', () => {
-      literal.equals({
-        termType: 'Literal',
-        value: 'my @^^ string',
-        language: 'en',
-        datatype: { value: 'http://example.org/types#type', termType: 'NamedNode' },
-      }).should.be.false;
-    });
+    it(
+      'should not equal an object with the same term type but a different language',
+      () => {
+        expect(literal.equals({
+          termType: 'Literal',
+          value: 'my @^^ string',
+          language: 'en',
+          datatype: { value: 'http://example.org/types#type', termType: 'NamedNode' },
+        })).toBe(false);
+      }
+    );
 
-    it('should not equal an object with the same term type but a different datatype', () => {
-      literal.equals({
-        termType: 'Literal',
-        value: 'my @^^ string',
-        language: '',
-        datatype: { value: 'other', termType: 'NamedNode' },
-      }).should.be.false;
-    });
+    it(
+      'should not equal an object with the same term type but a different datatype',
+      () => {
+        expect(literal.equals({
+          termType: 'Literal',
+          value: 'my @^^ string',
+          language: '',
+          datatype: { value: 'other', termType: 'NamedNode' },
+        })).toBe(false);
+      }
+    );
 
     it('should not equal an object with a different term type', () => {
-      literal.equals({
+      expect(literal.equals({
         termType: 'NamedNode',
         value: 'my @^^ string',
         language: '',
         datatype: { value: 'http://example.org/types#type', termType: 'NamedNode' },
-      }).should.be.false;
+      })).toBe(false);
     });
 
     it('should provide a JSON representation', () => {
-      literal.toJSON().should.deep.equal({
+      expect(literal.toJSON()).toEqual({
         termType: 'Literal',
         value: 'my @^^ string',
         language: '',

--- a/test/N3DataFactory-test.js
+++ b/test/N3DataFactory-test.js
@@ -11,102 +11,104 @@ import {
 describe('DataFactory', () => {
   describe('namedNode', () => {
     it('converts a plain IRI', () => {
-      DataFactory.namedNode('http://ex.org/foo#bar').should.deep.equal(new NamedNode('http://ex.org/foo#bar'));
+      expect(DataFactory.namedNode('http://ex.org/foo#bar')).toEqual(new NamedNode('http://ex.org/foo#bar'));
     });
   });
 
   describe('blankNode', () => {
     it('converts a label', () => {
-      DataFactory.blankNode('abc').should.deep.equal(new BlankNode('abc'));
+      expect(DataFactory.blankNode('abc')).toEqual(new BlankNode('abc'));
     });
 
     it('creates an anonymous blank node', () => {
-      DataFactory.blankNode().should.deep.equal(new BlankNode('n3-0'));
-      DataFactory.blankNode().should.deep.equal(new BlankNode('n3-1'));
+      expect(DataFactory.blankNode()).toEqual(new BlankNode('n3-0'));
+      expect(DataFactory.blankNode()).toEqual(new BlankNode('n3-1'));
     });
 
     it('does not create two equal anonymous blank nodes', () => {
-      DataFactory.blankNode().should.not.deep.equal(DataFactory.blankNode());
+      expect(DataFactory.blankNode()).not.toEqual(DataFactory.blankNode());
     });
   });
 
   describe('literal', () => {
     it('converts the empty string', () => {
-      DataFactory.literal('').should.deep.equal(new Literal('""'));
+      expect(DataFactory.literal('')).toEqual(new Literal('""'));
     });
 
     it('converts the empty string with a language', () => {
-      DataFactory.literal('', 'en-GB').should.deep.equal(new Literal('""@en-gb'));
+      expect(DataFactory.literal('', 'en-GB')).toEqual(new Literal('""@en-gb'));
     });
 
     it('converts the empty string with a named node type', () => {
-      DataFactory.literal('', new NamedNode('http://ex.org/type')).should.deep.equal(new Literal('""^^http://ex.org/type'));
+      expect(DataFactory.literal('', new NamedNode('http://ex.org/type'))).toEqual(new Literal('""^^http://ex.org/type'));
     });
 
     it('converts a non-empty string', () => {
-      DataFactory.literal('abc').should.deep.equal(new Literal('"abc"'));
+      expect(DataFactory.literal('abc')).toEqual(new Literal('"abc"'));
     });
 
     it('converts a non-empty string with a language', () => {
-      DataFactory.literal('abc', 'en-GB').should.deep.equal(new Literal('"abc"@en-gb'));
+      expect(DataFactory.literal('abc', 'en-GB')).toEqual(new Literal('"abc"@en-gb'));
     });
 
     it('converts a non-empty string with a named node type', () => {
-      DataFactory.literal('abc', new NamedNode('http://ex.org/type')).should.deep.equal(new Literal('"abc"^^http://ex.org/type'));
+      expect(DataFactory.literal('abc', new NamedNode('http://ex.org/type'))).toEqual(new Literal('"abc"^^http://ex.org/type'));
     });
 
     it('converts a non-empty string with an xsd:string type', () => {
-      DataFactory.literal('abc', new NamedNode('http://www.w3.org/2001/XMLSchema#string')).should.deep.equal(new Literal('"abc"'));
+      expect(
+        DataFactory.literal('abc', new NamedNode('http://www.w3.org/2001/XMLSchema#string'))
+      ).toEqual(new Literal('"abc"'));
     });
 
     it('converts an integer', () => {
-      DataFactory.literal(123).should.deep.equal(new Literal('"123"^^http://www.w3.org/2001/XMLSchema#integer'));
+      expect(DataFactory.literal(123)).toEqual(new Literal('"123"^^http://www.w3.org/2001/XMLSchema#integer'));
     });
 
     it('converts a double', () => {
-      DataFactory.literal(2.3).should.deep.equal(new Literal('"2.3"^^http://www.w3.org/2001/XMLSchema#double'));
+      expect(DataFactory.literal(2.3)).toEqual(new Literal('"2.3"^^http://www.w3.org/2001/XMLSchema#double'));
     });
 
     it('converts Infinity', () => {
-      DataFactory.literal(Infinity).should.deep.equal(new Literal('"INF"^^http://www.w3.org/2001/XMLSchema#double'));
+      expect(DataFactory.literal(Infinity)).toEqual(new Literal('"INF"^^http://www.w3.org/2001/XMLSchema#double'));
     });
 
     it('converts -Infinity', () => {
-      DataFactory.literal(-Infinity).should.deep.equal(new Literal('"-INF"^^http://www.w3.org/2001/XMLSchema#double'));
+      expect(DataFactory.literal(-Infinity)).toEqual(new Literal('"-INF"^^http://www.w3.org/2001/XMLSchema#double'));
     });
 
     it('converts NaN', () => {
-      DataFactory.literal(NaN).should.deep.equal(new Literal('"NaN"^^http://www.w3.org/2001/XMLSchema#double'));
+      expect(DataFactory.literal(NaN)).toEqual(new Literal('"NaN"^^http://www.w3.org/2001/XMLSchema#double'));
     });
 
     it('converts false', () => {
-      DataFactory.literal(false).should.deep.equal(new Literal('"false"^^http://www.w3.org/2001/XMLSchema#boolean'));
+      expect(DataFactory.literal(false)).toEqual(new Literal('"false"^^http://www.w3.org/2001/XMLSchema#boolean'));
     });
 
     it('converts true', () => {
-      DataFactory.literal(true).should.deep.equal(new Literal('"true"^^http://www.w3.org/2001/XMLSchema#boolean'));
+      expect(DataFactory.literal(true)).toEqual(new Literal('"true"^^http://www.w3.org/2001/XMLSchema#boolean'));
     });
   });
 
   describe('variable', () => {
     it('converts a label', () => {
-      DataFactory.variable('abc').should.deep.equal(new Variable('abc'));
+      expect(DataFactory.variable('abc')).toEqual(new Variable('abc'));
     });
   });
 
   describe('defaultGraph', () => {
     it('returns the default graph', () => {
-      DataFactory.defaultGraph().should.deep.equal(new DefaultGraph());
+      expect(DataFactory.defaultGraph()).toEqual(new DefaultGraph());
     });
   });
 
   describe('triple', () => {
     it('returns a quad in the default graph', () => {
-      DataFactory.triple(
+      expect(DataFactory.triple(
         new NamedNode('http://ex.org/a'),
         new NamedNode('http://ex.org/b'),
         new Literal('abc')
-      ).should.deep.equal(new Quad(
+      )).toEqual(new Quad(
         new NamedNode('http://ex.org/a'),
         new NamedNode('http://ex.org/b'),
         new Literal('abc'),
@@ -117,12 +119,12 @@ describe('DataFactory', () => {
 
   describe('quad', () => {
     it('returns a quad', () => {
-      DataFactory.quad(
+      expect(DataFactory.quad(
         new NamedNode('http://ex.org/a'),
         new NamedNode('http://ex.org/b'),
         new Literal('abc'),
         new NamedNode('http://ex.org/d')
-      ).should.deep.equal(new Quad(
+      )).toEqual(new Quad(
         new NamedNode('http://ex.org/a'),
         new NamedNode('http://ex.org/b'),
         new Literal('abc'),
@@ -131,7 +133,7 @@ describe('DataFactory', () => {
     });
 
     it('should return a nested quad', () => {
-      DataFactory.quad(
+      expect(DataFactory.quad(
         new Quad(
           new NamedNode('http://ex.org/a'),
           new NamedNode('http://ex.org/b'),
@@ -141,7 +143,7 @@ describe('DataFactory', () => {
         new NamedNode('http://ex.org/b'),
         new Literal('abc'),
         new NamedNode('http://ex.org/d')
-      ).should.deep.equal(new Quad(
+      )).toEqual(new Quad(
         new Quad(
           new NamedNode('http://ex.org/a'),
           new NamedNode('http://ex.org/b'),
@@ -155,7 +157,7 @@ describe('DataFactory', () => {
     });
 
     it('should return a nested quad', () => {
-      DataFactory.quad(
+      expect(DataFactory.quad(
         new NamedNode('http://ex.org/a'),
         new NamedNode('http://ex.org/b'),
         new Literal('abc'),
@@ -165,7 +167,7 @@ describe('DataFactory', () => {
           new Literal('abc'),
           new NamedNode('http://ex.org/d')
         )
-      ).should.deep.equal(new Quad(
+      )).toEqual(new Quad(
         new NamedNode('http://ex.org/a'),
         new NamedNode('http://ex.org/b'),
         new Literal('abc'),
@@ -179,11 +181,11 @@ describe('DataFactory', () => {
     });
 
     it('without graph parameter returns a quad in the default graph', () => {
-      DataFactory.quad(
+      expect(DataFactory.quad(
         new NamedNode('http://ex.org/a'),
         new NamedNode('http://ex.org/b'),
         new Literal('abc')
-      ).should.deep.equal(new Quad(
+      )).toEqual(new Quad(
         new NamedNode('http://ex.org/a'),
         new NamedNode('http://ex.org/b'),
         new Literal('abc'),

--- a/test/N3Lexer-test.js
+++ b/test/N3Lexer-test.js
@@ -6,315 +6,404 @@ import { EventEmitter } from 'events';
 describe('Lexer', () => {
   describe('The Lexer export', () => {
     it('should be a function', () => {
-      Lexer.should.be.a('function');
+      expect(Lexer).toBeInstanceOf(Function);
     });
 
     it('should be an Lexer constructor', () => {
-      new Lexer().should.be.an.instanceof(Lexer);
+      expect(new Lexer()).toBeInstanceOf(Lexer);
     });
   });
 
   describe('A Lexer instance', () => {
-    it('should tokenize the empty string',
-      shouldTokenize('',
-                     { type: 'eof', line: 1 }));
+    it('should tokenize the empty string', shouldTokenize('',
+                   { type: 'eof', line: 1 }));
 
+    it(
+      'should tokenize byte order mark at beginning as empty string',
+      shouldTokenize('\ufeff', { type: 'eof', line: 1 })
+    );
 
-    it('should tokenize byte order mark at beginning as empty string',
-        shouldTokenize('\ufeff', { type: 'eof', line: 1 }));
+    it('should tokenize a whitespace string', shouldTokenize(' \t \n  ',
+                   { type: 'eof', line: 2 }));
 
-    it('should tokenize a whitespace string',
-      shouldTokenize(' \t \n  ',
-                     { type: 'eof', line: 2 }));
+    it('should tokenize an IRI', shouldTokenize('<http://ex.org/?bla#foo>',
+                   { type: 'IRI', value: 'http://ex.org/?bla#foo', line: 1 },
+                   { type: 'eof', line: 1 }));
 
-    it('should tokenize an IRI',
-      shouldTokenize('<http://ex.org/?bla#foo>',
-                     { type: 'IRI', value: 'http://ex.org/?bla#foo', line: 1 },
-                     { type: 'eof', line: 1 }));
-
-    it('should tokenize a split IRI',
+    it(
+      'should tokenize a split IRI',
       shouldTokenize(streamOf('<', 'http://ex.org/?bla#foo>'),
         { type: 'IRI', value: 'http://ex.org/?bla#foo', line: 1 },
-        { type: 'eof', line: 1 }));
+        { type: 'eof', line: 1 })
+    );
 
-    it('should not tokenize an IRI with disallowed characters',
+    it(
+      'should not tokenize an IRI with disallowed characters',
       shouldNotTokenize('<http://ex.org/bla"foo>',
-                        'Unexpected "<http://ex.org/bla"foo>" on line 1.'));
+                        'Unexpected "<http://ex.org/bla"foo>" on line 1.')
+    );
 
-    it('should not tokenize an IRI with escaped characters',
+    it(
+      'should not tokenize an IRI with escaped characters',
       shouldNotTokenize('<http://ex.org/bla\\"foo>',
-                        'Unexpected "<http://ex.org/bla\\"foo>" on line 1.'));
+                        'Unexpected "<http://ex.org/bla\\"foo>" on line 1.')
+    );
 
-    it('should not tokenize an IRI with disallowed escaped characters',
+    it(
+      'should not tokenize an IRI with disallowed escaped characters',
       shouldNotTokenize('<http://ex.org/bla\\u0020foo>',
-                        'Unexpected "<http://ex.org/bla\\u0020foo>" on line 1.'));
+                        'Unexpected "<http://ex.org/bla\\u0020foo>" on line 1.')
+    );
 
-    it('should not tokenize an IRI with invalid 4-digit unicode escapes',
+    it(
+      'should not tokenize an IRI with invalid 4-digit unicode escapes',
       shouldNotTokenize('<http://ex.org/bla\\uXYZZfoo>',
-                        'Unexpected "<http://ex.org/bla\\uXYZZfoo>" on line 1.'));
+                        'Unexpected "<http://ex.org/bla\\uXYZZfoo>" on line 1.')
+    );
 
-    it('should not tokenize an IRI with invalid 8-digit unicode escapes',
+    it(
+      'should not tokenize an IRI with invalid 8-digit unicode escapes',
       shouldNotTokenize('<http://ex.org/bla\\uXYZZxyzzfoo>',
-                        'Unexpected "<http://ex.org/bla\\uXYZZxyzzfoo>" on line 1.'));
+                        'Unexpected "<http://ex.org/bla\\uXYZZxyzzfoo>" on line 1.')
+    );
 
-    it('should not tokenize an IRI with a non-numeric 4-digit unicode escapes', done => {
-      const stream = new EventEmitter(), lexer = new Lexer();
-      lexer.tokenize(stream, (error, token) => {
-        error.should.be.an.instanceof(Error);
-        error.message.should.equal('Unexpected "<\\uz234>" on line 1.');
-        done(token);
-      });
-      stream.emit('data', '<\\uz234>');
-    });
+    it(
+      'should not tokenize an IRI with a non-numeric 4-digit unicode escapes',
+      done => {
+        const stream = new EventEmitter(), lexer = new Lexer();
+        lexer.tokenize(stream, (error, token) => {
+          expect(error).toBeInstanceOf(Error);
+          expect(error.message).toBe('Unexpected "<\\uz234>" on line 1.');
+          done(token);
+        });
+        stream.emit('data', '<\\uz234>');
+      }
+    );
 
-    it('should not tokenize an IRI with a non-numeric 8-digit unicode escapes', done => {
-      const stream = new EventEmitter(), lexer = new Lexer();
-      lexer.tokenize(stream, (error, token) => {
-        error.should.be.an.instanceof(Error);
-        error.message.should.equal('Unexpected "<\\Uz2345678>" on line 1.');
-        done(token);
-      });
-      stream.emit('data', '<\\Uz2345678>');
-    });
+    it(
+      'should not tokenize an IRI with a non-numeric 8-digit unicode escapes',
+      done => {
+        const stream = new EventEmitter(), lexer = new Lexer();
+        lexer.tokenize(stream, (error, token) => {
+          expect(error).toBeInstanceOf(Error);
+          expect(error.message).toBe('Unexpected "<\\Uz2345678>" on line 1.');
+          done(token);
+        });
+        stream.emit('data', '<\\Uz2345678>');
+      }
+    );
 
-    it('should tokenize an IRI with four-digit unicode escapes',
+    it(
+      'should tokenize an IRI with four-digit unicode escapes',
       shouldTokenize('<http://a.example/\\u0073>',
                      { type: 'IRI', value: 'http://a.example/s', line: 1 },
-                     { type: 'eof', line: 1 }));
+                     { type: 'eof', line: 1 })
+    );
 
-    it('should tokenize an IRI with eight-digit unicode escapes',
+    it(
+      'should tokenize an IRI with eight-digit unicode escapes',
       shouldTokenize('<http://a.example/\\U00000073\\U00A00073>',
                      { type: 'IRI', value: 'http://a.example/s\uffc0\udc73', line: 1 },
-                     { type: 'eof', line: 1 }));
+                     { type: 'eof', line: 1 })
+    );
 
-    it('should not decode an IRI',
-      shouldTokenize('<http://a.example/%66oo-bar>',
-                     { type: 'IRI', value: 'http://a.example/%66oo-bar', line: 1 },
-                     { type: 'eof', line: 1 }));
+    it('should not decode an IRI', shouldTokenize('<http://a.example/%66oo-bar>',
+                   { type: 'IRI', value: 'http://a.example/%66oo-bar', line: 1 },
+                   { type: 'eof', line: 1 }));
 
-    it('should tokenize two IRIs separated by whitespace',
+    it(
+      'should tokenize two IRIs separated by whitespace',
       shouldTokenize(' \n\t<http://ex.org/?bla#foo> \n\t<http://ex.org/?bla#bar> \n\t',
                      { type: 'IRI', value: 'http://ex.org/?bla#foo', line: 2 },
                      { type: 'IRI', value: 'http://ex.org/?bla#bar', line: 3 },
-                     { type: 'eof', line: 4 }));
+                     { type: 'eof', line: 4 })
+    );
 
-    it('should tokenize a statement with IRIs',
+    it(
+      'should tokenize a statement with IRIs',
       shouldTokenize(' \n\t<http://ex.org/?bla#foo> \n\t<http://ex.org/?bla#bar> \n\t<http://ex.org/?bla#boo> .',
                      { type: 'IRI', value: 'http://ex.org/?bla#foo', line: 2 },
                      { type: 'IRI', value: 'http://ex.org/?bla#bar', line: 3 },
                      { type: 'IRI', value: 'http://ex.org/?bla#boo', line: 4 },
                      { type: '.', line: 4 },
-                     { type: 'eof', line: 4 }));
+                     { type: 'eof', line: 4 })
+    );
 
-    it('should tokenize prefixed names',
-      shouldTokenize(':a b:c d-dd:e-ee.',
-                     { type: 'prefixed', prefix: '',      value: 'a',    line: 1 },
-                     { type: 'prefixed', prefix: 'b',     value: 'c',    line: 1 },
-                     { type: 'prefixed', prefix: 'd-dd',  value: 'e-ee', line: 1 },
-                     { type: '.', line: 1 },
-                     { type: 'eof', line: 1 }));
+    it('should tokenize prefixed names', shouldTokenize(':a b:c d-dd:e-ee.',
+                   { type: 'prefixed', prefix: '',      value: 'a',    line: 1 },
+                   { type: 'prefixed', prefix: 'b',     value: 'c',    line: 1 },
+                   { type: 'prefixed', prefix: 'd-dd',  value: 'e-ee', line: 1 },
+                   { type: '.', line: 1 },
+                   { type: 'eof', line: 1 }));
 
-    it('should tokenize prefixed names with leading digits',
+    it(
+      'should tokenize prefixed names with leading digits',
       shouldTokenize('leg:3032571 isbn13:9780136019701 ',
                      { type: 'prefixed', prefix: 'leg',    value: '3032571',       line: 1 },
                      { type: 'prefixed', prefix: 'isbn13', value: '9780136019701', line: 1 },
-                     { type: 'eof', line: 1 }));
+                     { type: 'eof', line: 1 })
+    );
 
-    it('should tokenize prefixed names starting with true',
+    it(
+      'should tokenize prefixed names starting with true',
       shouldTokenize('true:a  truer:b ',
                      { type: 'prefixed', prefix: 'true',   value: 'a', line: 1 },
                      { type: 'prefixed', prefix: 'truer',  value: 'b', line: 1 },
-                     { type: 'eof', line: 1 }));
+                     { type: 'eof', line: 1 })
+    );
 
-    it('should tokenize prefixed names starting with false',
+    it(
+      'should tokenize prefixed names starting with false',
       shouldTokenize('false:a falser:b ',
                      { type: 'prefixed', prefix: 'false',  value: 'a', line: 1 },
                      { type: 'prefixed', prefix: 'falser', value: 'b', line: 1 },
-                     { type: 'eof', line: 1 }));
+                     { type: 'eof', line: 1 })
+    );
 
-    it('should tokenize prefixed names with non-leading colons',
+    it(
+      'should tokenize prefixed names with non-leading colons',
       shouldTokenize('og:video:height ',
                      { type: 'prefixed', prefix: 'og', value: 'video:height', line: 1 },
-                     { type: 'eof', line: 1 }));
+                     { type: 'eof', line: 1 })
+    );
 
-    it('should tokenize prefixed names with reserved escape sequences',
+    it(
+      'should tokenize prefixed names with reserved escape sequences',
       shouldTokenize('wgs:lat\\-long ',
                      { type: 'prefixed', prefix: 'wgs', value: 'lat-long', line: 1 },
-                     { type: 'eof', line: 1 }));
+                     { type: 'eof', line: 1 })
+    );
 
-    it('should tokenize the colon prefixed name',
-      shouldTokenize(': : :.',
-                     { type: 'prefixed', prefix: '', value: '', line: 1 },
-                     { type: 'prefixed', prefix: '', value: '', line: 1 },
-                     { type: 'prefixed', prefix: '', value: '', line: 1 },
-                     { type: '.', line: 1 },
-                     { type: 'eof', line: 1 }));
+    it('should tokenize the colon prefixed name', shouldTokenize(': : :.',
+                   { type: 'prefixed', prefix: '', value: '', line: 1 },
+                   { type: 'prefixed', prefix: '', value: '', line: 1 },
+                   { type: 'prefixed', prefix: '', value: '', line: 1 },
+                   { type: '.', line: 1 },
+                   { type: 'eof', line: 1 }));
 
-    it('should tokenize a prefixed name with a dot, split in half while streaming',
+    it(
+      'should tokenize a prefixed name with a dot, split in half while streaming',
       shouldTokenize(streamOf('dbpedia:Anthony_J._Batt', 'aglia '),
                      { type: 'prefixed', prefix: 'dbpedia', value: 'Anthony_J._Battaglia', line: 1 },
-                     { type: 'eof', line: 1 }));
+                     { type: 'eof', line: 1 })
+    );
 
-    it('should tokenize a prefixed name with a dot, split after the dot while streaming',
+    it(
+      'should tokenize a prefixed name with a dot, split after the dot while streaming',
       shouldTokenize(streamOf('dbpedia:Anthony_J.', '_Battaglia '),
                      { type: 'prefixed', prefix: 'dbpedia', value: 'Anthony_J._Battaglia', line: 1 },
-                     { type: 'eof', line: 1 }));
+                     { type: 'eof', line: 1 })
+    );
 
-    it('should tokenize a blank node with a dot, split in half while streaming',
+    it(
+      'should tokenize a blank node with a dot, split in half while streaming',
       shouldTokenize(streamOf('_:Anthony_J._Batt', 'aglia '),
                      { type: 'blank', prefix: '_', value: 'Anthony_J._Battaglia', line: 1 },
-                     { type: 'eof', line: 1 }));
+                     { type: 'eof', line: 1 })
+    );
 
-    it('should tokenize a blank node with a dot, split after the dot while streaming',
+    it(
+      'should tokenize a blank node with a dot, split after the dot while streaming',
       shouldTokenize(streamOf('_:Anthony_J.', '_Battaglia '),
                      { type: 'blank', prefix: '_', value: 'Anthony_J._Battaglia', line: 1 },
-                     { type: 'eof', line: 1 }));
+                     { type: 'eof', line: 1 })
+    );
 
-    it('should not decode a prefixed name',
-      shouldTokenize('ex:%66oo-bar ',
-                     { type: 'prefixed', prefix: 'ex', value: '%66oo-bar', line: 1 },
-                     { type: 'eof', line: 1 }));
+    it('should not decode a prefixed name', shouldTokenize('ex:%66oo-bar ',
+                   { type: 'prefixed', prefix: 'ex', value: '%66oo-bar', line: 1 },
+                   { type: 'eof', line: 1 }));
 
-    it('should not tokenize a prefixed name with disallowed characters',
+    it(
+      'should not tokenize a prefixed name with disallowed characters',
       shouldNotTokenize('ex:bla"foo',
-                        'Unexpected ""foo" on line 1.'));
+                        'Unexpected ""foo" on line 1.')
+    );
 
-    it('should not tokenize a prefixed name with escaped characters',
+    it(
+      'should not tokenize a prefixed name with escaped characters',
       shouldNotTokenize('ex:bla\\"foo',
-                        'Unexpected "ex:bla\\"foo" on line 1.'));
+                        'Unexpected "ex:bla\\"foo" on line 1.')
+    );
 
-    it('should not tokenize a prefixed name with disallowed escaped characters',
+    it(
+      'should not tokenize a prefixed name with disallowed escaped characters',
       shouldNotTokenize('ex:bla\\u0020foo',
-                        'Unexpected "ex:bla\\u0020foo" on line 1.'));
+                        'Unexpected "ex:bla\\u0020foo" on line 1.')
+    );
 
-    it('should not tokenize a prefixed name with invalid 4-digit unicode escapes',
+    it(
+      'should not tokenize a prefixed name with invalid 4-digit unicode escapes',
       shouldNotTokenize('ex:bla\\uXYZZfoo',
-                        'Unexpected "ex:bla\\uXYZZfoo" on line 1.'));
+                        'Unexpected "ex:bla\\uXYZZfoo" on line 1.')
+    );
 
-    it('should not tokenize a prefixed name with invalid 8-digit unicode escapes',
+    it(
+      'should not tokenize a prefixed name with invalid 8-digit unicode escapes',
       shouldNotTokenize('ex:bla\\uXYZZxyzzfoo',
-                        'Unexpected "ex:bla\\uXYZZxyzzfoo" on line 1.'));
+                        'Unexpected "ex:bla\\uXYZZxyzzfoo" on line 1.')
+    );
 
-    it('should not tokenize a prefixed name with four-digit unicode escapes',
+    it(
+      'should not tokenize a prefixed name with four-digit unicode escapes',
       shouldNotTokenize('ex:foo\\u0073bar',
-                        'Unexpected "ex:foo\\u0073bar" on line 1.'));
+                        'Unexpected "ex:foo\\u0073bar" on line 1.')
+    );
 
-    it('should not tokenize a prefixed name with eight-digit unicode escapes',
+    it(
+      'should not tokenize a prefixed name with eight-digit unicode escapes',
       shouldNotTokenize('ex:foo\\U00000073\\U00A00073bar',
-                        'Unexpected "ex:foo\\U00000073\\U00A00073bar" on line 1.'));
+                        'Unexpected "ex:foo\\U00000073\\U00A00073bar" on line 1.')
+    );
 
-    it('should tokenize two prefixed names separated by whitespace',
+    it(
+      'should tokenize two prefixed names separated by whitespace',
       shouldTokenize(' \n\tex:foo \n\tex:bar \n\t',
                      { type: 'prefixed', prefix: 'ex', value: 'foo', line: 2 },
                      { type: 'prefixed', prefix: 'ex', value: 'bar', line: 3 },
-                     { type: 'eof', line: 4 }));
+                     { type: 'eof', line: 4 })
+    );
 
-    it('should tokenize a statement with prefixed names',
+    it(
+      'should tokenize a statement with prefixed names',
       shouldTokenize(' \n\tex:foo \n\tex:bar \n\tex:baz .',
                      { type: 'prefixed', prefix: 'ex', value: 'foo', line: 2 },
                      { type: 'prefixed', prefix: 'ex', value: 'bar', line: 3 },
                      { type: 'prefixed', prefix: 'ex', value: 'baz', line: 4 },
                      { type: '.', line: 4 },
-                     { type: 'eof', line: 4 }));
+                     { type: 'eof', line: 4 })
+    );
 
-    it('should correctly recognize different types of newlines',
+    it(
+      'should correctly recognize different types of newlines',
       shouldTokenize('<a>\r<b>\n<c>\r\n.',
                      { type: 'IRI', value: 'a', line: 1 },
                      { type: 'IRI', value: 'b', line: 2 },
                      { type: 'IRI', value: 'c', line: 3 },
                      { type: '.', line: 4 },
-                     { type: 'eof', line: 4 }));
+                     { type: 'eof', line: 4 })
+    );
 
-    it('should tokenize a single comment',
-      shouldTokenize('#mycomment',
-                     { type: 'eof', line: 1 }));
+    it('should tokenize a single comment', shouldTokenize('#mycomment',
+                   { type: 'eof', line: 1 }));
 
-    it('should tokenize a stream with split comment',
+    it(
+      'should tokenize a stream with split comment',
       shouldTokenize(streamOf('#mycom', 'ment'),
-                     { type: 'eof', line: 1 }));
+                     { type: 'eof', line: 1 })
+    );
 
-    it('should ignore comments',
+    it(
+      'should ignore comments',
       shouldTokenize('<#foo> #mycomment\n <#foo>  #mycomment \r# mycomment\n\n<#bla>#',
                      { type: 'IRI', value: '#foo', line: 1 },
                      { type: 'IRI', value: '#foo', line: 2 },
                      { type: 'IRI', value: '#bla', line: 5 },
-                     { type: 'eof', line: 5 }));
+                     { type: 'eof', line: 5 })
+    );
 
-    it('should tokenize comments after abbreviations and local names',
+    it(
+      'should tokenize comments after abbreviations and local names',
       shouldTokenize('[a#\na:a#\n].',
                      { type: '[', line: 1 },
                      { type: 'abbreviation', value: 'a', line: 1 },
                      { type: 'prefixed', prefix: 'a', value: 'a', line: 2 },
                      { type: ']', line: 3 },
                      { type: '.', line: 3 },
-                     { type: 'eof', line: 3 }));
+                     { type: 'eof', line: 3 })
+    );
 
-    it('should tokenize a quoted string literal',
-      shouldTokenize('"string" ',
-                     { type: 'literal', value: 'string', line: 1 },
-                     { type: 'eof', line: 1 }));
+    it('should tokenize a quoted string literal', shouldTokenize('"string" ',
+                   { type: 'literal', value: 'string', line: 1 },
+                   { type: 'eof', line: 1 }));
 
-    it('should not tokenize a quoted string literal with a newline',
+    it(
+      'should not tokenize a quoted string literal with a newline',
       shouldNotTokenize('"abc\ndef" ',
-                        'Unexpected ""abc" on line 1.'));
+                        'Unexpected ""abc" on line 1.')
+    );
 
-    it('should not tokenize a quoted string literal with a carriage return',
+    it(
+      'should not tokenize a quoted string literal with a carriage return',
       shouldNotTokenize('"abc\rdef" ',
-                        'Unexpected ""abc" on line 1.'));
+                        'Unexpected ""abc" on line 1.')
+    );
 
-    it('should tokenize a triple quoted string literal',
+    it(
+      'should tokenize a triple quoted string literal',
       shouldTokenize('"""string"""',
                      { type: 'literal', value: 'string', line: 1 },
-                     { type: 'eof', line: 1 }));
+                     { type: 'eof', line: 1 })
+    );
 
-    it('should tokenize a triple quoted string literal with quoted newlines inside',
+    it(
+      'should tokenize a triple quoted string literal with quoted newlines inside',
       shouldTokenize('"""st"r\r\ni""\n\rng"""',
                      { type: 'literal', value: 'st"r\r\ni""\n\rng', line: 1 },
-                     { type: 'eof', line: 4 }));
+                     { type: 'eof', line: 4 })
+    );
 
-    it('should tokenize a string with escape characters',
+    it(
+      'should tokenize a string with escape characters',
       shouldTokenize('"\\\\ \\\' \\" \\n \\r \\t \\ua1b2" \n """\\\\ \\\' \\" \\n \\r \\t \\U0000a1b2"""',
                      { type: 'literal', value: '\\ \' " \n \r \t \ua1b2', line: 1 },
                      { type: 'literal', value: '\\ \' " \n \r \t \ua1b2', line: 2 },
-                     { type: 'eof', line: 2 }));
+                     { type: 'eof', line: 2 })
+    );
 
-    it('should not tokenize a string with invalid characters',
+    it(
+      'should not tokenize a string with invalid characters',
       shouldNotTokenize('"\\uXYZX" ',
-                        'Unexpected ""\\uXYZX"" on line 1.'));
+                        'Unexpected ""\\uXYZX"" on line 1.')
+    );
 
-    it('should not tokenize a double-quoted string ending with an escaped quote',
+    it(
+      'should not tokenize a double-quoted string ending with an escaped quote',
       shouldNotTokenize('"abc\\"',
-                        'Unexpected ""abc\\"" on line 1.'));
+                        'Unexpected ""abc\\"" on line 1.')
+    );
 
-    it('should not tokenize a single-quoted string ending with an escaped quote',
+    it(
+      'should not tokenize a single-quoted string ending with an escaped quote',
       shouldNotTokenize("'abc\\'",
-                        'Unexpected "\'abc\\\'" on line 1.'));
+                        'Unexpected "\'abc\\\'" on line 1.')
+    );
 
-    it('should not tokenize a double-quoted string ending with a backslash and escaped quote',
+    it(
+      'should not tokenize a double-quoted string ending with a backslash and escaped quote',
       shouldNotTokenize('"abc\\\\\\"',
-                        'Unexpected ""abc\\\\\\"" on line 1.'));
+                        'Unexpected ""abc\\\\\\"" on line 1.')
+    );
 
-    it('should not tokenize a single-quoted string ending with a backslash and escaped quote',
+    it(
+      'should not tokenize a single-quoted string ending with a backslash and escaped quote',
       shouldNotTokenize("'abc\\\\\\'",
-                        'Unexpected "\'abc\\\\\\\'" on line 1.'));
+                        'Unexpected "\'abc\\\\\\\'" on line 1.')
+    );
 
-    it('should tokenize a double-quoted string ending in backslashes',
+    it(
+      'should tokenize a double-quoted string ending in backslashes',
       shouldTokenize('"abc\\\\" "abc\\\\\\\\"',
                      { type: 'literal', value: 'abc\\', line: 1 },
                      { type: 'literal', value: 'abc\\\\', line: 1 },
-                     { type: 'eof', line: 1 }));
+                     { type: 'eof', line: 1 })
+    );
 
-    it('should tokenize a single-quoted string ending in backslashes',
+    it(
+      'should tokenize a single-quoted string ending in backslashes',
       shouldTokenize("'abc\\\\' 'abc\\\\\\\\'",
                      { type: 'literal', value: 'abc\\', line: 1 },
                      { type: 'literal', value: 'abc\\\\', line: 1 },
-                     { type: 'eof', line: 1 }));
+                     { type: 'eof', line: 1 })
+    );
 
-    it('should not tokenize a triple-quoted string with invalid characters',
+    it(
+      'should not tokenize a triple-quoted string with invalid characters',
       shouldNotTokenize("'''\\uXYZX''' ",
-                        "Unexpected \"'''\\uXYZX'''\" on line 1."));
+                        "Unexpected \"'''\\uXYZX'''\" on line 1.")
+    );
 
-    it('should tokenize a quoted string literal with language code',
+    it(
+      'should tokenize a quoted string literal with language code',
       shouldTokenize('"string"@en "string"@nl-be "string"@EN ',
                      { type: 'literal', value: 'string', line: 1 },
                      { type: 'langcode', value: 'en', line: 1 },
@@ -322,54 +411,71 @@ describe('Lexer', () => {
                      { type: 'langcode', value: 'nl-be', line: 1 },
                      { type: 'literal', value: 'string', line: 1 },
                      { type: 'langcode', value: 'EN', line: 1 },
-                     { type: 'eof', line: 1 }));
+                     { type: 'eof', line: 1 })
+    );
 
-    it('should tokenize a quoted string literal with type',
+    it(
+      'should tokenize a quoted string literal with type',
       shouldTokenize('"stringA"^^<type> "stringB"^^ns:mytype ',
                      { type: 'literal', value: 'stringA', line: 1 },
                      { type: 'typeIRI', value: 'type', line: 1 },
                      { type: 'literal', value: 'stringB', line: 1 },
                      { type: 'type', value: 'mytype', prefix: 'ns', line: 1 },
-                     { type: 'eof', line: 1 }));
+                     { type: 'eof', line: 1 })
+    );
 
-    it('should not tokenize a single hat',
-      shouldNotTokenize('^',
-                        'Unexpected "^" on line 1.'));
+    it('should not tokenize a single hat', shouldNotTokenize('^',
+                      'Unexpected "^" on line 1.'));
 
-    it('should not tokenize a double hat followed by a non-IRI',
+    it(
+      'should not tokenize a double hat followed by a non-IRI',
       shouldNotTokenize('^^1',
-                        'Unexpected "1" on line 1.'));
+                        'Unexpected "1" on line 1.')
+    );
 
-    it('should tokenize a single-quoted string literal',
+    it(
+      'should tokenize a single-quoted string literal',
       shouldTokenize("'string' ",
                      { type: 'literal', value: 'string', line: 1 },
-                     { type: 'eof', line: 1 }));
+                     { type: 'eof', line: 1 })
+    );
 
-    it('should tokenize a triple single-quoted string literal',
+    it(
+      'should tokenize a triple single-quoted string literal',
       shouldTokenize("'''string'''",
                      { type: 'literal', value: 'string', line: 1 },
-                     { type: 'eof', line: 1 }));
+                     { type: 'eof', line: 1 })
+    );
 
-    it('should not tokenize a single-quoted string literal with a newline',
+    it(
+      'should not tokenize a single-quoted string literal with a newline',
       shouldNotTokenize("'abc\ndef' ",
-                        'Unexpected "\'abc" on line 1.'));
+                        'Unexpected "\'abc" on line 1.')
+    );
 
-    it('should not tokenize a single-quoted string literal with a carriage return',
+    it(
+      'should not tokenize a single-quoted string literal with a carriage return',
       shouldNotTokenize("'abc\rdef' ",
-                        'Unexpected "\'abc" on line 1.'));
+                        'Unexpected "\'abc" on line 1.')
+    );
 
-    it('should tokenize a triple single-quoted string literal with quotes newlines inside',
+    it(
+      'should tokenize a triple single-quoted string literal with quotes newlines inside',
       shouldTokenize("'''st'r\ni''ng'''",
                      { type: 'literal', value: 'st\'r\ni\'\'ng', line: 1 },
-                     { type: 'eof', line: 2 }));
+                     { type: 'eof', line: 2 })
+    );
 
-    it('should tokenize a single-quoted string with escape characters',
+    it(
+      'should tokenize a single-quoted string with escape characters',
       shouldTokenize("'\\\\ \\\" \\' \\n \\r \\t \\ua1b2' \n '''\\\\ \\\" \\' \\n \\r \\t \\U0020a1b2'''",
                      { type: 'literal', value: '\\ " \' \n \r \t \ua1b2', line: 1 },
                      { type: 'literal', value: '\\ " \' \n \r \t \udfe8\uddb2', line: 2 },
-                     { type: 'eof', line: 2 }));
+                     { type: 'eof', line: 2 })
+    );
 
-    it('should tokenize a single-quoted string literal with language code',
+    it(
+      'should tokenize a single-quoted string literal with language code',
       shouldTokenize("'string'@en 'string'@nl-be 'string'@EN ",
                      { type: 'literal', value: 'string', line: 1 },
                      { type: 'langcode', value: 'en', line: 1 },
@@ -377,29 +483,32 @@ describe('Lexer', () => {
                      { type: 'langcode', value: 'nl-be', line: 1 },
                      { type: 'literal', value: 'string', line: 1 },
                      { type: 'langcode', value: 'EN', line: 1 },
-                     { type: 'eof', line: 1 }));
+                     { type: 'eof', line: 1 })
+    );
 
-    it('should tokenize a single-quoted string literal with type',
+    it(
+      'should tokenize a single-quoted string literal with type',
       shouldTokenize("'stringA'^^<type> 'stringB'^^ns:mytype ",
                      { type: 'literal', value: 'stringA', line: 1 },
                      { type: 'typeIRI', value: 'type', line: 1 },
                      { type: 'literal', value: 'stringB', line: 1 },
                      { type: 'type', value: 'mytype', prefix: 'ns', line: 1 },
-                     { type: 'eof', line: 1 }));
+                     { type: 'eof', line: 1 })
+    );
 
-    it('should tokenize an integer literal',
-      shouldTokenize('10, +20. -30, 40. ',
-                     { type: 'literal', value:  '10', prefix: 'http://www.w3.org/2001/XMLSchema#integer', line: 1 },
-                     { type: ',', line: 1 },
-                     { type: 'literal', value: '+20', prefix: 'http://www.w3.org/2001/XMLSchema#integer', line: 1 },
-                     { type: '.', line: 1 },
-                     { type: 'literal', value: '-30', prefix: 'http://www.w3.org/2001/XMLSchema#integer', line: 1 },
-                     { type: ',', line: 1 },
-                     { type: 'literal', value:  '40', prefix: 'http://www.w3.org/2001/XMLSchema#integer', line: 1 },
-                     { type: '.', line: 1 },
-                     { type: 'eof', line: 1 }));
+    it('should tokenize an integer literal', shouldTokenize('10, +20. -30, 40. ',
+                   { type: 'literal', value:  '10', prefix: 'http://www.w3.org/2001/XMLSchema#integer', line: 1 },
+                   { type: ',', line: 1 },
+                   { type: 'literal', value: '+20', prefix: 'http://www.w3.org/2001/XMLSchema#integer', line: 1 },
+                   { type: '.', line: 1 },
+                   { type: 'literal', value: '-30', prefix: 'http://www.w3.org/2001/XMLSchema#integer', line: 1 },
+                   { type: ',', line: 1 },
+                   { type: 'literal', value:  '40', prefix: 'http://www.w3.org/2001/XMLSchema#integer', line: 1 },
+                   { type: '.', line: 1 },
+                   { type: 'eof', line: 1 }));
 
-    it('should tokenize a decimal literal',
+    it(
+      'should tokenize a decimal literal',
       shouldTokenize('1. 2.0, .3. -0.4, -.5. ',
                      { type: 'literal', value:    '1', prefix: 'http://www.w3.org/2001/XMLSchema#integer', line: 1 },
                      { type: '.', line: 1 },
@@ -411,9 +520,11 @@ describe('Lexer', () => {
                      { type: ',', line: 1 },
                      { type: 'literal', value:  '-.5', prefix: 'http://www.w3.org/2001/XMLSchema#decimal', line: 1 },
                      { type: '.', line: 1 },
-                     { type: 'eof', line: 1 }));
+                     { type: 'eof', line: 1 })
+    );
 
-    it('should tokenize a double literal',
+    it(
+      'should tokenize a double literal',
       shouldTokenize('10e20, +30.40E+50. -60.70e-80. .171e-11.',
                      { type: 'literal', value:      '10e20', prefix: 'http://www.w3.org/2001/XMLSchema#double', line: 1 },
                      { type: ',', line: 1 },
@@ -423,19 +534,19 @@ describe('Lexer', () => {
                      { type: '.', line: 1 },
                      { type: 'literal', value: '.171e-11', prefix: 'http://www.w3.org/2001/XMLSchema#double', line: 1 },
                      { type: '.', line: 1 },
-                     { type: 'eof', line: 1 }));
+                     { type: 'eof', line: 1 })
+    );
 
-    it('should not tokenize an invalid number',
-      shouldNotTokenize('10-10 ',
-                        'Unexpected "10-10" on line 1.'));
+    it('should not tokenize an invalid number', shouldNotTokenize('10-10 ',
+                      'Unexpected "10-10" on line 1.'));
 
-    it('should tokenize booleans',
-      shouldTokenize('true false ',
-                     { type: 'literal', value:  'true', prefix: 'http://www.w3.org/2001/XMLSchema#boolean', line: 1 },
-                     { type: 'literal', value: 'false', prefix: 'http://www.w3.org/2001/XMLSchema#boolean', line: 1 },
-                     { type: 'eof', line: 1 }));
+    it('should tokenize booleans', shouldTokenize('true false ',
+                   { type: 'literal', value:  'true', prefix: 'http://www.w3.org/2001/XMLSchema#boolean', line: 1 },
+                   { type: 'literal', value: 'false', prefix: 'http://www.w3.org/2001/XMLSchema#boolean', line: 1 },
+                   { type: 'eof', line: 1 }));
 
-    it('should tokenize statements with shared subjects',
+    it(
+      'should tokenize statements with shared subjects',
       shouldTokenize('<a> <b> <c>;\n<d> <e>.',
                      { type: 'IRI', value: 'a', line: 1 },
                      { type: 'IRI', value: 'b', line: 1 },
@@ -444,9 +555,11 @@ describe('Lexer', () => {
                      { type: 'IRI', value: 'd', line: 2 },
                      { type: 'IRI', value: 'e', line: 2 },
                      { type: '.', line: 2 },
-                     { type: 'eof', line: 2 }));
+                     { type: 'eof', line: 2 })
+    );
 
-    it('should tokenize statements with shared subjects and predicates',
+    it(
+      'should tokenize statements with shared subjects and predicates',
       shouldTokenize('<a> <b> <c>,\n<d>.',
                      { type: 'IRI', value: 'a', line: 1 },
                      { type: 'IRI', value: 'b', line: 1 },
@@ -454,9 +567,11 @@ describe('Lexer', () => {
                      { type: ',', line: 1 },
                      { type: 'IRI', value: 'd', line: 2 },
                      { type: '.', line: 2 },
-                     { type: 'eof', line: 2 }));
+                     { type: 'eof', line: 2 })
+    );
 
-    it('should tokenize statements with shared subjects and predicates and prefixed names',
+    it(
+      'should tokenize statements with shared subjects and predicates and prefixed names',
       shouldTokenize('a:a b:b c:c;d:d e:e,f:f.',
                      { type: 'prefixed', prefix: 'a', value: 'a', line: 1 },
                      { type: 'prefixed', prefix: 'b', value: 'b', line: 1 },
@@ -467,9 +582,11 @@ describe('Lexer', () => {
                      { type: ',', line: 1 },
                      { type: 'prefixed', prefix: 'f', value: 'f', line: 1 },
                      { type: '.', line: 1 },
-                     { type: 'eof', line: 1 }));
+                     { type: 'eof', line: 1 })
+    );
 
-    it('should tokenize a stream',
+    it(
+      'should tokenize a stream',
       shouldTokenize(streamOf('<a>\n<b', '> ', '"""', 'c\n', '"""', '.',
                               '<d> <e', '> ', '""', '.',
                               '<g> <h> "i"', '@e', 'n.'),
@@ -486,49 +603,69 @@ describe('Lexer', () => {
                      { type: 'literal', value: 'i', line: 3 },
                      { type: 'langcode', value: 'en', line: 3 },
                      { type: '.', line: 3 },
-                     { type: 'eof', line: 3 }));
+                     { type: 'eof', line: 3 })
+    );
 
-    it('should tokenize a stream ending with a digit and a dot',
+    it(
+      'should tokenize a stream ending with a digit and a dot',
       shouldTokenize(streamOf('1', '.'),
                      { type: 'literal', value: '1', prefix: 'http://www.w3.org/2001/XMLSchema#integer', line: 1 },
                      { type: '.', line: 1 },
-                     { type: 'eof', line: 1 }));
+                     { type: 'eof', line: 1 })
+    );
 
-    it('should tokenize a stream containing a decimal without leading digit',
+    it(
+      'should tokenize a stream containing a decimal without leading digit',
       shouldTokenize(streamOf('.', '1 '),
                      { type: 'literal', value: '.1', prefix: 'http://www.w3.org/2001/XMLSchema#decimal', line: 1 },
-                     { type: 'eof', line: 1 }));
+                     { type: 'eof', line: 1 })
+    );
 
-    it('should tokenize a stream containing a decimal with leading digit',
+    it(
+      'should tokenize a stream containing a decimal with leading digit',
       shouldTokenize(streamOf('1.', '1 '),
                      { type: 'literal', value: '1.1', prefix: 'http://www.w3.org/2001/XMLSchema#decimal', line: 1 },
-                     { type: 'eof', line: 1 }));
+                     { type: 'eof', line: 1 })
+    );
 
-    it('should immediately signal an error if a linebreak occurs anywhere outside a triple-quoted literal',
-      shouldNotTokenize(streamOf('abc\n', null), 'Unexpected "abc" on line 1.'));
+    it(
+      'should immediately signal an error if a linebreak occurs anywhere outside a triple-quoted literal',
+      shouldNotTokenize(streamOf('abc\n', null), 'Unexpected "abc" on line 1.')
+    );
 
-    it('should immediately signal an error if a linebreak occurs inside a single-quoted literal',
-      shouldNotTokenize(streamOf('"abc\n', null), 'Unexpected ""abc" on line 1.'));
+    it(
+      'should immediately signal an error if a linebreak occurs inside a single-quoted literal',
+      shouldNotTokenize(streamOf('"abc\n', null), 'Unexpected ""abc" on line 1.')
+    );
 
-    it('should immediately signal an error if a carriage return occurs anywhere outside a triple-quoted literal',
-      shouldNotTokenize(streamOf('abc\r', null), 'Unexpected "abc" on line 1.'));
+    it(
+      'should immediately signal an error if a carriage return occurs anywhere outside a triple-quoted literal',
+      shouldNotTokenize(streamOf('abc\r', null), 'Unexpected "abc" on line 1.')
+    );
 
-    it('should immediately signal an error if a carriage return occurs inside a single-quoted literal',
-      shouldNotTokenize(streamOf('"abc\r', null), 'Unexpected ""abc" on line 1.'));
+    it(
+      'should immediately signal an error if a carriage return occurs inside a single-quoted literal',
+      shouldNotTokenize(streamOf('"abc\r', null), 'Unexpected ""abc" on line 1.')
+    );
 
-    it('should tokenize a split single-quoted string',
+    it(
+      'should tokenize a split single-quoted string',
       shouldTokenize(streamOf("'abc", "def' "),
                      { type: 'literal', value: 'abcdef', line: 1 },
-                     { type: 'eof', line: 1 }));
+                     { type: 'eof', line: 1 })
+    );
 
-    it('should tokenize a split single-quoted string followed by a triple-quoted string',
+    it(
+      'should tokenize a split single-quoted string followed by a triple-quoted string',
       // Checks whether _literalClosingPos is properly reset
       shouldTokenize(streamOf("'abcdef", "' '''a'''"),
                      { type: 'literal', value: 'abcdef', line: 1 },
                      { type: 'literal', value: 'a', line: 1 },
-                     { type: 'eof', line: 1 }));
+                     { type: 'eof', line: 1 })
+    );
 
-    it('should tokenize split triple-quoted strings',
+    it(
+      'should tokenize split triple-quoted strings',
       shouldTokenize(streamOf('"', '""abc""" ',
                               '""', '"def""" ',
                               '"""', 'ghi""" ',
@@ -541,22 +678,28 @@ describe('Lexer', () => {
                      { type: 'literal', value: 'jkl', line: 1 },
                      { type: 'literal', value: 'mno', line: 1 },
                      { type: 'literal', value: 'pqr', line: 1 },
-                     { type: 'eof', line: 1 }));
+                     { type: 'eof', line: 1 })
+    );
 
-    it('should tokenize a triple-quoted string split after a newline',
+    it(
+      'should tokenize a triple-quoted string split after a newline',
       shouldTokenize(streamOf('"""abc\n', 'def"""'),
                      { type: 'literal', value: 'abc\ndef', line: 1 },
-                     { type: 'eof', line: 2 }));
+                     { type: 'eof', line: 2 })
+    );
 
-    it('should tokenize @ keywords',
+    it(
+      'should tokenize @ keywords',
       shouldTokenize('@prefix @base @forSome @forAll ',
                      { type: '@prefix',  line: 1 },
                      { type: '@base',    line: 1 },
                      { type: '@forSome', line: 1 },
                      { type: '@forAll',  line: 1 },
-                     { type: 'eof',      line: 1 }));
+                     { type: 'eof',      line: 1 })
+    );
 
-    it('should tokenize @prefix declarations',
+    it(
+      'should tokenize @prefix declarations',
       shouldTokenize('@prefix : <http://iri.org/#>.\n@prefix abc:<http://iri.org/#>.\n@prefix:<http://example/c/>.',
                      { type: '@prefix', line: 1 },
                      { type: 'prefix', value: '', line: 1 },
@@ -570,13 +713,17 @@ describe('Lexer', () => {
                      { type: 'prefix', value: '', line: 3 },
                      { type: 'IRI', value: 'http://example/c/', line: 3 },
                      { type: '.', line: 3 },
-                     { type: 'eof', line: 3 }));
+                     { type: 'eof', line: 3 })
+    );
 
-    it('should not tokenize prefixes that end with a dot',
+    it(
+      'should not tokenize prefixes that end with a dot',
       shouldNotTokenize('@prefix abc.: <def>.',
-                        'Unexpected "abc.:" on line 1.'));
+                        'Unexpected "abc.:" on line 1.')
+    );
 
-    it('should tokenize @base declarations',
+    it(
+      'should tokenize @base declarations',
       shouldTokenize('@base <http://iri.org/#>.\n@base <http://iri.org/#>.',
                      { type: '@base', line: 1 },
                      { type: 'IRI', value: 'http://iri.org/#', line: 1 },
@@ -584,9 +731,11 @@ describe('Lexer', () => {
                      { type: '@base', line: 2 },
                      { type: 'IRI', value: 'http://iri.org/#', line: 2 },
                      { type: '.', line: 2 },
-                     { type: 'eof', line: 2 }));
+                     { type: 'eof', line: 2 })
+    );
 
-    it('should tokenize PREFIX declarations',
+    it(
+      'should tokenize PREFIX declarations',
       shouldTokenize('PREFIX : <http://iri.org/#>\npreFiX abc: <http://iri.org/#>',
                      { type: 'PREFIX', line: 1 },
                      { type: 'prefix', value: '', line: 1 },
@@ -594,17 +743,21 @@ describe('Lexer', () => {
                      { type: 'PREFIX', line: 2 },
                      { type: 'prefix', value: 'abc', line: 2 },
                      { type: 'IRI', value: 'http://iri.org/#', line: 2 },
-                     { type: 'eof', line: 2 }));
+                     { type: 'eof', line: 2 })
+    );
 
-    it('should tokenize BASE declarations',
+    it(
+      'should tokenize BASE declarations',
       shouldTokenize('BASE <http://iri.org/#>\nbAsE <http://iri.org/#>',
                      { type: 'BASE', line: 1 },
                      { type: 'IRI', value: 'http://iri.org/#', line: 1 },
                      { type: 'BASE', line: 2 },
                      { type: 'IRI', value: 'http://iri.org/#', line: 2 },
-                     { type: 'eof', line: 2 }));
+                     { type: 'eof', line: 2 })
+    );
 
-    it('should tokenize blank nodes',
+    it(
+      'should tokenize blank nodes',
       shouldTokenize('[] [<a> <b>] [a:b "c"^^d:e][a:b[]] _:a:b.',
                      { type: '[', line: 1 },
                      { type: ']', line: 1 },
@@ -625,26 +778,26 @@ describe('Lexer', () => {
                      { type: 'blank', prefix: '_', value: 'a', line: 1 },
                      { type: 'prefixed', prefix: '',  value: 'b', line: 1 },
                      { type: '.', line: 1 },
-                     { type: 'eof', line: 1 }));
+                     { type: 'eof', line: 1 })
+    );
 
-    it('should not tokenize invalid blank nodes',
-      shouldNotTokenize('_::',
-                        'Unexpected "_::" on line 1.'));
+    it('should not tokenize invalid blank nodes', shouldNotTokenize('_::',
+                      'Unexpected "_::" on line 1.'));
 
-    it('should tokenize lists',
-      shouldTokenize('() (<a>) (<a> <b>)',
-                     { type: '(', line: 1 },
-                     { type: ')', line: 1 },
-                     { type: '(', line: 1 },
-                     { type: 'IRI', value: 'a', line: 1 },
-                     { type: ')', line: 1 },
-                     { type: '(', line: 1 },
-                     { type: 'IRI', value: 'a', line: 1 },
-                     { type: 'IRI', value: 'b', line: 1 },
-                     { type: ')', line: 1 },
-                     { type: 'eof', line: 1 }));
+    it('should tokenize lists', shouldTokenize('() (<a>) (<a> <b>)',
+                   { type: '(', line: 1 },
+                   { type: ')', line: 1 },
+                   { type: '(', line: 1 },
+                   { type: 'IRI', value: 'a', line: 1 },
+                   { type: ')', line: 1 },
+                   { type: '(', line: 1 },
+                   { type: 'IRI', value: 'a', line: 1 },
+                   { type: 'IRI', value: 'b', line: 1 },
+                   { type: ')', line: 1 },
+                   { type: 'eof', line: 1 }));
 
-    it('should tokenize mixed lists',
+    it(
+      'should tokenize mixed lists',
       shouldTokenize('<a> <b> (1 "2" :o)(1()(1))',
                      { type: 'IRI', value: 'a', line: 1 },
                      { type: 'IRI', value: 'b', line: 1 },
@@ -661,17 +814,18 @@ describe('Lexer', () => {
                      { type: 'literal', value: '1', prefix: 'http://www.w3.org/2001/XMLSchema#integer', line: 1 },
                      { type: ')', line: 1 },
                      { type: ')', line: 1 },
-                     { type: 'eof', line: 1 }));
+                     { type: 'eof', line: 1 })
+    );
 
-    it('should tokenize the "a" predicate',
-      shouldTokenize('<x> a <y>.',
-                     { type: 'IRI', value: 'x', line: 1 },
-                     { type: 'abbreviation', value: 'a', line: 1 },
-                     { type: 'IRI', value: 'y', line: 1 },
-                     { type: '.', line: 1 },
-                     { type: 'eof', line: 1 }));
+    it('should tokenize the "a" predicate', shouldTokenize('<x> a <y>.',
+                   { type: 'IRI', value: 'x', line: 1 },
+                   { type: 'abbreviation', value: 'a', line: 1 },
+                   { type: 'IRI', value: 'y', line: 1 },
+                   { type: '.', line: 1 },
+                   { type: 'eof', line: 1 }));
 
-    it('should tokenize the "a" predicate without spacing',
+    it(
+      'should tokenize the "a" predicate without spacing',
       shouldTokenize('[a<>].\n[a[]].\n[a()].\n<>a<>.\n<>a[].\n<>a().\n',
                      { type: '[', line: 1 },
                      { type: 'abbreviation', value: 'a', line: 1 },
@@ -704,31 +858,36 @@ describe('Lexer', () => {
                      { type: '(', line: 6 },
                      { type: ')', line: 6 },
                      { type: '.', line: 6 },
-                     { type: 'eof', line: 7 }));
+                     { type: 'eof', line: 7 })
+    );
 
-    it('should tokenize an empty default graph',
-      shouldTokenize('{}',
-                     { type: '{', line: 1 },
-                     { type: '}', line: 1 },
-                     { type: 'eof', line: 1 }));
+    it('should tokenize an empty default graph', shouldTokenize('{}',
+                   { type: '{', line: 1 },
+                   { type: '}', line: 1 },
+                   { type: 'eof', line: 1 }));
 
-    it('should tokenize a non-empty default graph',
+    it(
+      'should tokenize a non-empty default graph',
       shouldTokenize('{<a> <b> c:d}',
                      { type: '{', line: 1 },
                      { type: 'IRI', value: 'a', line: 1 },
                      { type: 'IRI', value: 'b', line: 1 },
                      { type: 'prefixed', prefix: 'c', value: 'd', line: 1 },
                      { type: '}', line: 1 },
-                     { type: 'eof', line: 1 }));
+                     { type: 'eof', line: 1 })
+    );
 
-    it('should tokenize an empty graph identified by an IRI',
+    it(
+      'should tokenize an empty graph identified by an IRI',
       shouldTokenize('<g>{}',
                      { type: 'IRI', value: 'g', line: 1 },
                      { type: '{', line: 1 },
                      { type: '}', line: 1 },
-                     { type: 'eof', line: 1 }));
+                     { type: 'eof', line: 1 })
+    );
 
-    it('should tokenize a non-empty graph identified by an IRI',
+    it(
+      'should tokenize a non-empty graph identified by an IRI',
       shouldTokenize('<g> {<a> <b> c:d}',
                      { type: 'IRI', value: 'g', line: 1 },
                      { type: '{', line: 1 },
@@ -736,16 +895,20 @@ describe('Lexer', () => {
                      { type: 'IRI', value: 'b', line: 1 },
                      { type: 'prefixed', prefix: 'c', value: 'd', line: 1 },
                      { type: '}', line: 1 },
-                     { type: 'eof', line: 1 }));
+                     { type: 'eof', line: 1 })
+    );
 
-    it('should tokenize an empty graph identified by a blank node',
+    it(
+      'should tokenize an empty graph identified by a blank node',
       shouldTokenize('_:g{}',
                      { type: 'blank', prefix: '_', value: 'g', line: 1 },
                      { type: '{', line: 1 },
                      { type: '}', line: 1 },
-                     { type: 'eof', line: 1 }));
+                     { type: 'eof', line: 1 })
+    );
 
-    it('should tokenize a non-empty graph identified by a blank node',
+    it(
+      'should tokenize a non-empty graph identified by a blank node',
       shouldTokenize('_:g {<a> <b> c:d}',
                      { type: 'blank', prefix: '_', value: 'g', line: 1 },
                      { type: '{', line: 1 },
@@ -753,17 +916,21 @@ describe('Lexer', () => {
                      { type: 'IRI', value: 'b', line: 1 },
                      { type: 'prefixed', prefix: 'c', value: 'd', line: 1 },
                      { type: '}', line: 1 },
-                     { type: 'eof', line: 1 }));
+                     { type: 'eof', line: 1 })
+    );
 
-    it('should tokenize an empty graph with the GRAPH keyword',
+    it(
+      'should tokenize an empty graph with the GRAPH keyword',
       shouldTokenize('GRAPH<g>{}',
                      { type: 'GRAPH', line: 1 },
                      { type: 'IRI', value: 'g', line: 1 },
                      { type: '{', line: 1 },
                      { type: '}', line: 1 },
-                     { type: 'eof', line: 1 }));
+                     { type: 'eof', line: 1 })
+    );
 
-    it('should tokenize a non-empty graph with the GRAPH keyword',
+    it(
+      'should tokenize a non-empty graph with the GRAPH keyword',
       shouldTokenize('graph <g> {<a> <b> c:d}',
                      { type: 'GRAPH', line: 1 },
                      { type: 'IRI', value: 'g', line: 1 },
@@ -772,48 +939,50 @@ describe('Lexer', () => {
                      { type: 'IRI', value: 'b', line: 1 },
                      { type: 'prefixed', prefix: 'c', value: 'd', line: 1 },
                      { type: '}', line: 1 },
-                     { type: 'eof', line: 1 }));
+                     { type: 'eof', line: 1 })
+    );
 
-    it('should tokenize variables',
-      shouldTokenize('?a ?abc ?a_B_c.',
-                     { type: 'var', value: '?a',     line: 1 },
-                     { type: 'var', value: '?abc',   line: 1 },
-                     { type: 'var', value: '?a_B_c', line: 1 },
-                     { type: '.',   value: '',       line: 1 },
-                     { type: 'eof', line: 1 }));
+    it('should tokenize variables', shouldTokenize('?a ?abc ?a_B_c.',
+                   { type: 'var', value: '?a',     line: 1 },
+                   { type: 'var', value: '?abc',   line: 1 },
+                   { type: 'var', value: '?a_B_c', line: 1 },
+                   { type: '.',   value: '',       line: 1 },
+                   { type: 'eof', line: 1 }));
 
-    it('should not tokenize invalid variables',
-      shouldNotTokenize('?0a ', 'Unexpected "?0a" on line 1.'));
+    it(
+      'should not tokenize invalid variables',
+      shouldNotTokenize('?0a ', 'Unexpected "?0a" on line 1.')
+    );
 
-    it('should tokenize the equality sign',
-      shouldTokenize('<a> = <b> ',
-                     { type: 'IRI', value: 'a', line: 1 },
-                     { type: 'abbreviation', value: '=', line: 1 },
-                     { type: 'IRI', value: 'b', line: 1 },
-                     { type: 'eof', line: 1 }));
+    it('should tokenize the equality sign', shouldTokenize('<a> = <b> ',
+                   { type: 'IRI', value: 'a', line: 1 },
+                   { type: 'abbreviation', value: '=', line: 1 },
+                   { type: 'IRI', value: 'b', line: 1 },
+                   { type: 'eof', line: 1 }));
 
-    it('should tokenize the right implication',
-      shouldTokenize('<a> => <b> ',
-                     { type: 'IRI', value: 'a', line: 1 },
-                     { type: 'abbreviation', value: '>', line: 1 },
-                     { type: 'IRI', value: 'b', line: 1 },
-                     { type: 'eof', line: 1 }));
+    it('should tokenize the right implication', shouldTokenize('<a> => <b> ',
+                   { type: 'IRI', value: 'a', line: 1 },
+                   { type: 'abbreviation', value: '>', line: 1 },
+                   { type: 'IRI', value: 'b', line: 1 },
+                   { type: 'eof', line: 1 }));
 
-    it('should tokenize the left implication',
-      shouldTokenize('<a> <= <b> ',
-                     { type: 'IRI', value: 'a', line: 1 },
-                     { type: 'inverse', value: '>', line: 1 },
-                     { type: 'IRI', value: 'b', line: 1 },
-                     { type: 'eof', line: 1 }));
+    it('should tokenize the left implication', shouldTokenize('<a> <= <b> ',
+                   { type: 'IRI', value: 'a', line: 1 },
+                   { type: 'inverse', value: '>', line: 1 },
+                   { type: 'IRI', value: 'b', line: 1 },
+                   { type: 'eof', line: 1 }));
 
-    it('should tokenize a split left implication',
+    it(
+      'should tokenize a split left implication',
       shouldTokenize(streamOf('<a> <', '= <b> '),
         { type: 'IRI', value: 'a', line: 1 },
         { type: 'inverse', value: '>', line: 1 },
         { type: 'IRI', value: 'b', line: 1 },
-        { type: 'eof', line: 1 }));
+        { type: 'eof', line: 1 })
+    );
 
-    it('should tokenize paths',
+    it(
+      'should tokenize paths',
       shouldTokenize(':joe!fam:mother!loc:office!loc:zip :joe!fam:mother^fam:mother',
                      { type: 'prefixed', prefix: '', value: 'joe', line: 1 },
                      { type: '!', line: 1 },
@@ -828,34 +997,37 @@ describe('Lexer', () => {
                      { type: 'prefixed', prefix: 'fam', value: 'mother', line: 1 },
                      { type: '^', line: 1 },
                      { type: 'prefixed', prefix: 'fam', value: 'mother', line: 1 },
-                     { type: 'eof', line: 1 }));
+                     { type: 'eof', line: 1 })
+    );
 
-    it('should not tokenize an invalid document',
-      shouldNotTokenize(' \n @!', 'Unexpected "@!" on line 2.'));
+    it(
+      'should not tokenize an invalid document',
+      shouldNotTokenize(' \n @!', 'Unexpected "@!" on line 2.')
+    );
 
     it('does not call setEncoding if not available', () => {
       new Lexer().tokenize({ on: function () {} });
     });
 
-    it('should tokenize an Quadterm start',
-      shouldTokenize('<<',
-        { type: '<<', line: 1 }, { type: 'eof', line: 1 }));
+    it('should tokenize an Quadterm start', shouldTokenize('<<',
+      { type: '<<', line: 1 }, { type: 'eof', line: 1 }));
 
-    it('should tokenize a split Quadterm start',
+    it(
+      'should tokenize a split Quadterm start',
       shouldTokenize(streamOf('<', '<'),
-        { type: '<<', line: 1 }, { type: 'eof', line: 1 }));
+        { type: '<<', line: 1 }, { type: 'eof', line: 1 })
+    );
 
-    it('should tokenize an Quadterm end',
-      shouldTokenize('>>',
-        { type: '>>', line: 1 }, { type: 'eof', line: 1 }));
+    it('should tokenize an Quadterm end', shouldTokenize('>>',
+      { type: '>>', line: 1 }, { type: 'eof', line: 1 }));
 
-    it('should tokenize an empty Quadterm',
-      shouldTokenize('<< >>',
-        { type: '<<', line: 1 },
-        { type: '>>', line: 1 },
-        { type: 'eof', line: 1 }));
+    it('should tokenize an empty Quadterm', shouldTokenize('<< >>',
+      { type: '<<', line: 1 },
+      { type: '>>', line: 1 },
+      { type: 'eof', line: 1 }));
 
-    it('should tokenize an RDF* statement with IRIs',
+    it(
+      'should tokenize an RDF* statement with IRIs',
       shouldTokenize('<<<http://ex.org/?bla#foo> \n\t<http://ex.org/?bla#bar> \n\t<http://ex.org/?bla#boo>>> .',
         { type: '<<', line: 1 },
         { type: 'IRI', value: 'http://ex.org/?bla#foo', line: 1 },
@@ -863,13 +1035,17 @@ describe('Lexer', () => {
         { type: 'IRI', value: 'http://ex.org/?bla#boo', line: 3 },
         { type: '>>', line: 3 },
         { type: '.', line: 3 },
-        { type: 'eof', line: 3 }));
+        { type: 'eof', line: 3 })
+    );
 
-    it('should not tokenize a wrongly closed RDF* statement with IRIs',
+    it(
+      'should not tokenize a wrongly closed RDF* statement with IRIs',
       shouldNotTokenize('<<<http://ex.org/?bla#foo> \n\t<http://ex.org/?bla#bar> \n\t<http://ex.org/?bla#boo>> .',
-        'Unexpected ">" on line 3.'));
+        'Unexpected ">" on line 3.')
+    );
 
-    it('should tokenize a split RDF* statement with IRIs',
+    it(
+      'should tokenize a split RDF* statement with IRIs',
       shouldTokenize(streamOf('<', '<<http://ex.org/?bla#foo> \n\t<http://ex.org/?bla#bar> \n\t<http://ex.org/?bla#boo>>> .'),
         { type: '<<', line: 1 },
         { type: 'IRI', value: 'http://ex.org/?bla#foo', line: 1 },
@@ -877,9 +1053,11 @@ describe('Lexer', () => {
         { type: 'IRI', value: 'http://ex.org/?bla#boo', line: 3 },
         { type: '>>', line: 3 },
         { type: '.', line: 3 },
-        { type: 'eof', line: 3 }));
+        { type: 'eof', line: 3 })
+    );
 
-    it('should tokenize an RDF* statement with string literals',
+    it(
+      'should tokenize an RDF* statement with string literals',
       shouldTokenize('<<"string"@en "string"@nl-be "string"@EN>> .',
         { type: '<<', line: 1 },
         { type: 'literal', value: 'string', line: 1 },
@@ -890,9 +1068,11 @@ describe('Lexer', () => {
         { type: 'langcode', value: 'EN', line: 1 },
         { type: '>>', line: 1 },
         { type: '.', line: 1 },
-        { type: 'eof', line: 1 }));
+        { type: 'eof', line: 1 })
+    );
 
-    it('should tokenize an RDF* statement with integers',
+    it(
+      'should tokenize an RDF* statement with integers',
       shouldTokenize('<<1 2 3>>.',
         { type: '<<', line: 1 },
         { type: 'literal', value: '1', prefix: 'http://www.w3.org/2001/XMLSchema#integer', line: 1 },
@@ -900,9 +1080,11 @@ describe('Lexer', () => {
         { type: 'literal', value: '3', prefix: 'http://www.w3.org/2001/XMLSchema#integer', line: 1 },
         { type: '>>', line: 1 },
         { type: '.', line: 1 },
-        { type: 'eof', line: 1 }));
+        { type: 'eof', line: 1 })
+    );
 
-    it('should tokenize an RDF* statement with decimals',
+    it(
+      'should tokenize an RDF* statement with decimals',
       shouldTokenize('<<1.2 3.4 5.6>>.',
         { type: '<<', line: 1 },
         { type: 'literal', value: '1.2', prefix: 'http://www.w3.org/2001/XMLSchema#decimal', line: 1 },
@@ -910,9 +1092,11 @@ describe('Lexer', () => {
         { type: 'literal', value: '5.6', prefix: 'http://www.w3.org/2001/XMLSchema#decimal', line: 1 },
         { type: '>>', line: 1 },
         { type: '.', line: 1 },
-        { type: 'eof', line: 1 }));
+        { type: 'eof', line: 1 })
+    );
 
-    it('should tokenize an RDF* statement with booleans',
+    it(
+      'should tokenize an RDF* statement with booleans',
       shouldTokenize('<<true false true>>.',
         { type: '<<', line: 1 },
         { type: 'literal', value: 'true',  prefix: 'http://www.w3.org/2001/XMLSchema#boolean', line: 1 },
@@ -920,16 +1104,20 @@ describe('Lexer', () => {
         { type: 'literal', value: 'true',  prefix: 'http://www.w3.org/2001/XMLSchema#boolean', line: 1 },
         { type: '>>', line: 1 },
         { type: '.', line: 1 },
-        { type: 'eof', line: 1 }));
+        { type: 'eof', line: 1 })
+    );
 
-    it('should tokenize a prefixed iri followed by the end of a QuadTerm',
+    it(
+      'should tokenize a prefixed iri followed by the end of a QuadTerm',
       shouldTokenize('c:c>> .',
         { type: 'prefixed', prefix: 'c', value: 'c', line: 1 },
         { type: '>>', line: 1 },
         { type: '.', line: 1 },
-        { type: 'eof', line: 1 }));
+        { type: 'eof', line: 1 })
+    );
 
-    it('should tokenize an RDF* statement with prefixed names',
+    it(
+      'should tokenize an RDF* statement with prefixed names',
       shouldTokenize('<<a:a b:b c:c>> .',
         { type: '<<', line: 1 },
         { type: 'prefixed', prefix: 'a', value: 'a', line: 1 },
@@ -937,9 +1125,11 @@ describe('Lexer', () => {
         { type: 'prefixed', prefix: 'c', value: 'c', line: 1 },
         { type: '>>', line: 1 },
         { type: '.', line: 1 },
-        { type: 'eof', line: 1 }));
+        { type: 'eof', line: 1 })
+    );
 
-    it('should tokenize an RDF* statement with blank nodes',
+    it(
+      'should tokenize an RDF* statement with blank nodes',
       shouldTokenize('<<_:a _:b _:c>> .',
         { type: '<<', line: 1 },
         { type: 'blank', prefix: '_', value: 'a', line: 1 },
@@ -947,9 +1137,11 @@ describe('Lexer', () => {
         { type: 'blank', prefix: '_', value: 'c', line: 1 },
         { type: '>>', line: 1 },
         { type: '.', line: 1 },
-        { type: 'eof', line: 1 }));
+        { type: 'eof', line: 1 })
+    );
 
-    it('should tokenize an RDF* statement with variables',
+    it(
+      'should tokenize an RDF* statement with variables',
       shouldTokenize('<<?a ?b ?c>> .',
         { type: '<<', line: 1 },
         { type: 'var', value: '?a', line: 1 },
@@ -957,9 +1149,11 @@ describe('Lexer', () => {
         { type: 'var', value: '?c', line: 1 },
         { type: '>>', line: 1 },
         { type: '.', line: 1 },
-        { type: 'eof', line: 1 }));
+        { type: 'eof', line: 1 })
+    );
 
-    it('should tokenize an RDF* statement with mixed types',
+    it(
+      'should tokenize an RDF* statement with mixed types',
       shouldTokenize('<<<http://ex.org/?bla#foo> "string"@nl-be c:c>> .',
         { type: '<<', line: 1 },
         { type: 'IRI', value: 'http://ex.org/?bla#foo', line: 1 },
@@ -968,9 +1162,11 @@ describe('Lexer', () => {
         { type: 'prefixed', prefix: 'c', value: 'c', line: 1 },
         { type: '>>', line: 1 },
         { type: '.', line: 1 },
-        { type: 'eof', line: 1 }));
+        { type: 'eof', line: 1 })
+    );
 
-    it('should tokenize an RDF* statement with mixed types',
+    it(
+      'should tokenize an RDF* statement with mixed types',
       shouldTokenize('<<_:a a:a "string"@EN>> .',
         { type: '<<', line: 1 },
         { type: 'blank', prefix: '_', value: 'a', line: 1 },
@@ -979,9 +1175,11 @@ describe('Lexer', () => {
         { type: 'langcode', value: 'EN', line: 1 },
         { type: '>>', line: 1 },
         { type: '.', line: 1 },
-        { type: 'eof', line: 1 }));
+        { type: 'eof', line: 1 })
+    );
 
-    it('should tokenize an RDF* statement with mixed types',
+    it(
+      'should tokenize an RDF* statement with mixed types',
       shouldTokenize('<<"literal"@AU <http://ex.org/?bla#foo> _:a>> .',
         { type: '<<', line: 1 },
         { type: 'literal', value: 'literal', line: 1 },
@@ -990,9 +1188,11 @@ describe('Lexer', () => {
         { type: 'blank', prefix: '_', value: 'a', line: 1 },
         { type: '>>', line: 1 },
         { type: '.', line: 1 },
-        { type: 'eof', line: 1 }));
+        { type: 'eof', line: 1 })
+    );
 
-    it('should tokenize RDF* statements with shared subjects',
+    it(
+      'should tokenize RDF* statements with shared subjects',
       shouldTokenize('<<<a> <b> <c>;\n<d> <e>>>.',
         { type: '<<', line: 1 },
         { type: 'IRI', value: 'a', line: 1 },
@@ -1003,9 +1203,11 @@ describe('Lexer', () => {
         { type: 'IRI', value: 'e', line: 2 },
         { type: '>>', line: 2 },
         { type: '.', line: 2 },
-        { type: 'eof', line: 2 }));
+        { type: 'eof', line: 2 })
+    );
 
-    it('should tokenize RDF* statements with shared subjects and predicates',
+    it(
+      'should tokenize RDF* statements with shared subjects and predicates',
       shouldTokenize('<<<a> <b> <c>,\n<d>>>.',
         { type: '<<', line: 1 },
         { type: 'IRI', value: 'a', line: 1 },
@@ -1015,9 +1217,11 @@ describe('Lexer', () => {
         { type: 'IRI', value: 'd', line: 2 },
         { type: '>>', line: 2 },
         { type: '.', line: 2 },
-        { type: 'eof', line: 2 }));
+        { type: 'eof', line: 2 })
+    );
 
-    it('should tokenize an RDF* statement with shared subjects and predicates and prefixed names',
+    it(
+      'should tokenize an RDF* statement with shared subjects and predicates and prefixed names',
       shouldTokenize('<<a:a b:b c:c;d:d e:e,f:f>> .',
         { type: '<<', line: 1 },
         { type: 'prefixed', prefix: 'a', value: 'a', line: 1 },
@@ -1030,9 +1234,11 @@ describe('Lexer', () => {
         { type: 'prefixed', prefix: 'f', value: 'f', line: 1 },
         { type: '>>', line: 1 },
         { type: '.', line: 1 },
-        { type: 'eof', line: 1 }));
+        { type: 'eof', line: 1 })
+    );
 
-    it('should tokenize a QuadTerm followed by other tokens',
+    it(
+      'should tokenize a QuadTerm followed by other tokens',
       shouldTokenize('<<_:a <b> "lit"@EN>> _:a b:b.',
         { type: '<<', line: 1 },
         { type: 'blank', prefix: '_', value: 'a', line: 1 },
@@ -1043,9 +1249,11 @@ describe('Lexer', () => {
         { type: 'blank', prefix: '_', value: 'a', line: 1 },
         { type: 'prefixed', prefix: 'b', value: 'b', line: 1 },
         { type: '.', line: 1 },
-        { type: 'eof', line: 1 }));
+        { type: 'eof', line: 1 })
+    );
 
-    it('should tokenize a QuadTerm preceded by other tokens',
+    it(
+      'should tokenize a QuadTerm preceded by other tokens',
       shouldTokenize('"lit"@DE _:b <<_:a b:b "lit"@EN>>.',
         { type: 'literal', value: 'lit', line: 1 },
         { type: 'langcode', value: 'DE', line: 1 },
@@ -1057,9 +1265,11 @@ describe('Lexer', () => {
         { type: 'langcode', value: 'EN', line: 1 },
         { type: '>>', line: 1 },
         { type: '.', line: 1 },
-        { type: 'eof', line: 1 }));
+        { type: 'eof', line: 1 })
+    );
 
-    it('should tokenize a nested QuadTerm as subject in a statement',
+    it(
+      'should tokenize a nested QuadTerm as subject in a statement',
       shouldTokenize('<<<<_:b <b> "lit"@DE>> <a> "lit"@EN>>.',
         { type: '<<', line: 1 },
         { type: '<<', line: 1 },
@@ -1073,9 +1283,11 @@ describe('Lexer', () => {
         { type: 'langcode', value: 'EN', line: 1 },
         { type: '>>', line: 1 },
         { type: '.', line: 1 },
-        { type: 'eof', line: 1 }));
+        { type: 'eof', line: 1 })
+    );
 
-    it('should tokenize a nested QuadTerm as object in a statement',
+    it(
+      'should tokenize a nested QuadTerm as object in a statement',
       shouldTokenize('<<a:a _:a <<_:b <b> "lit"@DE>>>>.',
         { type: '<<', line: 1 },
         { type: 'prefixed', prefix: 'a', value: 'a', line: 1 },
@@ -1088,54 +1300,65 @@ describe('Lexer', () => {
         { type: '>>', line: 1 },
         { type: '>>', line: 1 },
         { type: '.', line: 1 },
+        { type: 'eof', line: 1 })
+    );
+
+    it('should tokenize a quoted triple annotation start', shouldTokenize('{|',
+        { type: '{|', line: 1 },
         { type: 'eof', line: 1 }));
 
-    it('should tokenize a quoted triple annotation start',
-        shouldTokenize('{|',
-            { type: '{|', line: 1 },
-            { type: 'eof', line: 1 }));
+    it(
+      'should tokenize a split quoted triple annotation start',
+      shouldTokenize(streamOf('{', '|'),
+          { type: '{|', line: 1 },
+          { type: 'eof', line: 1 })
+    );
 
-    it('should tokenize a split quoted triple annotation start',
-        shouldTokenize(streamOf('{', '|'),
-            { type: '{|', line: 1 },
-            { type: 'eof', line: 1 }));
+    it('should tokenize a quoted triple annotation end', shouldTokenize('|}',
+        { type: '|}', line: 1 },
+        { type: 'eof', line: 1 }));
 
-    it('should tokenize a quoted triple annotation end',
-        shouldTokenize('|}',
-            { type: '|}', line: 1 },
-            { type: 'eof', line: 1 }));
+    it(
+      'should tokenize a split quoted triple annotation end',
+      shouldTokenize(streamOf('|', '}'),
+          { type: '|}', line: 1 },
+          { type: 'eof', line: 1 })
+    );
 
-    it('should tokenize a split quoted triple annotation end',
-        shouldTokenize(streamOf('|', '}'),
-            { type: '|}', line: 1 },
-            { type: 'eof', line: 1 }));
+    it(
+      'should tokenize an empty quoted triple annotation',
+      shouldTokenize('{| |}',
+          { type: '{|', line: 1 },
+          { type: '|}', line: 1 },
+          { type: 'eof', line: 1 })
+    );
 
-    it('should tokenize an empty quoted triple annotation',
-        shouldTokenize('{| |}',
-            { type: '{|', line: 1 },
-            { type: '|}', line: 1 },
-            { type: 'eof', line: 1 }));
+    it(
+      'should tokenize a non-empty quoted triple annotation',
+      shouldTokenize('{| <http://ex.org/?bla#bar> \n\t<http://ex.org/?bla#boo> |}.',
+          { type: '{|', line: 1 },
+          { type: 'IRI', value: 'http://ex.org/?bla#bar', line: 1 },
+          { type: 'IRI', value: 'http://ex.org/?bla#boo', line: 2 },
+          { type: '|}', line: 2 },
+          { type: '.', line: 2 },
+          { type: 'eof', line: 2 })
+    );
 
-    it('should tokenize a non-empty quoted triple annotation',
-        shouldTokenize('{| <http://ex.org/?bla#bar> \n\t<http://ex.org/?bla#boo> |}.',
-            { type: '{|', line: 1 },
-            { type: 'IRI', value: 'http://ex.org/?bla#bar', line: 1 },
-            { type: 'IRI', value: 'http://ex.org/?bla#boo', line: 2 },
-            { type: '|}', line: 2 },
-            { type: '.', line: 2 },
-            { type: 'eof', line: 2 }));
+    it(
+      'should not tokenize an incomplete closing triple annotation',
+      shouldNotTokenize('{| |',
+          'Unexpected "|" on line 1.')
+    );
 
-    it('should not tokenize an incomplete closing triple annotation',
-        shouldNotTokenize('{| |',
-            'Unexpected "|" on line 1.'));
-
-    it('should not tokenize an invalid closing triple annotation',
-        shouldNotTokenize('{| ||',
-            'Unexpected "||" on line 1.'));
+    it(
+      'should not tokenize an invalid closing triple annotation',
+      shouldNotTokenize('{| ||',
+          'Unexpected "||" on line 1.')
+    );
 
     it('returns start and end index for every token', () => {
       const tokens = new Lexer().tokenize('<a:a> <b:c> "lit"@EN.');
-      tokens.should.deep.equal([
+      expect(tokens).toEqual([
         { line: 1, prefix: '', type: 'IRI', value: 'a:a', start: 0, end: 6 },
         { line: 1, prefix: '', type: 'IRI', value: 'b:c', start: 6, end: 12 },
         { line: 1, prefix: '', type: 'literal', value: 'lit', start: 12, end: 17 },
@@ -1147,7 +1370,7 @@ describe('Lexer', () => {
 
     it('returns start and end index relative to line', () => {
       const tokens = new Lexer().tokenize('<a:a> <b:c> "lit"@EN ; \n <b:d> <d:e> .');
-      tokens.should.deep.equal([
+      expect(tokens).toEqual([
         { line: 1, prefix: '', type: 'IRI', value: 'a:a', start: 0, end: 6 },
         { line: 1, prefix: '', type: 'IRI', value: 'b:c', start: 6, end: 12 },
         { line: 1, prefix: '', type: 'literal', value: 'lit', start: 12, end: 17 },
@@ -1162,7 +1385,7 @@ describe('Lexer', () => {
 
     it('returns index including whitespaces', () => {
       const tokens = new Lexer().tokenize('<a:a>   <b:c>    <d:e>  .');
-      tokens.should.deep.equal([
+      expect(tokens).toEqual([
         { line: 1, prefix: '', type: 'IRI', value: 'a:a', start: 0, end: 8 },
         { line: 1, prefix: '', type: 'IRI', value: 'b:c', start: 8, end: 17 },
         { line: 1, prefix: '', type: 'IRI', value: 'd:e', start: 17, end: 24 },
@@ -1173,7 +1396,7 @@ describe('Lexer', () => {
 
     it('returns index for comments and eof', () => {
       const tokens = new Lexer({ comments: true }).tokenize('# some\n<a:a> <b:b> <c:c> . # trailing comment\n# thing');
-      tokens.should.deep.equal([
+      expect(tokens).toEqual([
         { line: 1, prefix: '', type: 'comment', value: ' some', start: 0, end: 7 },
         { line: 2, prefix: '', type: 'IRI', value: 'a:a', start: 0, end: 6 },
         { line: 2, prefix: '', type: 'IRI', value: 'b:b', start: 6, end: 12 },
@@ -1188,7 +1411,7 @@ describe('Lexer', () => {
     describe('passing data after the stream has been finished', () => {
       const tokens = [];
       let error;
-      before(() => {
+      beforeAll(() => {
         const stream = new EventEmitter(), lexer = new Lexer();
         lexer.tokenize(stream, (err, token) => {
           if (err)
@@ -1203,18 +1426,18 @@ describe('Lexer', () => {
       });
 
       it('parses only the first chunk (plus EOF)', () => {
-        tokens.should.have.length(2);
+        expect(tokens).toHaveLength(2);
       });
 
       it('does not emit an error', () => {
-        expect(error).to.not.exist;
+        expect(error).toBeFalsy();
       });
     });
 
     describe('passing data after a syntax error', () => {
       const tokens = [];
       let error;
-      before(() => {
+      beforeAll(() => {
         const stream = new EventEmitter(), lexer = new Lexer();
         lexer.tokenize(stream, (err, token) => {
           if (err)
@@ -1230,19 +1453,19 @@ describe('Lexer', () => {
       });
 
       it('parses only the first chunk', () => {
-        tokens.should.have.length(1);
+        expect(tokens).toHaveLength(1);
       });
 
       it('emits the error', () => {
-        expect(error).to.exist;
-        expect(error).to.have.property('message', 'Unexpected "error" on line 1.');
+        expect(error).toBeDefined();
+        expect(error).toHaveProperty('message', 'Unexpected "error" on line 1.');
       });
     });
 
     describe('when the stream errors', () => {
       const tokens = [];
       let error;
-      before(() => {
+      beforeAll(() => {
         const stream = new EventEmitter(), lexer = new Lexer();
         lexer.tokenize(stream, (err, token) => {
           if (err)
@@ -1254,8 +1477,8 @@ describe('Lexer', () => {
       });
 
       it('passes the error', () => {
-        expect(error).to.exist;
-        expect(error).to.have.property('message', 'my error');
+        expect(error).toBeDefined();
+        expect(error).toHaveProperty('message', 'my error');
       });
     });
 
@@ -1264,7 +1487,7 @@ describe('Lexer', () => {
           tokens = lexer.tokenize('<a> <b> <c>.');
 
       it('returns all tokens synchronously', () => {
-        tokens.should.deep.equal([
+        expect(tokens).toEqual([
           { line: 1, type: 'IRI', value: 'a', prefix: '', start: 0,  end:  4 },
           { line: 1, type: 'IRI', value: 'b', prefix: '', start: 4,  end:  8 },
           { line: 1, type: 'IRI', value: 'c', prefix: '', start: 8,  end: 11 },
@@ -1278,8 +1501,7 @@ describe('Lexer', () => {
       const lexer = new Lexer();
 
       it('throws an error', () => {
-        (function () { lexer.tokenize('<a> bar'); })
-        .should.throw('Unexpected "bar" on line 1.');
+        expect((() => { lexer.tokenize('<a> bar'); })).toThrow('Unexpected "bar" on line 1.');
       });
     });
   });
@@ -1288,39 +1510,56 @@ describe('Lexer', () => {
 describe('A Lexer instance with the n3 option set to false', () => {
   function createLexer() { return new Lexer({ n3: false }); }
 
-  it('should not tokenize a variable',
-    shouldNotTokenize(createLexer(), '?a', 'Unexpected "?a" on line 1.'));
+  it(
+    'should not tokenize a variable',
+    shouldNotTokenize(createLexer(), '?a', 'Unexpected "?a" on line 1.')
+  );
 
-  it('should not tokenize a right implication',
-    shouldNotTokenize(createLexer(), '<a> => <c>.', 'Unexpected "=>" on line 1.'));
+  it(
+    'should not tokenize a right implication',
+    shouldNotTokenize(createLexer(), '<a> => <c>.', 'Unexpected "=>" on line 1.')
+  );
 
-  it('should not tokenize a left implication',
-    shouldNotTokenize(createLexer(), '<a> <= <c>.', 'Unexpected "<=" on line 1.'));
+  it(
+    'should not tokenize a left implication',
+    shouldNotTokenize(createLexer(), '<a> <= <c>.', 'Unexpected "<=" on line 1.')
+  );
 
-  it('should not tokenize an equality',
-    shouldNotTokenize(createLexer(), '<a> = <c>.', 'Unexpected "=" on line 1.'));
+  it(
+    'should not tokenize an equality',
+    shouldNotTokenize(createLexer(), '<a> = <c>.', 'Unexpected "=" on line 1.')
+  );
 
-  it('should not tokenize a ! path',
-    shouldNotTokenize(createLexer(), ':joe!fam:mother', 'Unexpected "!fam:mother" on line 1.'));
+  it(
+    'should not tokenize a ! path',
+    shouldNotTokenize(createLexer(), ':joe!fam:mother', 'Unexpected "!fam:mother" on line 1.')
+  );
 
-  it('should not tokenize a ^ path',
-    shouldNotTokenize(createLexer(), ':joe^fam:father', 'Unexpected "^fam:father" on line 1.'));
+  it(
+    'should not tokenize a ^ path',
+    shouldNotTokenize(createLexer(), ':joe^fam:father', 'Unexpected "^fam:father" on line 1.')
+  );
 });
 
 describe('A Lexer instance with the comment option set to true', () => {
   function createLexer() { return new Lexer({ comments: true }); }
 
-  it('should tokenize a single comment',
+  it(
+    'should tokenize a single comment',
     shouldTokenize(createLexer(), '#mycomment',
                    { type: 'comment', value: 'mycomment', line: 1 },
-                   { type: 'eof', line: 1 }));
+                   { type: 'eof', line: 1 })
+  );
 
-  it('should tokenize a stream with split comment',
+  it(
+    'should tokenize a stream with split comment',
     shouldTokenize(createLexer(), streamOf('#mycom', 'ment'),
                    { type: 'comment', value: 'mycomment', line: 1 },
-                   { type: 'eof', line: 1 }));
+                   { type: 'eof', line: 1 })
+  );
 
-  it('should tokenize comments',
+  it(
+    'should tokenize comments',
     shouldTokenize(createLexer(), '<#foo> #mycomment\n <#foo>  #mycomment \r# mycomment\n\n<#bla>#',
                    { type: 'IRI', value: '#foo', line: 1 },
                    { type: 'comment', value: 'mycomment', line: 1 },
@@ -1329,7 +1568,8 @@ describe('A Lexer instance with the comment option set to true', () => {
                    { type: 'comment', value: ' mycomment', line: 3 },
                    { type: 'IRI', value: '#bla', line: 5 },
                    { type: 'comment', value: '', line: 5 },
-                   { type: 'eof', line: 5 }));
+                   { type: 'eof', line: 5 })
+  );
 });
 
 function shouldTokenize(lexer, input) {
@@ -1347,8 +1587,8 @@ function shouldTokenize(lexer, input) {
     lexer.tokenize(input, tokenCallback);
 
     function tokenCallback(error, token) {
-      expect(error).not.to.exist;
-      expect(token).to.exist;
+      expect(error).toBeFalsy();
+      expect(token).toBeDefined();
       const expectedItem = expected[result.length];
       if (expectedItem)
         for (const attribute in token)
@@ -1357,7 +1597,7 @@ function shouldTokenize(lexer, input) {
             delete token[attribute];
       result.push(token);
       if (token.type === 'eof') {
-        result.should.eql(expected);
+        expect(result).toEqual(expected);
         done(null, result);
       }
     }
@@ -1373,9 +1613,9 @@ function shouldNotTokenize(lexer, input, expectedError) {
     lexer.tokenize(input, tokenCallback);
     function tokenCallback(error, token) {
       if (error) {
-        expect(token).not.to.exist;
-        error.should.be.an.instanceof(Error);
-        error.message.should.eql(expectedError);
+        expect(token).toBeFalsy();
+        expect(error).toBeInstanceOf(Error);
+        expect(error.message).toEqual(expectedError);
         done();
       }
       else if (token.type === 'eof')

--- a/test/N3Parser-test.js
+++ b/test/N3Parser-test.js
@@ -15,75 +15,89 @@ Parser.prototype._blankNode = name => new BlankNode(name || `b${blankId++}`);
 describe('Parser', () => {
   describe('The Parser export', () => {
     it('should be a function', () => {
-      Parser.should.be.a('function');
+      expect(Parser).toBeInstanceOf(Function);
     });
 
     it('should be a Parser constructor', () => {
-      new Parser().should.be.an.instanceof(Parser);
+      expect(new Parser()).toBeInstanceOf(Parser);
     });
   });
 
   describe('A Parser instance', () => {
-    it('should parse the empty string',
-      shouldParse(''
-                  /* no triples */));
+    it('should parse the empty string', shouldParse(''
+                /* no triples */));
 
-    it('should parse a whitespace string',
-      shouldParse(' \t \n  '
-                  /* no triples */));
+    it('should parse a whitespace string', shouldParse(' \t \n  '
+                /* no triples */));
 
-    it('should parse a single triple',
-      shouldParse('<a> <b> <c>.',
-                  ['a', 'b', 'c']));
+    it('should parse a single triple', shouldParse('<a> <b> <c>.',
+                ['a', 'b', 'c']));
 
-    it('should parse three triples',
+    it(
+      'should parse three triples',
       shouldParse('<a> <b> <c>.\n<d> <e> <f>.\n<g> <h> <i>.',
                   ['a', 'b', 'c'],
                   ['d', 'e', 'f'],
-                  ['g', 'h', 'i']));
+                  ['g', 'h', 'i'])
+    );
 
-    it('should parse a triple with a literal',
-      shouldParse('<a> <b> "string".',
-                  ['a', 'b', '"string"']));
+    it('should parse a triple with a literal', shouldParse('<a> <b> "string".',
+                ['a', 'b', '"string"']));
 
-    it('should parse a triple with a numeric literal',
+    it(
+      'should parse a triple with a numeric literal',
       shouldParse('<a> <b> 3.0.',
-                  ['a', 'b', '"3.0"^^http://www.w3.org/2001/XMLSchema#decimal']));
+                  ['a', 'b', '"3.0"^^http://www.w3.org/2001/XMLSchema#decimal'])
+    );
 
-    it('should parse a triple with an integer literal',
-      shouldParse('<a> <b> 3.',
-                  ['a', 'b', '"3"^^http://www.w3.org/2001/XMLSchema#integer']));
+    it('should parse a triple with an integer literal', shouldParse('<a> <b> 3.',
+                ['a', 'b', '"3"^^http://www.w3.org/2001/XMLSchema#integer']));
 
-    it('should parse a triple with a floating point literal',
+    it(
+      'should parse a triple with a floating point literal',
       shouldParse('<a> <b> 1.3e2.',
-                  ['a', 'b', '"1.3e2"^^http://www.w3.org/2001/XMLSchema#double']));
+                  ['a', 'b', '"1.3e2"^^http://www.w3.org/2001/XMLSchema#double'])
+    );
 
-    it('should parse a triple with a boolean literal',
+    it(
+      'should parse a triple with a boolean literal',
       shouldParse('<a> <b> true.',
-                  ['a', 'b', '"true"^^http://www.w3.org/2001/XMLSchema#boolean']));
+                  ['a', 'b', '"true"^^http://www.w3.org/2001/XMLSchema#boolean'])
+    );
 
-    it('should parse a triple with a literal and a language code',
+    it(
+      'should parse a triple with a literal and a language code',
       shouldParse('<a> <b> "string"@en.',
-                  ['a', 'b', '"string"@en']));
+                  ['a', 'b', '"string"@en'])
+    );
 
-    it('should normalize language codes to lowercase',
+    it(
+      'should normalize language codes to lowercase',
       shouldParse('<a> <b> "string"@EN.',
-                  ['a', 'b', '"string"@en']));
+                  ['a', 'b', '"string"@en'])
+    );
 
-    it('should parse a triple with a literal and an IRI type',
+    it(
+      'should parse a triple with a literal and an IRI type',
       shouldParse('<a> <b> "string"^^<type>.',
-                  ['a', 'b', '"string"^^http://example.org/type']));
+                  ['a', 'b', '"string"^^http://example.org/type'])
+    );
 
-    it('should parse a triple with a literal and a prefixed name type',
+    it(
+      'should parse a triple with a literal and a prefixed name type',
       shouldParse('@prefix x: <urn:x:y#>. <a> <b> "string"^^x:z.',
-                  ['a', 'b', '"string"^^urn:x:y#z']));
+                  ['a', 'b', '"string"^^urn:x:y#z'])
+    );
 
-    it('should differentiate between IRI and prefixed name types',
+    it(
+      'should differentiate between IRI and prefixed name types',
       shouldParse('@prefix : <noturn:>. :a :b "x"^^<urn:foo>. :a :b "x"^^:urn:foo.',
                   ['noturn:a', 'noturn:b', '"x"^^urn:foo'],
-                  ['noturn:a', 'noturn:b', '"x"^^noturn:urn:foo']));
+                  ['noturn:a', 'noturn:b', '"x"^^noturn:urn:foo'])
+    );
 
-    it('should not parse a triple with a literal and a prefixed name type with an inexistent prefix',
+    it(
+      'should not parse a triple with a literal and a prefixed name type with an inexistent prefix',
       shouldNotParse('<a> <b> "string"^^x:z.',
                      'Undefined prefix "x:" on line 1.', {
                        token: {
@@ -103,136 +117,174 @@ describe('Parser', () => {
                          start: 8,
                          end: 16,
                        },
-                     }));
+                     })
+    );
 
-    it('should parse a triple with the "a" shorthand predicate',
+    it(
+      'should parse a triple with the "a" shorthand predicate',
       shouldParse('<a> a <t>.',
-                  ['a', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 't']));
+                  ['a', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 't'])
+    );
 
-    it('should parse triples with prefixes',
-      shouldParse('@prefix : <#>.\n' +
-                  '@prefix a: <a#>.\n' +
-                  ':x a:a a:b.',
-                  ['#x', 'a#a', 'a#b']));
+    it('should parse triples with prefixes', shouldParse('@prefix : <#>.\n' +
+                '@prefix a: <a#>.\n' +
+                ':x a:a a:b.',
+                ['#x', 'a#a', 'a#b']));
 
-    it('should parse triples with the prefix "prefix"',
+    it(
+      'should parse triples with the prefix "prefix"',
       shouldParse('@prefix prefix: <http://prefix.cc/>.' +
                   'prefix:a prefix:b prefix:c.',
-                  ['http://prefix.cc/a', 'http://prefix.cc/b', 'http://prefix.cc/c']));
+                  ['http://prefix.cc/a', 'http://prefix.cc/b', 'http://prefix.cc/c'])
+    );
 
-    it('should parse triples with the prefix "base"',
+    it(
+      'should parse triples with the prefix "base"',
       shouldParse('PREFIX base: <http://prefix.cc/>' +
                   'base:a base:b base:c.',
-                  ['http://prefix.cc/a', 'http://prefix.cc/b', 'http://prefix.cc/c']));
+                  ['http://prefix.cc/a', 'http://prefix.cc/b', 'http://prefix.cc/c'])
+    );
 
-    it('should parse triples with the prefix "graph"',
+    it(
+      'should parse triples with the prefix "graph"',
       shouldParse('PREFIX graph: <http://prefix.cc/>' +
                   'graph:a graph:b graph:c.',
-                  ['http://prefix.cc/a', 'http://prefix.cc/b', 'http://prefix.cc/c']));
+                  ['http://prefix.cc/a', 'http://prefix.cc/b', 'http://prefix.cc/c'])
+    );
 
-    it('should not parse @PREFIX',
-      shouldNotParse('@PREFIX : <#>.',
-                     'Expected entity but got @PREFIX on line 1.', {
-                       token: {
-                         line: 1,
-                         type: '@PREFIX',
-                         value: '',
-                         prefix: '',
-                         start: 0,
-                         end: 7,
-                       },
-                       previousToken: undefined,
+    it('should not parse @PREFIX', shouldNotParse('@PREFIX : <#>.',
+                   'Expected entity but got @PREFIX on line 1.', {
+                     token: {
                        line: 1,
-                     }));
+                       type: '@PREFIX',
+                       value: '',
+                       prefix: '',
+                       start: 0,
+                       end: 7,
+                     },
+                     previousToken: undefined,
+                     line: 1,
+                   }));
 
-    it('should parse triples with prefixes and different punctuation',
+    it(
+      'should parse triples with prefixes and different punctuation',
       shouldParse('@prefix : <#>.\n' +
                   '@prefix a: <a#>.\n' +
                   ':x a:a a:b;a:c a:d,a:e.',
                   ['#x', 'a#a', 'a#b'],
                   ['#x', 'a#c', 'a#d'],
-                  ['#x', 'a#c', 'a#e']));
+                  ['#x', 'a#c', 'a#e'])
+    );
 
-    it('should not parse undefined empty prefix in subject',
+    it(
+      'should not parse undefined empty prefix in subject',
       shouldNotParse(':a ',
-                     'Undefined prefix ":" on line 1.'));
+                     'Undefined prefix ":" on line 1.')
+    );
 
-    it('should not parse undefined prefix in subject',
-      shouldNotParse('a:a ',
-                     'Undefined prefix "a:" on line 1.'));
+    it('should not parse undefined prefix in subject', shouldNotParse('a:a ',
+                   'Undefined prefix "a:" on line 1.'));
 
-    it('should not parse undefined prefix in predicate',
+    it(
+      'should not parse undefined prefix in predicate',
       shouldNotParse('<a> b:c ',
-                     'Undefined prefix "b:" on line 1.'));
+                     'Undefined prefix "b:" on line 1.')
+    );
 
-    it('should not parse undefined prefix in object',
+    it(
+      'should not parse undefined prefix in object',
       shouldNotParse('<a> <b> c:d ',
-                     'Undefined prefix "c:" on line 1.'));
+                     'Undefined prefix "c:" on line 1.')
+    );
 
-    it('should not parse undefined prefix in datatype',
+    it(
+      'should not parse undefined prefix in datatype',
       shouldNotParse('<a> <b> "c"^^d:e ',
-                     'Undefined prefix "d:" on line 1.'));
+                     'Undefined prefix "d:" on line 1.')
+    );
 
-    it('should parse triples with SPARQL prefixes',
+    it(
+      'should parse triples with SPARQL prefixes',
       shouldParse('PREFIX : <#>\n' +
                   'PrEfIX a: <a#> ' +
                   ':x a:a a:b.',
-                  ['#x', 'a#a', 'a#b']));
+                  ['#x', 'a#a', 'a#b'])
+    );
 
-    it('should not parse prefix declarations without prefix',
+    it(
+      'should not parse prefix declarations without prefix',
       shouldNotParse('@prefix <a> ',
-                     'Expected prefix to follow @prefix on line 1.'));
+                     'Expected prefix to follow @prefix on line 1.')
+    );
 
-    it('should not parse prefix declarations without IRI',
+    it(
+      'should not parse prefix declarations without IRI',
       shouldNotParse('@prefix : .',
-                     'Expected IRI to follow prefix ":" on line 1.'));
+                     'Expected IRI to follow prefix ":" on line 1.')
+    );
 
-    it('should not parse prefix declarations without a dot',
+    it(
+      'should not parse prefix declarations without a dot',
       shouldNotParse('@prefix : <a> ;',
-                     'Expected declaration to end with a dot on line 1.'));
+                     'Expected declaration to end with a dot on line 1.')
+    );
 
-    it('should parse statements with shared subjects',
+    it(
+      'should parse statements with shared subjects',
       shouldParse('<a> <b> <c>;\n<d> <e>.',
                   ['a', 'b', 'c'],
-                  ['a', 'd', 'e']));
+                  ['a', 'd', 'e'])
+    );
 
-    it('should parse statements with shared subjects and trailing semicolon',
+    it(
+      'should parse statements with shared subjects and trailing semicolon',
       shouldParse('<a> <b> <c>;\n<d> <e>;\n.',
                   ['a', 'b', 'c'],
-                  ['a', 'd', 'e']));
+                  ['a', 'd', 'e'])
+    );
 
-    it('should parse statements with shared subjects and multiple semicolons',
+    it(
+      'should parse statements with shared subjects and multiple semicolons',
       shouldParse('<a> <b> <c>;;\n<d> <e>.',
                   ['a', 'b', 'c'],
-                  ['a', 'd', 'e']));
+                  ['a', 'd', 'e'])
+    );
 
-    it('should parse statements with shared subjects and predicates',
+    it(
+      'should parse statements with shared subjects and predicates',
       shouldParse('<a> <b> <c>, <d>.',
                   ['a', 'b', 'c'],
-                  ['a', 'b', 'd']));
+                  ['a', 'b', 'd'])
+    );
 
-    it('should not accept ; without preceding predicate',
+    it(
+      'should not accept ; without preceding predicate',
       shouldNotParse('<a> <b> <c>. <x>; <y> <z>.',
-                     'Expected predicate but got ; on line 1.'));
+                     'Expected predicate but got ; on line 1.')
+    );
 
-    it('should not accept , without preceding object',
+    it(
+      'should not accept , without preceding object',
       shouldNotParse('<a> <b> <c>. <x> <y>, <z>.',
-                     'Expected entity but got , on line 1.'));
+                     'Expected entity but got , on line 1.')
+    );
 
-    it('should parse diamonds',
-      shouldParse('<> <> <> <>.\n(<>) <> (<>) <>.',
-                  [BASE_IRI, BASE_IRI, BASE_IRI, BASE_IRI],
-                  ['_:b0', BASE_IRI, '_:b1', BASE_IRI],
-                  ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', BASE_IRI],
-                  ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil'],
-                  ['_:b1', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', BASE_IRI],
-                  ['_:b1', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil']));
+    it('should parse diamonds', shouldParse('<> <> <> <>.\n(<>) <> (<>) <>.',
+                [BASE_IRI, BASE_IRI, BASE_IRI, BASE_IRI],
+                ['_:b0', BASE_IRI, '_:b1', BASE_IRI],
+                ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', BASE_IRI],
+                ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil'],
+                ['_:b1', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', BASE_IRI],
+                ['_:b1', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil']));
 
-    it('should parse statements with named blank nodes',
+    it(
+      'should parse statements with named blank nodes',
       shouldParse('_:a <b> _:c.',
-                  ['_:b0_a', 'b', '_:b0_c']));
+                  ['_:b0_a', 'b', '_:b0_c'])
+    );
 
-    it('should not parse statements with a blank node as predicate',
+    it(
+      'should not parse statements with a blank node as predicate',
       shouldNotParse('PREFIX : <#>\n<a> [] <c>.',
                      'Disallowed blank node as predicate on line 2.', {
                        token: {
@@ -252,9 +304,11 @@ describe('Parser', () => {
                          start: 0,
                          end: 4,
                        },
-                     }));
+                     })
+    );
 
-    it('should not parse statements with a blank node label as predicate',
+    it(
+      'should not parse statements with a blank node label as predicate',
       shouldNotParse('PREFIX : <#>\n<a> _:b <c>.',
                      'Disallowed blank node as predicate on line 2.', {
                        token: {
@@ -274,179 +328,239 @@ describe('Parser', () => {
                          start: 0,
                          end: 4,
                        },
-                     }));
+                     })
+    );
 
-    it('should parse statements with empty blank nodes',
+    it(
+      'should parse statements with empty blank nodes',
       shouldParse('[] <b> [].',
-                  ['_:b0', 'b', '_:b1']));
+                  ['_:b0', 'b', '_:b1'])
+    );
 
-    it('should parse statements with unnamed blank nodes in the subject',
+    it(
+      'should parse statements with unnamed blank nodes in the subject',
       shouldParse('[<a> <b>] <c> <d>.',
                   ['_:b0', 'c', 'd'],
-                  ['_:b0', 'a', 'b']));
+                  ['_:b0', 'a', 'b'])
+    );
 
-    it('should parse statements with unnamed blank nodes in the object',
+    it(
+      'should parse statements with unnamed blank nodes in the object',
       shouldParse('<a> <b> [<c> <d>].',
                   ['a', 'b', '_:b0'],
-                  ['_:b0', 'c', 'd']));
+                  ['_:b0', 'c', 'd'])
+    );
 
-    it('should parse statements with unnamed blank nodes with a string object',
+    it(
+      'should parse statements with unnamed blank nodes with a string object',
       shouldParse('<a> <b> [<c> "x"].',
                   ['a', 'b', '_:b0'],
-                  ['_:b0', 'c', '"x"']));
+                  ['_:b0', 'c', '"x"'])
+    );
 
-    it('should not parse a blank node with missing subject',
+    it(
+      'should not parse a blank node with missing subject',
       shouldNotParse('<a> <b> [<c>].',
-                     'Expected entity but got ] on line 1.'));
+                     'Expected entity but got ] on line 1.')
+    );
 
-    it('should not parse a blank node with only a semicolon',
+    it(
+      'should not parse a blank node with only a semicolon',
       shouldNotParse('<a> <b> [;].',
-                     'Expected predicate but got ; on line 1.'));
+                     'Expected predicate but got ; on line 1.')
+    );
 
-    it('should not parse a dangling blank node closing brace',
+    it(
+      'should not parse a dangling blank node closing brace',
       shouldNotParse('<a:a> <b:b> <c:c> ; ]',
-                     'Unexpected ] on line 1.'));
+                     'Unexpected ] on line 1.')
+    );
 
-    it('should parse a blank node with a trailing semicolon',
+    it(
+      'should parse a blank node with a trailing semicolon',
       shouldParse('<a> <b> [ <u> <v>; ].',
                   ['a', 'b', '_:b0'],
-                  ['_:b0', 'u', 'v']));
+                  ['_:b0', 'u', 'v'])
+    );
 
-    it('should parse a blank node with multiple trailing semicolons',
+    it(
+      'should parse a blank node with multiple trailing semicolons',
       shouldParse('<a> <b> [ <u> <v>;;; ].',
                   ['a', 'b', '_:b0'],
-                  ['_:b0', 'u', 'v']));
+                  ['_:b0', 'u', 'v'])
+    );
 
-    it('should parse a multi-predicate blank node',
+    it(
+      'should parse a multi-predicate blank node',
       shouldParse('<a> <b> [ <u> <v>; <w> <z> ].',
                   ['a', 'b', '_:b0'],
                   ['_:b0', 'u', 'v'],
-                  ['_:b0', 'w', 'z']));
+                  ['_:b0', 'w', 'z'])
+    );
 
-    it('should parse a multi-predicate blank node with multiple semicolons',
+    it(
+      'should parse a multi-predicate blank node with multiple semicolons',
       shouldParse('<a> <b> [ <u> <v>;;; <w> <z> ].',
                   ['a', 'b', '_:b0'],
                   ['_:b0', 'u', 'v'],
-                  ['_:b0', 'w', 'z']));
+                  ['_:b0', 'w', 'z'])
+    );
 
-    it('should parse a multi-object blank node',
+    it(
+      'should parse a multi-object blank node',
       shouldParse('<a> <b> [ <u> <v>, <z> ].',
                   ['a', 'b', '_:b0'],
                   ['_:b0', 'u', 'v'],
-                  ['_:b0', 'u', 'z']));
+                  ['_:b0', 'u', 'z'])
+    );
 
-    it('should parse a multi-statement blank node ending with a literal',
+    it(
+      'should parse a multi-statement blank node ending with a literal',
       shouldParse('<a> <b> [ <u> <v>; <w> "z" ].',
                   ['a', 'b', '_:b0'],
                   ['_:b0', 'u', 'v'],
-                  ['_:b0', 'w', '"z"']));
+                  ['_:b0', 'w', '"z"'])
+    );
 
-    it('should parse a multi-statement blank node ending with a typed literal',
+    it(
+      'should parse a multi-statement blank node ending with a typed literal',
       shouldParse('<a> <b> [ <u> <v>; <w> "z"^^<t> ].',
                   ['a', 'b', '_:b0'],
                   ['_:b0', 'u', 'v'],
-                  ['_:b0', 'w', '"z"^^http://example.org/t']));
+                  ['_:b0', 'w', '"z"^^http://example.org/t'])
+    );
 
-    it('should parse a multi-statement blank node ending with a string with language',
+    it(
+      'should parse a multi-statement blank node ending with a string with language',
       shouldParse('<a> <b> [ <u> <v>; <w> "z"^^<t> ].',
                   ['a', 'b', '_:b0'],
                   ['_:b0', 'u', 'v'],
-                  ['_:b0', 'w', '"z"^^http://example.org/t']));
+                  ['_:b0', 'w', '"z"^^http://example.org/t'])
+    );
 
-    it('should parse a multi-statement blank node with trailing semicolon',
+    it(
+      'should parse a multi-statement blank node with trailing semicolon',
       shouldParse('<a> <b> [ <u> <v>; <w> <z>; ].',
                   ['a', 'b', '_:b0'],
                   ['_:b0', 'u', 'v'],
-                  ['_:b0', 'w', 'z']));
+                  ['_:b0', 'w', 'z'])
+    );
 
-    it('should parse statements with nested blank nodes in the subject',
+    it(
+      'should parse statements with nested blank nodes in the subject',
       shouldParse('[<a> [<x> <y>]] <c> <d>.',
                   ['_:b0', 'c', 'd'],
                   ['_:b0', 'a', '_:b1'],
-                  ['_:b1', 'x', 'y']));
+                  ['_:b1', 'x', 'y'])
+    );
 
-    it('should parse statements with nested blank nodes in the object',
+    it(
+      'should parse statements with nested blank nodes in the object',
       shouldParse('<a> <b> [<c> [<d> <e>]].',
                   ['a', 'b', '_:b0'],
                   ['_:b0', 'c', '_:b1'],
-                  ['_:b1', 'd', 'e']));
+                  ['_:b1', 'd', 'e'])
+    );
 
-    it('should reuse identifiers of blank nodes within and outside of graphs',
+    it(
+      'should reuse identifiers of blank nodes within and outside of graphs',
       shouldParse('_:a <b> _:c. <g> { _:a <b> _:c }',
                   ['_:b0_a', 'b', '_:b0_c'],
-                  ['_:b0_a', 'b', '_:b0_c', 'g']));
+                  ['_:b0_a', 'b', '_:b0_c', 'g'])
+    );
 
-    it('should not parse an invalid blank node',
-      shouldNotParse('[ <a> <b> .',
-                     'Expected punctuation to follow "http://example.org/b" on line 1.'));
+    it('should not parse an invalid blank node', shouldNotParse('[ <a> <b> .',
+                   'Expected punctuation to follow "http://example.org/b" on line 1.'));
 
-    it('should parse a statements with only an anonymous node',
+    it(
+      'should parse a statements with only an anonymous node',
       shouldParse('[<p> <o>].',
-                  ['_:b0', 'p', 'o']));
+                  ['_:b0', 'p', 'o'])
+    );
 
-    it('should not parse a statement with only a blank anonymous node',
+    it(
+      'should not parse a statement with only a blank anonymous node',
       shouldNotParse('[].',
-                     'Unexpected . on line 1.'));
+                     'Unexpected . on line 1.')
+    );
 
-    it('should not parse an anonymous node with only an anonymous node inside',
+    it(
+      'should not parse an anonymous node with only an anonymous node inside',
       shouldNotParse('[[<p> <o>]].',
-                     'Disallowed blank node as predicate on line 1.'));
+                     'Disallowed blank node as predicate on line 1.')
+    );
 
-    it('should parse statements with an empty list in the subject',
+    it(
+      'should parse statements with an empty list in the subject',
       shouldParse('() <a> <b>.',
-                  ['http://www.w3.org/1999/02/22-rdf-syntax-ns#nil', 'a', 'b']));
+                  ['http://www.w3.org/1999/02/22-rdf-syntax-ns#nil', 'a', 'b'])
+    );
 
-    it('should parse statements with an empty list in the object',
+    it(
+      'should parse statements with an empty list in the object',
       shouldParse('<a> <b> ().',
-                  ['a', 'b', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil']));
+                  ['a', 'b', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil'])
+    );
 
-    it('should parse statements with a single-element list in the subject',
+    it(
+      'should parse statements with a single-element list in the subject',
       shouldParse('(<x>) <a> <b>.',
                   ['_:b0', 'a', 'b'],
                   ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', 'x'],
-                  ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil']));
+                  ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil'])
+    );
 
-    it('should parse statements with a single-element list in the object',
+    it(
+      'should parse statements with a single-element list in the object',
       shouldParse('<a> <b> (<x>).',
                   ['a', 'b', '_:b0'],
                   ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', 'x'],
-                  ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil']));
+                  ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil'])
+    );
 
-    it('should parse a list with a literal',
-      shouldParse('<a> <b> ("x").',
-                  ['a', 'b', '_:b0'],
-                  ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', '"x"'],
-                  ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil']));
+    it('should parse a list with a literal', shouldParse('<a> <b> ("x").',
+                ['a', 'b', '_:b0'],
+                ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', '"x"'],
+                ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil']));
 
-    it('should parse a list with a typed literal',
+    it(
+      'should parse a list with a typed literal',
       shouldParse('<a> <b> ("x"^^<y>).',
                   ['a', 'b', '_:b0'],
                   ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', '"x"^^http://example.org/y'],
-                  ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil']));
+                  ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil'])
+    );
 
-    it('should parse a list with a language-tagged literal',
+    it(
+      'should parse a list with a language-tagged literal',
       shouldParse('<a> <b> ("x"@en-GB).',
                   ['a', 'b', '_:b0'],
                   ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', '"x"@en-gb'],
-                  ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil']));
+                  ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil'])
+    );
 
-    it('should parse statements with a multi-element list in the subject',
+    it(
+      'should parse statements with a multi-element list in the subject',
       shouldParse('(<x> <y>) <a> <b>.',
                   ['_:b0', 'a', 'b'],
                   ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', 'x'],
                   ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', '_:b1'],
                   ['_:b1', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', 'y'],
-                  ['_:b1', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil']));
+                  ['_:b1', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil'])
+    );
 
-    it('should parse statements with a multi-element list in the object',
+    it(
+      'should parse statements with a multi-element list in the object',
       shouldParse('<a> <b> (<x> <y>).',
                   ['a', 'b', '_:b0'],
                   ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', 'x'],
                   ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', '_:b1'],
                   ['_:b1', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', 'y'],
-                  ['_:b1', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil']));
+                  ['_:b1', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil'])
+    );
 
-    it('should parse statements with a multi-element literal list in the object',
+    it(
+      'should parse statements with a multi-element literal list in the object',
       shouldParse('<a> <b> ("x" "y"@en-GB 1 "z"^^<t>).',
                   ['a', 'b', '_:b0'],
                   ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', '"x"'],
@@ -456,37 +570,47 @@ describe('Parser', () => {
                   ['_:b2', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', '"1"^^http://www.w3.org/2001/XMLSchema#integer'],
                   ['_:b2', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', '_:b3'],
                   ['_:b3', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', '"z"^^http://example.org/t'],
-                  ['_:b3', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil']));
+                  ['_:b3', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil'])
+    );
 
-    it('should parse statements with prefixed names in lists',
+    it(
+      'should parse statements with prefixed names in lists',
       shouldParse('@prefix a: <a#>. <a> <b> (a:x a:y).',
                   ['a', 'b', '_:b0'],
                   ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', 'a#x'],
                   ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', '_:b1'],
                   ['_:b1', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', 'a#y'],
-                  ['_:b1', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil']));
+                  ['_:b1', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil'])
+    );
 
-    it('should not parse statements with undefined prefixes in lists',
+    it(
+      'should not parse statements with undefined prefixes in lists',
       shouldNotParse('<a> <b> (a:x a:y).',
-                     'Undefined prefix "a:" on line 1.'));
+                     'Undefined prefix "a:" on line 1.')
+    );
 
-    it('should parse statements with blank nodes in lists',
+    it(
+      'should parse statements with blank nodes in lists',
       shouldParse('<a> <b> (_:x _:y).',
                   ['a', 'b', '_:b0'],
                   ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', '_:b0_x'],
                   ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest',  '_:b1'],
                   ['_:b1', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', '_:b0_y'],
-                  ['_:b1', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil']));
+                  ['_:b1', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil'])
+    );
 
-    it('should parse statements with a nested empty list',
+    it(
+      'should parse statements with a nested empty list',
       shouldParse('<a> <b> (<x> ()).',
                   ['a', 'b', '_:b0'],
                   ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', 'x'],
                   ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', '_:b1'],
                   ['_:b1', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil'],
-                  ['_:b1', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil']));
+                  ['_:b1', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil'])
+    );
 
-    it('should parse statements with non-empty nested lists',
+    it(
+      'should parse statements with non-empty nested lists',
       shouldParse('<a> <b> (<x> (<y>)).',
                   ['a', 'b', '_:b0'],
                   ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', 'x'],
@@ -494,63 +618,78 @@ describe('Parser', () => {
                   ['_:b1', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', '_:b2'],
                   ['_:b1', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil'],
                   ['_:b2', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', 'y'],
-                  ['_:b2', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil']));
+                  ['_:b2', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil'])
+    );
 
-    it('should parse statements with a list containing a blank node',
+    it(
+      'should parse statements with a list containing a blank node',
       shouldParse('([]) <a> <b>.',
                   ['_:b0', 'a', 'b'],
                   ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', '_:b1'],
-                  ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil']));
+                  ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil'])
+    );
 
-    it('should parse statements with a list containing multiple blank nodes',
+    it(
+      'should parse statements with a list containing multiple blank nodes',
       shouldParse('([] [<x> <y>]) <a> <b>.',
                   ['_:b0', 'a', 'b'],
                   ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', '_:b1'],
                   ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', '_:b2'],
                   ['_:b2', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', '_:b3'],
                   ['_:b2', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil'],
-                  ['_:b3', 'x', 'y']));
+                  ['_:b3', 'x', 'y'])
+    );
 
-    it('should parse statements with a blank node containing a list',
+    it(
+      'should parse statements with a blank node containing a list',
       shouldParse('[<a> (<b>)] <c> <d>.',
                   ['_:b0', 'c', 'd'],
                   ['_:b0', 'a', '_:b1'],
                   ['_:b1', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', 'b'],
-                  ['_:b1', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil']));
+                  ['_:b1', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil'])
+    );
 
-    it('should not parse an invalid list',
-      shouldNotParse('<a> <b> (]).',
-                     'Expected entity but got ] on line 1.'));
+    it('should not parse an invalid list', shouldNotParse('<a> <b> (]).',
+                   'Expected entity but got ] on line 1.'));
 
-    it('should resolve IRIs against @base',
+    it(
+      'should resolve IRIs against @base',
       shouldParse('@base <http://ex.org/>.\n' +
                   '<a> <b> <c>.\n' +
                   '@base <d/>.\n' +
                   '<e> <f> <g>.',
                   ['http://ex.org/a', 'http://ex.org/b', 'http://ex.org/c'],
-                  ['http://ex.org/d/e', 'http://ex.org/d/f', 'http://ex.org/d/g']));
+                  ['http://ex.org/d/e', 'http://ex.org/d/f', 'http://ex.org/d/g'])
+    );
 
-    it('should not resolve IRIs against @BASE',
+    it(
+      'should not resolve IRIs against @BASE',
       shouldNotParse('@BASE <http://ex.org/>.',
-                     'Expected entity but got @BASE on line 1.'));
+                     'Expected entity but got @BASE on line 1.')
+    );
 
-    it('should resolve IRIs against SPARQL base',
+    it(
+      'should resolve IRIs against SPARQL base',
       shouldParse('BASE <http://ex.org/>\n' +
                   '<a> <b> <c>. ' +
                   'BASE <d/> ' +
                   '<e> <f> <g>.',
                   ['http://ex.org/a', 'http://ex.org/b', 'http://ex.org/c'],
-                  ['http://ex.org/d/e', 'http://ex.org/d/f', 'http://ex.org/d/g']));
+                  ['http://ex.org/d/e', 'http://ex.org/d/f', 'http://ex.org/d/g'])
+    );
 
-    it('should resolve IRIs against a @base with query string',
+    it(
+      'should resolve IRIs against a @base with query string',
       shouldParse('@base <http://ex.org/?foo>.\n' +
                   '<> <b> <c>.\n' +
                   '@base <d/?bar>.\n' +
                   '<> <f> <g>.',
                   ['http://ex.org/?foo', 'http://ex.org/b', 'http://ex.org/c'],
-                  ['http://ex.org/d/?bar', 'http://ex.org/d/f', 'http://ex.org/d/g']));
+                  ['http://ex.org/d/?bar', 'http://ex.org/d/f', 'http://ex.org/d/g'])
+    );
 
-    it('should resolve IRIs with query string against @base',
+    it(
+      'should resolve IRIs with query string against @base',
       shouldParse('@base <http://ex.org/>.\n' +
                   '<?> <?a> <?a=b>.\n' +
                   '@base <d>.\n' +
@@ -559,303 +698,395 @@ describe('Parser', () => {
                   '<> <?a> <?a=b>.',
                   ['http://ex.org/?', 'http://ex.org/?a', 'http://ex.org/?a=b'],
                   ['http://ex.org/d?', 'http://ex.org/d?a', 'http://ex.org/d?a=b'],
-                  ['http://ex.org/d?e', 'http://ex.org/d?a', 'http://ex.org/d?a=b']));
+                  ['http://ex.org/d?e', 'http://ex.org/d?a', 'http://ex.org/d?a=b'])
+    );
 
-    it('should not resolve IRIs with colons',
+    it(
+      'should not resolve IRIs with colons',
       shouldParse('@base <http://ex.org/>.\n' +
                   '<a>   <b>   <c>.\n' +
                   '<A:>  <b:>  <c:>.\n' +
                   '<a:a> <b:B> <C-D:c>.',
                   ['http://ex.org/a', 'http://ex.org/b', 'http://ex.org/c'],
                   ['A:',  'b:',  'c:'],
-                  ['a:a', 'b:B', 'C-D:c']));
+                  ['a:a', 'b:B', 'C-D:c'])
+    );
 
-    it('should not allow relative URIs with a colon in the first path segment',
+    it(
+      'should not allow relative URIs with a colon in the first path segment',
       shouldNotParse('<entity.beeldbank_leiden_person:A.E._Stuur.> <x:x> <x:x> .',
-                     'Invalid IRI on line 1.'));
+                     'Invalid IRI on line 1.')
+    );
 
-    it('should not allow relative URIs with a colon in the first path segment as base',
+    it(
+      'should not allow relative URIs with a colon in the first path segment as base',
       shouldNotParse('@base <entity.beeldbank_leiden_person:A.E._Stuur.> .',
-                     'Expected valid IRI to follow base declaration on line 1.'));
+                     'Expected valid IRI to follow base declaration on line 1.')
+    );
 
-    it('should resolve datatype IRIs against @base',
+    it(
+      'should resolve datatype IRIs against @base',
       shouldParse('@base <http://ex.org/>.\n' +
                   '<a> <b> "c"^^<d>.\n' +
                   '@base <d/>.\n' +
                   '<e> <f> "g"^^<h>.',
                   ['http://ex.org/a', 'http://ex.org/b', '"c"^^http://ex.org/d'],
-                  ['http://ex.org/d/e', 'http://ex.org/d/f', '"g"^^http://ex.org/d/h']));
+                  ['http://ex.org/d/e', 'http://ex.org/d/f', '"g"^^http://ex.org/d/h'])
+    );
 
-    it('should resolve IRIs against a base with a fragment',
+    it(
+      'should resolve IRIs against a base with a fragment',
       shouldParse('@base <http://ex.org/foo#bar>.\n' +
                   '<a> <b> <#c>.\n',
-                  ['http://ex.org/a', 'http://ex.org/b', 'http://ex.org/foo#c']));
+                  ['http://ex.org/a', 'http://ex.org/b', 'http://ex.org/foo#c'])
+    );
 
-    it('should resolve IRIs with an empty fragment',
+    it(
+      'should resolve IRIs with an empty fragment',
       shouldParse('@base <http://ex.org/foo>.\n' +
                   '<#> <b#> <#c>.\n',
-                  ['http://ex.org/foo#', 'http://ex.org/b#', 'http://ex.org/foo#c']));
+                  ['http://ex.org/foo#', 'http://ex.org/b#', 'http://ex.org/foo#c'])
+    );
 
-    it('should not resolve prefixed names',
+    it(
+      'should not resolve prefixed names',
       shouldParse('PREFIX ex: <http://ex.org/a/bb/ccc/../>\n' +
                   'ex:a ex:b ex:c .',
-                  ['http://ex.org/a/bb/ccc/../a', 'http://ex.org/a/bb/ccc/../b', 'http://ex.org/a/bb/ccc/../c']));
+                  ['http://ex.org/a/bb/ccc/../a', 'http://ex.org/a/bb/ccc/../b', 'http://ex.org/a/bb/ccc/../c'])
+    );
 
-    it('should parse an empty default graph',
-      shouldParse('{}'));
+    it('should parse an empty default graph', shouldParse('{}'));
 
-    it('should parse a one-triple default graph ending without a dot',
+    it(
+      'should parse a one-triple default graph ending without a dot',
       shouldParse('{<a> <b> <c>}',
-                  ['a', 'b', 'c']));
+                  ['a', 'b', 'c'])
+    );
 
-    it('should parse a one-triple default graph ending with a dot',
+    it(
+      'should parse a one-triple default graph ending with a dot',
       shouldParse('{<a> <b> <c>.}',
-                  ['a', 'b', 'c']));
+                  ['a', 'b', 'c'])
+    );
 
-    it('should parse a three-triple default graph ending without a dot',
+    it(
+      'should parse a three-triple default graph ending without a dot',
       shouldParse('{<a> <b> <c>;<d> <e>,<f>}',
                   ['a', 'b', 'c'],
                   ['a', 'd', 'e'],
-                  ['a', 'd', 'f']));
+                  ['a', 'd', 'f'])
+    );
 
-    it('should parse a three-triple default graph ending with a dot',
+    it(
+      'should parse a three-triple default graph ending with a dot',
       shouldParse('{<a> <b> <c>;<d> <e>,<f>.}',
                   ['a', 'b', 'c'],
                   ['a', 'd', 'e'],
-                  ['a', 'd', 'f']));
+                  ['a', 'd', 'f'])
+    );
 
-    it('should parse a three-triple default graph ending with a semicolon',
+    it(
+      'should parse a three-triple default graph ending with a semicolon',
       shouldParse('{<a> <b> <c>;<d> <e>,<f>;}',
                   ['a', 'b', 'c'],
                   ['a', 'd', 'e'],
-                  ['a', 'd', 'f']));
+                  ['a', 'd', 'f'])
+    );
 
-    it('should parse a default graph with a blank node ending with a dot',
+    it(
+      'should parse a default graph with a blank node ending with a dot',
       shouldParse('{ [<p> <o>]. }',
-                  ['_:b0', 'p', 'o']));
+                  ['_:b0', 'p', 'o'])
+    );
 
-    it('should parse a default graph with a blank node ending without a dot',
+    it(
+      'should parse a default graph with a blank node ending without a dot',
       shouldParse('{ [<p> <o>] }',
-                  ['_:b0', 'p', 'o']));
+                  ['_:b0', 'p', 'o'])
+    );
 
-    it('should parse an empty named graph with an IRI',
-      shouldParse('<g>{}'));
+    it('should parse an empty named graph with an IRI', shouldParse('<g>{}'));
 
-    it('should parse a one-triple named graph with an IRI ending without a dot',
+    it(
+      'should parse a one-triple named graph with an IRI ending without a dot',
       shouldParse('<g> {<a> <b> <c>}',
-                  ['a', 'b', 'c', 'g']));
+                  ['a', 'b', 'c', 'g'])
+    );
 
-    it('should parse a one-triple named graph with an IRI ending with a dot',
+    it(
+      'should parse a one-triple named graph with an IRI ending with a dot',
       shouldParse('<g>{<a> <b> <c>.}',
-                  ['a', 'b', 'c', 'g']));
+                  ['a', 'b', 'c', 'g'])
+    );
 
-    it('should parse a three-triple named graph with an IRI ending without a dot',
+    it(
+      'should parse a three-triple named graph with an IRI ending without a dot',
       shouldParse('<g> {<a> <b> <c>;<d> <e>,<f>}',
                   ['a', 'b', 'c', 'g'],
                   ['a', 'd', 'e', 'g'],
-                  ['a', 'd', 'f', 'g']));
+                  ['a', 'd', 'f', 'g'])
+    );
 
-    it('should parse a three-triple named graph with an IRI ending with a dot',
+    it(
+      'should parse a three-triple named graph with an IRI ending with a dot',
       shouldParse('<g>{<a> <b> <c>;<d> <e>,<f>.}',
                   ['a', 'b', 'c', 'g'],
                   ['a', 'd', 'e', 'g'],
-                  ['a', 'd', 'f', 'g']));
+                  ['a', 'd', 'f', 'g'])
+    );
 
-    it('should parse an empty named graph with a prefixed name',
-      shouldParse('@prefix g: <g#>.\ng:h {}'));
+    it(
+      'should parse an empty named graph with a prefixed name',
+      shouldParse('@prefix g: <g#>.\ng:h {}')
+    );
 
-    it('should parse a one-triple named graph with a prefixed name ending without a dot',
+    it(
+      'should parse a one-triple named graph with a prefixed name ending without a dot',
       shouldParse('@prefix g: <g#>.\ng:h {<a> <b> <c>}',
-                  ['a', 'b', 'c', 'g#h']));
+                  ['a', 'b', 'c', 'g#h'])
+    );
 
-    it('should parse a one-triple named graph with a prefixed name ending with a dot',
+    it(
+      'should parse a one-triple named graph with a prefixed name ending with a dot',
       shouldParse('@prefix g: <g#>.\ng:h{<a> <b> <c>.}',
-                  ['a', 'b', 'c', 'g#h']));
+                  ['a', 'b', 'c', 'g#h'])
+    );
 
-    it('should parse a three-triple named graph with a prefixed name ending without a dot',
+    it(
+      'should parse a three-triple named graph with a prefixed name ending without a dot',
       shouldParse('@prefix g: <g#>.\ng:h {<a> <b> <c>;<d> <e>,<f>}',
                   ['a', 'b', 'c', 'g#h'],
                   ['a', 'd', 'e', 'g#h'],
-                  ['a', 'd', 'f', 'g#h']));
+                  ['a', 'd', 'f', 'g#h'])
+    );
 
-    it('should parse a three-triple named graph with a prefixed name ending with a dot',
+    it(
+      'should parse a three-triple named graph with a prefixed name ending with a dot',
       shouldParse('@prefix g: <g#>.\ng:h{<a> <b> <c>;<d> <e>,<f>.}',
                   ['a', 'b', 'c', 'g#h'],
                   ['a', 'd', 'e', 'g#h'],
-                  ['a', 'd', 'f', 'g#h']));
+                  ['a', 'd', 'f', 'g#h'])
+    );
 
-    it('should parse a named graph with a blank node ending with a dot',
+    it(
+      'should parse a named graph with a blank node ending with a dot',
       shouldParse('<g> { [<p> <o>]. }',
-                  ['_:b0', 'p', 'o', 'g']));
+                  ['_:b0', 'p', 'o', 'g'])
+    );
 
-    it('should parse a named graph with a blank node ending without a dot',
+    it(
+      'should parse a named graph with a blank node ending without a dot',
       shouldParse('<g> { [<p> <o>] }',
-                  ['_:b0', 'p', 'o', 'g']));
+                  ['_:b0', 'p', 'o', 'g'])
+    );
 
-    it('should parse an empty anonymous graph',
-      shouldParse('[] {}'));
+    it('should parse an empty anonymous graph', shouldParse('[] {}'));
 
-    it('should parse a one-triple anonymous graph ending without a dot',
+    it(
+      'should parse a one-triple anonymous graph ending without a dot',
       shouldParse('[] {<a> <b> <c>}',
-                  ['a', 'b', 'c', '_:b0']));
+                  ['a', 'b', 'c', '_:b0'])
+    );
 
-    it('should parse a one-triple anonymous graph ending with a dot',
+    it(
+      'should parse a one-triple anonymous graph ending with a dot',
       shouldParse('[]{<a> <b> <c>.}',
-                  ['a', 'b', 'c', '_:b0']));
+                  ['a', 'b', 'c', '_:b0'])
+    );
 
-    it('should parse a three-triple anonymous graph ending without a dot',
+    it(
+      'should parse a three-triple anonymous graph ending without a dot',
       shouldParse('[] {<a> <b> <c>;<d> <e>,<f>}',
                   ['a', 'b', 'c', '_:b0'],
                   ['a', 'd', 'e', '_:b0'],
-                  ['a', 'd', 'f', '_:b0']));
+                  ['a', 'd', 'f', '_:b0'])
+    );
 
-    it('should parse a three-triple anonymous graph ending with a dot',
+    it(
+      'should parse a three-triple anonymous graph ending with a dot',
       shouldParse('[]{<a> <b> <c>;<d> <e>,<f>.}',
                   ['a', 'b', 'c', '_:b0'],
                   ['a', 'd', 'e', '_:b0'],
-                  ['a', 'd', 'f', '_:b0']));
+                  ['a', 'd', 'f', '_:b0'])
+    );
 
-    it('should parse an empty named graph with an IRI and the GRAPH keyword',
-      shouldParse('GRAPH <g> {}'));
+    it(
+      'should parse an empty named graph with an IRI and the GRAPH keyword',
+      shouldParse('GRAPH <g> {}')
+    );
 
-    it('should parse an empty named graph with a prefixed name and the GRAPH keyword',
-      shouldParse('@prefix g: <g#>.\nGRAPH g:h {}'));
+    it(
+      'should parse an empty named graph with a prefixed name and the GRAPH keyword',
+      shouldParse('@prefix g: <g#>.\nGRAPH g:h {}')
+    );
 
-    it('should parse an empty anonymous graph and the GRAPH keyword',
-      shouldParse('GRAPH [] {}'));
+    it(
+      'should parse an empty anonymous graph and the GRAPH keyword',
+      shouldParse('GRAPH [] {}')
+    );
 
-    it('should parse a one-triple named graph with an IRI and the GRAPH keyword',
+    it(
+      'should parse a one-triple named graph with an IRI and the GRAPH keyword',
       shouldParse('GRAPH <g> {<a> <b> <c>}',
-                  ['a', 'b', 'c', 'g']));
+                  ['a', 'b', 'c', 'g'])
+    );
 
-    it('should parse a one-triple named graph with a prefixed name and the GRAPH keyword',
+    it(
+      'should parse a one-triple named graph with a prefixed name and the GRAPH keyword',
       shouldParse('@prefix g: <g#>.\nGRAPH g:h {<a> <b> <c>}',
-                  ['a', 'b', 'c', 'g#h']));
+                  ['a', 'b', 'c', 'g#h'])
+    );
 
-    it('should parse a one-triple anonymous graph and the GRAPH keyword',
+    it(
+      'should parse a one-triple anonymous graph and the GRAPH keyword',
       shouldParse('GRAPH [] {<a> <b> <c>}',
-                  ['a', 'b', 'c', '_:b0']));
+                  ['a', 'b', 'c', '_:b0'])
+    );
 
-    it('should parse a graph with 8-bit unicode escape sequences',
+    it(
+      'should parse a graph with 8-bit unicode escape sequences',
       shouldParse('<\\U0001d400> {\n<\\U0001d400> <\\U0001d400> "\\U0001d400"^^<\\U0001d400>\n}\n',
-                  ['\ud835\udC00', '\ud835\udc00', '"\ud835\udc00"^^http://example.org/\ud835\udc00', '\ud835\udc00']));
+                  ['\ud835\udC00', '\ud835\udc00', '"\ud835\udc00"^^http://example.org/\ud835\udc00', '\ud835\udc00'])
+    );
 
-    it('should not parse a single closing brace',
-      shouldNotParse('}',
-                     'Unexpected graph closing on line 1.'));
+    it('should not parse a single closing brace', shouldNotParse('}',
+                   'Unexpected graph closing on line 1.'));
 
-    it('should not parse a single opening brace',
-      shouldNotParse('{',
-                     'Unexpected "{" on line 1.'));
+    it('should not parse a single opening brace', shouldNotParse('{',
+                   'Unexpected "{" on line 1.'));
 
-    it('should not parse a superfluous closing brace ',
-      shouldNotParse('{}}',
-                     'Unexpected graph closing on line 1.'));
+    it('should not parse a superfluous closing brace ', shouldNotParse('{}}',
+                   'Unexpected graph closing on line 1.'));
 
-    it('should not parse a graph with only a dot',
-      shouldNotParse('{.}',
-                     'Expected entity but got . on line 1.'));
+    it('should not parse a graph with only a dot', shouldNotParse('{.}',
+                   'Expected entity but got . on line 1.'));
 
-    it('should not parse a graph with only a semicolon',
-      shouldNotParse('{;}',
-                     'Expected entity but got ; on line 1.'));
+    it('should not parse a graph with only a semicolon', shouldNotParse('{;}',
+                   'Expected entity but got ; on line 1.'));
 
-    it('should not parse an unclosed graph',
-      shouldNotParse('{<a> <b> <c>.',
-                     'Unclosed graph on line 1.'));
+    it('should not parse an unclosed graph', shouldNotParse('{<a> <b> <c>.',
+                   'Unclosed graph on line 1.'));
 
-    it('should not parse a named graph with a list node as label',
+    it(
+      'should not parse a named graph with a list node as label',
       shouldNotParse('() {}',
-                     'Expected entity but got { on line 1.'));
+                     'Expected entity but got { on line 1.')
+    );
 
-    it('should not parse a named graph with a non-empty blank node as label',
+    it(
+      'should not parse a named graph with a non-empty blank node as label',
       shouldNotParse('[<a> <b>] {}',
-                     'Expected entity but got { on line 1.'));
+                     'Expected entity but got { on line 1.')
+    );
 
-    it('should not parse a named graph with the GRAPH keyword and a non-empty blank node as label',
+    it(
+      'should not parse a named graph with the GRAPH keyword and a non-empty blank node as label',
       shouldNotParse('GRAPH [<a> <b>] {}',
-                     'Invalid graph label on line 1.'));
+                     'Invalid graph label on line 1.')
+    );
 
-    it('should not parse a triple after the GRAPH keyword',
+    it(
+      'should not parse a triple after the GRAPH keyword',
       shouldNotParse('GRAPH <a> <b> <c>.',
-                     'Expected graph but got IRI on line 1.'));
+                     'Expected graph but got IRI on line 1.')
+    );
 
-    it('should not parse repeated GRAPH keywords',
+    it(
+      'should not parse repeated GRAPH keywords',
       shouldNotParse('GRAPH GRAPH <g> {}',
-                     'Invalid graph label on line 1.'));
+                     'Invalid graph label on line 1.')
+    );
 
-    it('should parse a quad with 4 IRIs',
-      shouldParse('<a> <b> <c> <g>.',
-                  ['a', 'b', 'c', 'g']));
+    it('should parse a quad with 4 IRIs', shouldParse('<a> <b> <c> <g>.',
+                ['a', 'b', 'c', 'g']));
 
-    it('should parse a quad with 4 prefixed names',
+    it(
+      'should parse a quad with 4 prefixed names',
       shouldParse('@prefix p: <p#>.\np:a p:b p:c p:g.',
-                  ['p#a', 'p#b', 'p#c', 'p#g']));
+                  ['p#a', 'p#b', 'p#c', 'p#g'])
+    );
 
-    it('should not parse a quad with an undefined prefix',
+    it(
+      'should not parse a quad with an undefined prefix',
       shouldNotParse('<a> <b> <c> p:g.',
-                     'Undefined prefix "p:" on line 1.'));
+                     'Undefined prefix "p:" on line 1.')
+    );
 
-    it('should parse a quad with 3 IRIs and a literal',
+    it(
+      'should parse a quad with 3 IRIs and a literal',
       shouldParse('<a> <b> "c"^^<d> <g>.',
-                  ['a', 'b', '"c"^^http://example.org/d', 'g']));
+                  ['a', 'b', '"c"^^http://example.org/d', 'g'])
+    );
 
-    it('should parse a quad with 2 blank nodes and a literal',
+    it(
+      'should parse a quad with 2 blank nodes and a literal',
       shouldParse('_:a <b> "c"^^<d> _:g.',
-                  ['_:b0_a', 'b', '"c"^^http://example.org/d', '_:b0_g']));
+                  ['_:b0_a', 'b', '"c"^^http://example.org/d', '_:b0_g'])
+    );
 
-    it('should not parse a quad in a graph',
-      shouldNotParse('{<a> <b> <c> <g>.}',
-                     'Expected punctuation to follow "http://example.org/c" on line 1.'));
+    it('should not parse a quad in a graph', shouldNotParse('{<a> <b> <c> <g>.}',
+                   'Expected punctuation to follow "http://example.org/c" on line 1.'));
 
-    it('should not parse a quad with different punctuation',
+    it(
+      'should not parse a quad with different punctuation',
       shouldNotParse('<a> <b> <c> <g>;',
-                     'Expected dot to follow quad on line 1.'));
+                     'Expected dot to follow quad on line 1.')
+    );
 
-    it('should not parse base declarations without IRI',
+    it(
+      'should not parse base declarations without IRI',
       shouldNotParse('@base a: ',
-                     'Expected valid IRI to follow base declaration on line 1.'));
+                     'Expected valid IRI to follow base declaration on line 1.')
+    );
 
-    it('should not parse improperly nested parentheses and brackets',
+    it(
+      'should not parse improperly nested parentheses and brackets',
       shouldNotParse('<a> <b> [<c> (<d>]).',
-                     'Expected entity but got ] on line 1.'));
+                     'Expected entity but got ] on line 1.')
+    );
 
-    it('should not parse improperly nested square brackets',
+    it(
+      'should not parse improperly nested square brackets',
       shouldNotParse('<a> <b> [<c> <d>]].',
-                     'Expected entity but got ] on line 1.'));
+                     'Expected entity but got ] on line 1.')
+    );
 
-    it('should error when an object is not there',
-      shouldNotParse('<a> <b>.',
-                     'Expected entity but got . on line 1.'));
+    it('should error when an object is not there', shouldNotParse('<a> <b>.',
+                   'Expected entity but got . on line 1.'));
 
-    it('should error when a dot is not there',
-      shouldNotParse('<a> <b> <c>',
-                     'Expected entity but got eof on line 1.'));
+    it('should error when a dot is not there', shouldNotParse('<a> <b> <c>',
+                   'Expected entity but got eof on line 1.'));
 
-    it('should error with an abbreviation in the subject',
+    it(
+      'should error with an abbreviation in the subject',
       shouldNotParse('a <a> <a>.',
-                     'Expected entity but got abbreviation on line 1.'));
+                     'Expected entity but got abbreviation on line 1.')
+    );
 
-    it('should error with an abbreviation in the object',
+    it(
+      'should error with an abbreviation in the object',
       shouldNotParse('<a> <a> a .',
-                     'Expected entity but got abbreviation on line 1.'));
+                     'Expected entity but got abbreviation on line 1.')
+    );
 
-    it('should error if punctuation follows a subject',
-      shouldNotParse('<a> .',
-                     'Unexpected . on line 1.'));
+    it('should error if punctuation follows a subject', shouldNotParse('<a> .',
+                   'Unexpected . on line 1.'));
 
-    it('should error if an unexpected token follows a subject',
+    it(
+      'should error if an unexpected token follows a subject',
       shouldNotParse('<a> @',
-                     'Unexpected "@" on line 1.'), {
-                       token: {
-                         line: 1,
-                         type: '@PREFIX',
-                         value: '',
-                         prefix: '',
-                       },
-                       previousToken: undefined,
-                       line: 1,
-                     });
+                     'Unexpected "@" on line 1.'),
+      {
+        token: {
+          line: 1,
+          type: '@PREFIX',
+          value: '',
+          prefix: '',
+        },
+        previousToken: undefined,
+        line: 1,
+      }
+    );
 
     it('should not error if there is no triple callback', () => {
       new Parser().parse('');
@@ -867,51 +1098,54 @@ describe('Parser', () => {
                            tripleCallback, prefixCallback);
 
       function tripleCallback(error, triple) {
-        expect(error).not.to.exist;
+        expect(error).toBeFalsy();
         if (!triple) {
-          Object.keys(prefixes).should.have.length(2);
-          expect(prefixes).to.have.property('a');
-          expect(prefixes.a).to.deep.equal(new NamedNode('http://a.org/#'));
-          expect(prefixes).to.have.property('b');
-          expect(prefixes.b).to.deep.equal(new NamedNode('http://b.org/#'));
+          expect(Object.keys(prefixes)).toHaveLength(2);
+          expect(prefixes).toHaveProperty('a');
+          expect(prefixes.a).toEqual(new NamedNode('http://a.org/#'));
+          expect(prefixes).toHaveProperty('b');
+          expect(prefixes.b).toEqual(new NamedNode('http://b.org/#'));
           done();
         }
       }
 
       function prefixCallback(prefix, iri) {
-        expect(prefix).to.exist;
-        expect(iri).to.exist;
+        expect(prefix).toBeDefined();
+        expect(iri).toBeDefined();
         prefixes[prefix] = iri;
       }
     });
 
-    it('should return prefixes through a callback without triple callback', done => {
-      const prefixes = {};
-      new Parser().parse('@prefix a: <IRIa>. a:a a:b a:c. @prefix b: <IRIb>.',
-                           null, prefixCallback);
+    it(
+      'should return prefixes through a callback without triple callback',
+      done => {
+        const prefixes = {};
+        new Parser().parse('@prefix a: <IRIa>. a:a a:b a:c. @prefix b: <IRIb>.',
+                             null, prefixCallback);
 
-      function prefixCallback(prefix, iri) {
-        expect(prefix).to.exist;
-        expect(iri).to.exist;
-        prefixes[prefix] = iri;
-        if (Object.keys(prefixes).length === 2)
-          done();
+        function prefixCallback(prefix, iri) {
+          expect(prefix).toBeDefined();
+          expect(iri).toBeDefined();
+          prefixes[prefix] = iri;
+          if (Object.keys(prefixes).length === 2)
+            done();
+        }
       }
-    });
+    );
 
     it('should return prefixes at the last triple callback', done => {
       new Parser({ baseIRI: BASE_IRI })
         .parse('@prefix a: <IRIa>. a:a a:b a:c. @prefix b: <IRIb>.', tripleCallback);
 
       function tripleCallback(error, triple, prefixes) {
-        expect(error).not.to.exist;
+        expect(error).toBeFalsy();
         if (triple)
-          expect(prefixes).not.to.exist;
+          expect(prefixes).toBeFalsy();
         else {
-          expect(prefixes).to.exist;
-          Object.keys(prefixes).should.have.length(2);
-          expect(prefixes).to.have.property('a', 'http://example.org/IRIa');
-          expect(prefixes).to.have.property('b', 'http://example.org/IRIb');
+          expect(prefixes).toBeDefined();
+          expect(Object.keys(prefixes)).toHaveLength(2);
+          expect(prefixes).toHaveProperty('a', 'http://example.org/IRIa');
+          expect(prefixes).toHaveProperty('b', 'http://example.org/IRIb');
           done();
         }
       }
@@ -919,245 +1153,322 @@ describe('Parser', () => {
 
     it('should parse a string synchronously if no callback is given', () => {
       const triples = new Parser().parse('@prefix a: <urn:a:>. a:a a:b a:c.');
-      triples.should.deep.equal([
+      expect(triples).toEqual([
         new Quad(termFromId('urn:a:a'), termFromId('urn:a:b'),
                  termFromId('urn:a:c'), termFromId('')),
       ]);
     });
 
     it('should throw on syntax errors if no callback is given', () => {
-      (function () { new Parser().parse('<a> bar <c>'); })
-      .should.throw('Unexpected "bar" on line 1.').with.property('context').with.property('line', 1);
+      expect((() => { new Parser().parse('<a> bar <c>'); })).toThrowError('Unexpected "bar" on line 1.');
     });
 
     it('should throw on grammar errors if no callback is given', () => {
-      (function () { new Parser().parse('<a> <b> <c>'); })
-      .should.throw('Expected entity but got eof on line 1');
+      expect((() => { new Parser().parse('<a> <b> <c>'); })).toThrow('Expected entity but got eof on line 1');
     });
 
-    it('should parse an RDF* triple with a triple with iris as subject correctly', () => {
-      shouldParse('<<<a> <b> <c>>> <b> <c>.',
-        [['a', 'b', 'c'], 'b', 'c']);
-    });
+    it(
+      'should parse an RDF* triple with a triple with iris as subject correctly',
+      () => {
+        shouldParse('<<<a> <b> <c>>> <b> <c>.',
+          [['a', 'b', 'c'], 'b', 'c']);
+      }
+    );
 
-    it('should not parse an RDF* triple with a triple as predicate',
+    it(
+      'should not parse an RDF* triple with a triple as predicate',
       shouldNotParse('<a> <<<b> <c> <d>>> <e>',
-        'Expected entity but got << on line 1.'));
+        'Expected entity but got << on line 1.')
+    );
 
-    it('should parse an RDF* triple with a triple with blanknodes as subject correctly',
+    it(
+      'should parse an RDF* triple with a triple with blanknodes as subject correctly',
       shouldParse('<<_:a <b> _:c>> <b> <c>.',
-        [['_:b0_a', 'b', '_:b0_c'], 'b', 'c']));
+        [['_:b0_a', 'b', '_:b0_c'], 'b', 'c'])
+    );
 
-    it('should parse an RDF* triple with a triple with blanknodes and literals as subject correctly',
+    it(
+      'should parse an RDF* triple with a triple with blanknodes and literals as subject correctly',
       shouldParse('<<_:a <b> "c"^^<d>>> <b> <c>.',
-        [['_:b0_a', 'b', '"c"^^http://example.org/d'], 'b', 'c']));
+        [['_:b0_a', 'b', '"c"^^http://example.org/d'], 'b', 'c'])
+    );
 
-    it('should parse an RDF* triple with a triple as object correctly',
+    it(
+      'should parse an RDF* triple with a triple as object correctly',
       shouldParse('<a> <b> <<<a> <b> <c>>>.',
-        ['a', 'b', ['a', 'b', 'c']]));
+        ['a', 'b', ['a', 'b', 'c']])
+    );
 
-    it('should parse an RDF* triple with a triple as object correctly',
+    it(
+      'should parse an RDF* triple with a triple as object correctly',
       shouldParse('<a> <b> <<_:a <b> _:c>>.',
-        ['a', 'b', ['_:b0_a', 'b', '_:b0_c']]));
+        ['a', 'b', ['_:b0_a', 'b', '_:b0_c']])
+    );
 
-    it('should parse an RDF* triple with a triple as object correctly',
+    it(
+      'should parse an RDF* triple with a triple as object correctly',
       shouldParse('<a> <b> <<_:a <b> "c"^^<d>>>.',
-        ['a', 'b', ['_:b0_a', 'b', '"c"^^http://example.org/d']]));
+        ['a', 'b', ['_:b0_a', 'b', '"c"^^http://example.org/d']])
+    );
 
-    it('should parse nested triples correctly',
+    it(
+      'should parse nested triples correctly',
       shouldParse('<<<<<a> <b> <c>>> <f> <g>>> <d> <e>.',
-        [[['a', 'b', 'c'], 'f', 'g'], 'd', 'e']));
-    it('should parse nested triples correctly',
+        [[['a', 'b', 'c'], 'f', 'g'], 'd', 'e'])
+    );
+    it(
+      'should parse nested triples correctly',
       shouldParse('<d> <e> <<<f> <g> <<<a> <b> <c>>>>>.',
-        ['d', 'e', ['f', 'g', ['a', 'b', 'c']]]));
-    it('should parse nested triples correctly',
+        ['d', 'e', ['f', 'g', ['a', 'b', 'c']]])
+    );
+    it(
+      'should parse nested triples correctly',
       shouldParse('<<<f> <g> <<<a> <b> <c>>>>> <d> <e>.',
-        [['f', 'g', ['a', 'b', 'c']], 'd', 'e']));
-    it('should parse nested triples correctly',
+        [['f', 'g', ['a', 'b', 'c']], 'd', 'e'])
+    );
+    it(
+      'should parse nested triples correctly',
       shouldParse('<d> <e> <<<<<a> <b> <c>>> <f> <g>>>.',
-        ['d', 'e', [['a', 'b', 'c'], 'f', 'g']]));
+        ['d', 'e', [['a', 'b', 'c'], 'f', 'g']])
+    );
 
-    it('should not parse nested RDF* statements that are partially closed',
+    it(
+      'should not parse nested RDF* statements that are partially closed',
       shouldNotParse('<d> <e> <<<<<a> <b> <c>>> <f> <g>.',
         'Expected entity but got . on line 1.'
-      ));
+      )
+    );
 
-    it('should not parse partially closed nested RDF* statements',
+    it(
+      'should not parse partially closed nested RDF* statements',
       shouldNotParse('<d> <e> <<<<<a> <b> <c> <f> <g>>>.',
         'Expected >> but got IRI on line 1.'
-      ));
+      )
+    );
 
-    it('should not parse nested RDF* statements with too many closing tags',
+    it(
+      'should not parse nested RDF* statements with too many closing tags',
       shouldNotParse('<d> <e> <<<<<a> <b> <c>>>>> <f> <g>>>.',
         'Expected entity but got >> on line 1.'
-      ));
+      )
+    );
 
-    it('should not parse nested RDF* statements with too many closing tags',
+    it(
+      'should not parse nested RDF* statements with too many closing tags',
       shouldNotParse('<d> <e> <<<<<a> <b> <c>>> <f> <g>>>>>.',
         'Expected entity but got >> on line 1.'
-      ));
+      )
+    );
 
-    it('should not parse RDF* statements with too many closing tags',
+    it(
+      'should not parse RDF* statements with too many closing tags',
       shouldNotParse('<a> <b> <c>>>.',
         'Expected entity but got >> on line 1.'
-      ));
+      )
+    );
 
-    it('should not parse incomplete RDF* statements',
+    it(
+      'should not parse incomplete RDF* statements',
       shouldNotParse('<d> <e> <<<a> <b>>>.',
         'Expected entity but got >> on line 1.'
-      ));
+      )
+    );
 
-    it('should not parse incomplete RDF* statements',
+    it(
+      'should not parse incomplete RDF* statements',
       shouldNotParse('<<<a> <b>>> <d> <e>.',
         'Expected entity but got >> on line 1.'
-      ));
+      )
+    );
 
-    it('should not parse incorrectly nested RDF* statements',
+    it(
+      'should not parse incorrectly nested RDF* statements',
       shouldNotParse('>> <<',
         'Expected entity but got >> on line 1.'
-      ));
+      )
+    );
 
-    it('should not parse a nested triple on its own',
+    it(
+      'should not parse a nested triple on its own',
       shouldNotParse('<<<a> <b> <c>>>.',
         'Unexpected . on line 1.'
-      ));
+      )
+    );
 
-    it('should parse an RDF* quad',
-      shouldParse('<<<a> <b> <c> <d>>> <a> <b> .',
-        [['a', 'b', 'c', 'd'], 'a', 'b']));
+    it('should parse an RDF* quad', shouldParse('<<<a> <b> <c> <d>>> <a> <b> .',
+      [['a', 'b', 'c', 'd'], 'a', 'b']));
 
-    it('should not parse a malformed RDF* quad',
+    it(
+      'should not parse a malformed RDF* quad',
       shouldNotParse('<<<a> <b> <c> <d> <e>>> <a> <b> .',
-        'Expected >> but got IRI on line 1.'));
+        'Expected >> but got IRI on line 1.')
+    );
 
-    it('should parse statements with a shared RDF* subject',
+    it(
+      'should parse statements with a shared RDF* subject',
       shouldParse('<<<a> <b> <c>>> <b> <c>;\n<d> <c>.',
         [['a', 'b', 'c'], 'b', 'c'],
-        [['a', 'b', 'c'], 'd', 'c']));
+        [['a', 'b', 'c'], 'd', 'c'])
+    );
 
-    it('should parse statements with a shared RDF* subject',
+    it(
+      'should parse statements with a shared RDF* subject',
       shouldParse('<<<a> <b> <c>>> <b> <c>;\n<d> <<<a> <b> <c>>>.',
         [['a', 'b', 'c'], 'b', 'c'],
-        [['a', 'b', 'c'], 'd', ['a', 'b', 'c']]));
+        [['a', 'b', 'c'], 'd', ['a', 'b', 'c']])
+    );
 
-    it('should put nested triples in the default graph',
+    it(
+      'should put nested triples in the default graph',
       shouldParse('<a> <b> <c> <g>.\n<<<a> <b> <c>>> <d> <e>.',
           ['a', 'b', 'c', 'g'],
-          [['a', 'b', 'c'], 'd', 'e']));
+          [['a', 'b', 'c'], 'd', 'e'])
+    );
 
-    it('should parse an RDF* triple using annotation syntax with one predicate-object',
+    it(
+      'should parse an RDF* triple using annotation syntax with one predicate-object',
       shouldParse('<a> <b> <c> {| <b> <c> |}.',
-          ['a', 'b', 'c'], [['a', 'b', 'c'], 'b', 'c']));
+          ['a', 'b', 'c'], [['a', 'b', 'c'], 'b', 'c'])
+    );
 
-    it('should parse an RDF* triple using annotation syntax with two predicate-objects',
-        shouldParse('<a> <b> <c> {| <b1> <c1>; <b2> <c2> |}.',
-            ['a', 'b', 'c'], [['a', 'b', 'c'], 'b1', 'c1'], [['a', 'b', 'c'], 'b2', 'c2']));
+    it(
+      'should parse an RDF* triple using annotation syntax with two predicate-objects',
+      shouldParse('<a> <b> <c> {| <b1> <c1>; <b2> <c2> |}.',
+          ['a', 'b', 'c'], [['a', 'b', 'c'], 'b1', 'c1'], [['a', 'b', 'c'], 'b2', 'c2'])
+    );
 
-    it('should parse an RDF* triple using annotation syntax with one predicate-object followed by regular triples',
-        shouldParse('<a> <b> <c> {| <b> <c> |}.\n<a2> <b2> <c2>.',
-            ['a', 'b', 'c'], [['a', 'b', 'c'], 'b', 'c'], ['a2', 'b2', 'c2']));
+    it(
+      'should parse an RDF* triple using annotation syntax with one predicate-object followed by regular triples',
+      shouldParse('<a> <b> <c> {| <b> <c> |}.\n<a2> <b2> <c2>.',
+          ['a', 'b', 'c'], [['a', 'b', 'c'], 'b', 'c'], ['a2', 'b2', 'c2'])
+    );
 
-    it('should not parse an RDF* triple using annotation syntax with zero predicate-objects',
-        shouldNotParse('<a> <b> <c> {| |}',
-            'Expected entity but got |} on line 1.'));
+    it(
+      'should not parse an RDF* triple using annotation syntax with zero predicate-objects',
+      shouldNotParse('<a> <b> <c> {| |}',
+          'Expected entity but got |} on line 1.')
+    );
 
-    it('should not parse an RDF* triple using an incomplete annotation syntax',
-        shouldNotParse('<a> <b> <c> {| <b> |}',
-            'Expected entity but got |} on line 1.'));
+    it(
+      'should not parse an RDF* triple using an incomplete annotation syntax',
+      shouldNotParse('<a> <b> <c> {| <b> |}',
+          'Expected entity but got |} on line 1.')
+    );
 
-    it('should not parse an RDF* triple using an incomplete annotation syntax after a semicolon',
-        shouldNotParse('<a> <b> <c> {| <b1> <c1>; |}',
-            'Expected entity but got |} on line 1.'));
+    it(
+      'should not parse an RDF* triple using an incomplete annotation syntax after a semicolon',
+      shouldNotParse('<a> <b> <c> {| <b1> <c1>; |}',
+          'Expected entity but got |} on line 1.')
+    );
 
-    it('should not parse an RDF* triple using an incomplete annotation syntax after a semicolon and entity',
-        shouldNotParse('<a> <b> <c> {| <b1> <c1>; <b2> |}',
-            'Expected entity but got |} on line 1.'));
+    it(
+      'should not parse an RDF* triple using an incomplete annotation syntax after a semicolon and entity',
+      shouldNotParse('<a> <b> <c> {| <b1> <c1>; <b2> |}',
+          'Expected entity but got |} on line 1.')
+    );
 
-    it('should not parse an RDF* triple using an incomplete annotation syntax that misses |}',
-        shouldNotParse('<a> <b> <c> {| <b1> <c1>',
-            'Expected entity but got eof on line 1.'));
+    it(
+      'should not parse an RDF* triple using an incomplete annotation syntax that misses |}',
+      shouldNotParse('<a> <b> <c> {| <b1> <c1>',
+          'Expected entity but got eof on line 1.')
+    );
 
-    it('should not parse an RDF* triple using an incomplete annotation syntax that misses |} and starts a new subject',
-        shouldNotParse('<a> <b> <c> {| <b1> <c1>. <a2> <b2> <c2>',
-            'Expected entity but got eof on line 1.'));
+    it(
+      'should not parse an RDF* triple using an incomplete annotation syntax that misses |} and starts a new subject',
+      shouldNotParse('<a> <b> <c> {| <b1> <c1>. <a2> <b2> <c2>',
+          'Expected entity but got eof on line 1.')
+    );
 
-    it('should not parse an out of place |}',
-        shouldNotParse('<a> <b> <c> |}',
-            'Unexpected asserted triple closing on line 1.'));
+    it('should not parse an out of place |}', shouldNotParse('<a> <b> <c> |}',
+        'Unexpected asserted triple closing on line 1.'));
   });
 
   describe('An Parser instance without document IRI', () => {
     function parser() { return new Parser(); }
 
-    it('should keep relative IRIs',
-      shouldParse(parser,
-        '@prefix : <#>.\n' +
-        '<a> <b> <c> <g>.\n' +
-        ':d :e :f :g.',
-        [termFromId('a'), termFromId('b'), termFromId('c'), termFromId('g')],
-        [termFromId('#d'), termFromId('#e'), termFromId('#f'), termFromId('#g')]));
+    it('should keep relative IRIs', shouldParse(parser,
+      '@prefix : <#>.\n' +
+      '<a> <b> <c> <g>.\n' +
+      ':d :e :f :g.',
+      [termFromId('a'), termFromId('b'), termFromId('c'), termFromId('g')],
+      [termFromId('#d'), termFromId('#e'), termFromId('#f'), termFromId('#g')]));
 
-    it('should keep empty IRIs',
-      shouldParse(parser,
-        '@prefix : <>.\n' +
-        '<> <> <> <>.\n' +
-        ': : : :.',
-        [new NamedNode(''), new NamedNode(''), new NamedNode(''), new NamedNode('')],
-        [new NamedNode(''), new NamedNode(''), new NamedNode(''), new NamedNode('')]));
+    it('should keep empty IRIs', shouldParse(parser,
+      '@prefix : <>.\n' +
+      '<> <> <> <>.\n' +
+      ': : : :.',
+      [new NamedNode(''), new NamedNode(''), new NamedNode(''), new NamedNode('')],
+      [new NamedNode(''), new NamedNode(''), new NamedNode(''), new NamedNode('')]));
   });
 
   describe('An Parser instance with a document IRI', () => {
     function parser() { return new Parser({ baseIRI: 'http://ex.org/x/yy/zzz/f.ttl' }); }
 
-    it('should resolve IRIs against the document IRI',
-      shouldParse(parser,
-                  '@prefix : <#>.\n' +
-                  '<a> <b> <c> <g>.\n' +
-                  ':d :e :f :g.',
-                  ['http://ex.org/x/yy/zzz/a', 'http://ex.org/x/yy/zzz/b', 'http://ex.org/x/yy/zzz/c', 'http://ex.org/x/yy/zzz/g'],
-                  ['http://ex.org/x/yy/zzz/f.ttl#d', 'http://ex.org/x/yy/zzz/f.ttl#e', 'http://ex.org/x/yy/zzz/f.ttl#f', 'http://ex.org/x/yy/zzz/f.ttl#g']));
+    it('should resolve IRIs against the document IRI', shouldParse(parser,
+                '@prefix : <#>.\n' +
+                '<a> <b> <c> <g>.\n' +
+                ':d :e :f :g.',
+                ['http://ex.org/x/yy/zzz/a', 'http://ex.org/x/yy/zzz/b', 'http://ex.org/x/yy/zzz/c', 'http://ex.org/x/yy/zzz/g'],
+                ['http://ex.org/x/yy/zzz/f.ttl#d', 'http://ex.org/x/yy/zzz/f.ttl#e', 'http://ex.org/x/yy/zzz/f.ttl#f', 'http://ex.org/x/yy/zzz/f.ttl#g']));
 
-    it('should resolve IRIs with a trailing slash against the document IRI',
+    it(
+      'should resolve IRIs with a trailing slash against the document IRI',
       shouldParse(parser,
                   '</a> </a/b> </a/b/c>.\n',
-                  ['http://ex.org/a', 'http://ex.org/a/b', 'http://ex.org/a/b/c']));
+                  ['http://ex.org/a', 'http://ex.org/a/b', 'http://ex.org/a/b/c'])
+    );
 
-    it('should resolve IRIs starting with ./ against the document IRI',
+    it(
+      'should resolve IRIs starting with ./ against the document IRI',
       shouldParse(parser,
                   '<./a> <./a/b> <./a/b/c>.\n',
-                  ['http://ex.org/x/yy/zzz/a', 'http://ex.org/x/yy/zzz/a/b', 'http://ex.org/x/yy/zzz/a/b/c']));
+                  ['http://ex.org/x/yy/zzz/a', 'http://ex.org/x/yy/zzz/a/b', 'http://ex.org/x/yy/zzz/a/b/c'])
+    );
 
-    it('should resolve IRIs starting with multiple ./ sequences against the document IRI',
+    it(
+      'should resolve IRIs starting with multiple ./ sequences against the document IRI',
       shouldParse(parser,
                   '<./././a> <./././././a/b> <././././././a/b/c>.\n',
-                  ['http://ex.org/x/yy/zzz/a', 'http://ex.org/x/yy/zzz/a/b', 'http://ex.org/x/yy/zzz/a/b/c']));
+                  ['http://ex.org/x/yy/zzz/a', 'http://ex.org/x/yy/zzz/a/b', 'http://ex.org/x/yy/zzz/a/b/c'])
+    );
 
-    it('should resolve IRIs starting with ../ against the document IRI',
+    it(
+      'should resolve IRIs starting with ../ against the document IRI',
       shouldParse(parser,
                   '<../a> <../a/b> <../a/b/c>.\n',
-                  ['http://ex.org/x/yy/a', 'http://ex.org/x/yy/a/b', 'http://ex.org/x/yy/a/b/c']));
+                  ['http://ex.org/x/yy/a', 'http://ex.org/x/yy/a/b', 'http://ex.org/x/yy/a/b/c'])
+    );
 
-    it('should resolve IRIs starting multiple ../ sequences against the document IRI',
+    it(
+      'should resolve IRIs starting multiple ../ sequences against the document IRI',
       shouldParse(parser,
                   '<../../a> <../../../a/b> <../../../../../../../../a/b/c>.\n',
-                  ['http://ex.org/x/a', 'http://ex.org/a/b', 'http://ex.org/a/b/c']));
+                  ['http://ex.org/x/a', 'http://ex.org/a/b', 'http://ex.org/a/b/c'])
+    );
 
-    it('should resolve IRIs starting with mixes of ./ and ../ sequences against the document IRI',
+    it(
+      'should resolve IRIs starting with mixes of ./ and ../ sequences against the document IRI',
       shouldParse(parser,
                   '<.././a> <./.././a/b> <./.././.././a/b/c>.\n',
-                  ['http://ex.org/x/yy/a', 'http://ex.org/x/yy/a/b', 'http://ex.org/x/a/b/c']));
+                  ['http://ex.org/x/yy/a', 'http://ex.org/x/yy/a/b', 'http://ex.org/x/a/b/c'])
+    );
 
-    it('should resolve IRIs starting with .x, ..x, or .../ against the document IRI',
+    it(
+      'should resolve IRIs starting with .x, ..x, or .../ against the document IRI',
       shouldParse(parser,
                   '<.x/a> <..x/a/b> <.../a/b/c>.\n',
-                  ['http://ex.org/x/yy/zzz/.x/a', 'http://ex.org/x/yy/zzz/..x/a/b', 'http://ex.org/x/yy/zzz/.../a/b/c']));
+                  ['http://ex.org/x/yy/zzz/.x/a', 'http://ex.org/x/yy/zzz/..x/a/b', 'http://ex.org/x/yy/zzz/.../a/b/c'])
+    );
 
-    it('should resolve datatype IRIs against the document IRI',
+    it(
+      'should resolve datatype IRIs against the document IRI',
       shouldParse(parser,
                   '<a> <b> "c"^^<d>.',
-                  ['http://ex.org/x/yy/zzz/a', 'http://ex.org/x/yy/zzz/b', '"c"^^http://ex.org/x/yy/zzz/d']));
+                  ['http://ex.org/x/yy/zzz/a', 'http://ex.org/x/yy/zzz/b', '"c"^^http://ex.org/x/yy/zzz/d'])
+    );
 
-    it('should resolve IRIs in lists against the document IRI',
+    it(
+      'should resolve IRIs in lists against the document IRI',
       shouldParse(parser,
           '(<a> <b>) <p> (<c> <d>).',
           ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', 'http://ex.org/x/yy/zzz/a'],
@@ -1168,417 +1479,585 @@ describe('Parser', () => {
           ['_:b2', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', 'http://ex.org/x/yy/zzz/c'],
           ['_:b2', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', '_:b3'],
           ['_:b3', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', 'http://ex.org/x/yy/zzz/d'],
-          ['_:b3', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil']));
+          ['_:b3', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil'])
+    );
 
-    it('should respect @base statements',
-      shouldParse(parser,
-                  '<a> <b> <c>.\n' +
-                  '@base <http://ex.org/x/>.\n' +
-                  '<e> <f> <g>.\n' +
-                  '@base <d/>.\n' +
-                  '<h> <i> <j>.\n' +
-                  '@base </e/>.\n' +
-                  '<k> <l> <m>.',
-                  ['http://ex.org/x/yy/zzz/a', 'http://ex.org/x/yy/zzz/b', 'http://ex.org/x/yy/zzz/c'],
-                  ['http://ex.org/x/e', 'http://ex.org/x/f', 'http://ex.org/x/g'],
-                  ['http://ex.org/x/d/h', 'http://ex.org/x/d/i', 'http://ex.org/x/d/j'],
-                  ['http://ex.org/e/k', 'http://ex.org/e/l', 'http://ex.org/e/m']));
+    it('should respect @base statements', shouldParse(parser,
+                '<a> <b> <c>.\n' +
+                '@base <http://ex.org/x/>.\n' +
+                '<e> <f> <g>.\n' +
+                '@base <d/>.\n' +
+                '<h> <i> <j>.\n' +
+                '@base </e/>.\n' +
+                '<k> <l> <m>.',
+                ['http://ex.org/x/yy/zzz/a', 'http://ex.org/x/yy/zzz/b', 'http://ex.org/x/yy/zzz/c'],
+                ['http://ex.org/x/e', 'http://ex.org/x/f', 'http://ex.org/x/g'],
+                ['http://ex.org/x/d/h', 'http://ex.org/x/d/i', 'http://ex.org/x/d/j'],
+                ['http://ex.org/e/k', 'http://ex.org/e/l', 'http://ex.org/e/m']));
   });
 
   describe('A Parser instance with a blank node prefix', () => {
     function parser() { return new Parser({ baseIRI: BASE_IRI, blankNodePrefix: '_:blank' }); }
 
-    it('should use the given prefix for blank nodes',
-      shouldParse(parser,
-                  '_:a <b> _:c.\n',
-                  ['_:blanka', 'b', '_:blankc']));
+    it('should use the given prefix for blank nodes', shouldParse(parser,
+                '_:a <b> _:c.\n',
+                ['_:blanka', 'b', '_:blankc']));
   });
 
   describe('A Parser instance with an empty blank node prefix', () => {
     function parser() { return new Parser({ baseIRI: BASE_IRI, blankNodePrefix: '' }); }
 
-    it('should not use a prefix for blank nodes',
-      shouldParse(parser,
-                  '_:a <b> _:c.\n',
-                  ['_:a', 'b', '_:c']));
+    it('should not use a prefix for blank nodes', shouldParse(parser,
+                '_:a <b> _:c.\n',
+                ['_:a', 'b', '_:c']));
   });
 
   describe('A Parser instance with a non-string format', () => {
     function parser() { return new Parser({ baseIRI: BASE_IRI, format: 1 }); }
 
-    it('should parse a single triple',
-      shouldParse(parser, '<a> <b> <c>.', ['a', 'b', 'c']));
+    it(
+      'should parse a single triple',
+      shouldParse(parser, '<a> <b> <c>.', ['a', 'b', 'c'])
+    );
 
-    it('should parse a graph',
-      shouldParse(parser, '{<a> <b> <c>}', ['a', 'b', 'c']));
+    it(
+      'should parse a graph',
+      shouldParse(parser, '{<a> <b> <c>}', ['a', 'b', 'c'])
+    );
   });
 
   describe('A Parser instance for the Turtle format', () => {
     function parser() { return new Parser({ baseIRI: BASE_IRI, format: 'Turtle' }); }
 
-    it('should parse a single triple',
-      shouldParse(parser, '<a> <b> <c>.', ['a', 'b', 'c']));
+    it(
+      'should parse a single triple',
+      shouldParse(parser, '<a> <b> <c>.', ['a', 'b', 'c'])
+    );
 
-    it('should not parse a default graph',
-      shouldNotParse(parser, '{}', 'Unexpected graph on line 1.'));
+    it(
+      'should not parse a default graph',
+      shouldNotParse(parser, '{}', 'Unexpected graph on line 1.')
+    );
 
-    it('should not parse a named graph',
-      shouldNotParse(parser, '<g> {}', 'Expected entity but got { on line 1.'));
+    it(
+      'should not parse a named graph',
+      shouldNotParse(parser, '<g> {}', 'Expected entity but got { on line 1.')
+    );
 
-    it('should not parse a named graph with the GRAPH keyword',
-      shouldNotParse(parser, 'GRAPH <g> {}', 'Expected entity but got GRAPH on line 1.'));
+    it(
+      'should not parse a named graph with the GRAPH keyword',
+      shouldNotParse(parser, 'GRAPH <g> {}', 'Expected entity but got GRAPH on line 1.')
+    );
 
-    it('should not parse a quad',
-      shouldNotParse(parser, '<a> <b> <c> <d>.', 'Expected punctuation to follow "http://example.org/c" on line 1.'));
+    it(
+      'should not parse a quad',
+      shouldNotParse(parser, '<a> <b> <c> <d>.', 'Expected punctuation to follow "http://example.org/c" on line 1.')
+    );
 
-    it('should not parse a variable',
-      shouldNotParse(parser, '?a ?b ?c.', 'Unexpected "?a" on line 1.'));
+    it(
+      'should not parse a variable',
+      shouldNotParse(parser, '?a ?b ?c.', 'Unexpected "?a" on line 1.')
+    );
 
-    it('should not parse an equality statement',
-      shouldNotParse(parser, '<a> = <b>.', 'Unexpected "=" on line 1.'));
+    it(
+      'should not parse an equality statement',
+      shouldNotParse(parser, '<a> = <b>.', 'Unexpected "=" on line 1.')
+    );
 
-    it('should not parse a right implication statement',
-      shouldNotParse(parser, '<a> => <b>.', 'Unexpected "=>" on line 1.'));
+    it(
+      'should not parse a right implication statement',
+      shouldNotParse(parser, '<a> => <b>.', 'Unexpected "=>" on line 1.')
+    );
 
-    it('should not parse a left implication statement',
-      shouldNotParse(parser, '<a> <= <b>.', 'Unexpected "<=" on line 1.'));
+    it(
+      'should not parse a left implication statement',
+      shouldNotParse(parser, '<a> <= <b>.', 'Unexpected "<=" on line 1.')
+    );
 
-    it('should not parse a formula as object',
-      shouldNotParse(parser, '<a> <b> {}.', 'Unexpected graph on line 1.'));
+    it(
+      'should not parse a formula as object',
+      shouldNotParse(parser, '<a> <b> {}.', 'Unexpected graph on line 1.')
+    );
 
-    it('should not parse @forSome',
-      shouldNotParse(parser, '@forSome <x>.', 'Unexpected "@forSome" on line 1.'));
+    it(
+      'should not parse @forSome',
+      shouldNotParse(parser, '@forSome <x>.', 'Unexpected "@forSome" on line 1.')
+    );
 
-    it('should not parse @forAll',
-      shouldNotParse(parser, '@forAll <x>.', 'Unexpected "@forAll" on line 1.'));
+    it(
+      'should not parse @forAll',
+      shouldNotParse(parser, '@forAll <x>.', 'Unexpected "@forAll" on line 1.')
+    );
 
-    it('should not parse a formula as list item',
+    it(
+      'should not parse a formula as list item',
       shouldNotParse(parser, '( <a> { <b> <c> <d> } <e> ).',
-        'Unexpected graph on line 1.'));
+        'Unexpected graph on line 1.')
+    );
 
-    it('should not parse a literal as subject',
+    it(
+      'should not parse a literal as subject',
       shouldNotParse(parser, '1 <a> <b>.',
-        'Unexpected literal on line 1.'));
+        'Unexpected literal on line 1.')
+    );
 
-    it('should not parse RDF* in the subject position',
+    it(
+      'should not parse RDF* in the subject position',
       shouldNotParse(parser, '<<<a> <b> <c>>> <a> <b> .',
-        'Unexpected RDF* syntax on line 1.'));
+        'Unexpected RDF* syntax on line 1.')
+    );
 
-    it('should not parse RDF* in the object position',
+    it(
+      'should not parse RDF* in the object position',
       shouldNotParse(parser, '<a> <b> <<a> <b> <c>>>.',
-        'Unexpected RDF* syntax on line 1.'));
+        'Unexpected RDF* syntax on line 1.')
+    );
 
-    it('should not parse RDF* with annotated syntax',
-        shouldNotParse(parser, '<a> <b> <c> {| <b> <c> |}.',
-            'Unexpected RDF* syntax on line 1.'));
+    it(
+      'should not parse RDF* with annotated syntax',
+      shouldNotParse(parser, '<a> <b> <c> {| <b> <c> |}.',
+          'Unexpected RDF* syntax on line 1.')
+    );
   });
 
   describe('A Parser instance for the TurtleStar format', () => {
     function parser() { return new Parser({ baseIRI: BASE_IRI, format: 'TurtleStar' }); }
 
-    it('should parse RDF*',
-      shouldParse(parser,
-        '<<<a> <b> <c>>> <b> <c> .',
-        [['a', 'b', 'c'], 'b', 'c']));
+    it('should parse RDF*', shouldParse(parser,
+      '<<<a> <b> <c>>> <b> <c> .',
+      [['a', 'b', 'c'], 'b', 'c']));
 
-    it('should not parse nested quads',
+    it(
+      'should not parse nested quads',
       shouldNotParse(parser, '<<_:a <http://ex.org/b> _:b <http://ex.org/b>>> <http://ex.org/b> "c" .',
-        'Expected >> to follow "_:b0_b" on line 1.'));
+        'Expected >> to follow "_:b0_b" on line 1.')
+    );
   });
 
   describe('A Parser instance for the TriG format', () => {
     function parser() { return new Parser({ baseIRI: BASE_IRI, format: 'TriG' }); }
 
-    it('should parse a single triple',
-      shouldParse(parser, '<a> <b> <c>.', ['a', 'b', 'c']));
+    it(
+      'should parse a single triple',
+      shouldParse(parser, '<a> <b> <c>.', ['a', 'b', 'c'])
+    );
 
-    it('should parse a default graph',
-      shouldParse(parser, '{}'));
+    it('should parse a default graph', shouldParse(parser, '{}'));
 
-    it('should parse a named graph',
-      shouldParse(parser, '<g> {}'));
+    it('should parse a named graph', shouldParse(parser, '<g> {}'));
 
-    it('should parse a named graph with the GRAPH keyword',
-      shouldParse(parser, 'GRAPH <g> {}'));
+    it(
+      'should parse a named graph with the GRAPH keyword',
+      shouldParse(parser, 'GRAPH <g> {}')
+    );
 
-    it('should not parse a quad',
-      shouldNotParse(parser, '<a> <b> <c> <d>.', 'Expected punctuation to follow "http://example.org/c" on line 1.'));
+    it(
+      'should not parse a quad',
+      shouldNotParse(parser, '<a> <b> <c> <d>.', 'Expected punctuation to follow "http://example.org/c" on line 1.')
+    );
 
-    it('should not parse a variable',
-      shouldNotParse(parser, '?a ?b ?c.', 'Unexpected "?a" on line 1.'));
+    it(
+      'should not parse a variable',
+      shouldNotParse(parser, '?a ?b ?c.', 'Unexpected "?a" on line 1.')
+    );
 
-    it('should not parse an equality statement',
-      shouldNotParse(parser, '<a> = <b>.', 'Unexpected "=" on line 1.'));
+    it(
+      'should not parse an equality statement',
+      shouldNotParse(parser, '<a> = <b>.', 'Unexpected "=" on line 1.')
+    );
 
-    it('should not parse a right implication statement',
-      shouldNotParse(parser, '<a> => <b>.', 'Unexpected "=>" on line 1.'));
+    it(
+      'should not parse a right implication statement',
+      shouldNotParse(parser, '<a> => <b>.', 'Unexpected "=>" on line 1.')
+    );
 
-    it('should not parse a left implication statement',
-      shouldNotParse(parser, '<a> <= <b>.', 'Unexpected "<=" on line 1.'));
+    it(
+      'should not parse a left implication statement',
+      shouldNotParse(parser, '<a> <= <b>.', 'Unexpected "<=" on line 1.')
+    );
 
-    it('should not parse a formula as object',
-      shouldNotParse(parser, '<a> <b> {}.', 'Unexpected graph on line 1.'));
+    it(
+      'should not parse a formula as object',
+      shouldNotParse(parser, '<a> <b> {}.', 'Unexpected graph on line 1.')
+    );
 
-    it('should not parse @forSome',
-      shouldNotParse(parser, '@forSome <x>.', 'Unexpected "@forSome" on line 1.'));
+    it(
+      'should not parse @forSome',
+      shouldNotParse(parser, '@forSome <x>.', 'Unexpected "@forSome" on line 1.')
+    );
 
-    it('should not parse @forAll',
-      shouldNotParse(parser, '@forAll <x>.', 'Unexpected "@forAll" on line 1.'));
+    it(
+      'should not parse @forAll',
+      shouldNotParse(parser, '@forAll <x>.', 'Unexpected "@forAll" on line 1.')
+    );
 
-    it('should not parse RDF* in the subject position',
+    it(
+      'should not parse RDF* in the subject position',
       shouldNotParse(parser, '<<<a> <b> <c>>> <a> <b> .',
-        'Unexpected RDF* syntax on line 1.'));
+        'Unexpected RDF* syntax on line 1.')
+    );
 
-    it('should not parse RDF* in the object position',
+    it(
+      'should not parse RDF* in the object position',
       shouldNotParse(parser, '<a> <b> <<<a> <b> <c>>>.',
-        'Unexpected RDF* syntax on line 1.'));
+        'Unexpected RDF* syntax on line 1.')
+    );
 
-    it('should not parse RDF* with annotated syntax',
-        shouldNotParse(parser, '<a> <b> <c> {| <b> <c> |}.',
-            'Unexpected RDF* syntax on line 1.'));
+    it(
+      'should not parse RDF* with annotated syntax',
+      shouldNotParse(parser, '<a> <b> <c> {| <b> <c> |}.',
+          'Unexpected RDF* syntax on line 1.')
+    );
   });
 
   describe('A Parser instance for the TriGStar format', () => {
     function parser() { return new Parser({ baseIRI: BASE_IRI, format: 'TriGStar' }); }
 
-    it('should parse RDF*',
-      shouldParse(parser, '<<<a> <b> <c>>> <a> <b> .',
-        [['a', 'b', 'c'], 'a', 'b']));
+    it('should parse RDF*', shouldParse(parser, '<<<a> <b> <c>>> <a> <b> .',
+      [['a', 'b', 'c'], 'a', 'b']));
 
-    it('should not parse nested quads',
+    it(
+      'should not parse nested quads',
       shouldNotParse(parser, '<<_:a <http://ex.org/b> _:b <http://ex.org/b>>> <http://ex.org/b> "c" .',
-        'Expected >> to follow "_:b0_b" on line 1.'));
+        'Expected >> to follow "_:b0_b" on line 1.')
+    );
   });
 
   describe('A Parser instance for the N-Triples format', () => {
     function parser() { return new Parser({ baseIRI: BASE_IRI, format: 'N-Triples' }); }
 
-    it('should parse a single triple',
+    it(
+      'should parse a single triple',
       shouldParse(parser, '_:a <http://ex.org/b> "c".',
-                          ['_:b0_a', 'http://ex.org/b', '"c"']));
+                          ['_:b0_a', 'http://ex.org/b', '"c"'])
+    );
 
-    it('should parse a single triple starting with Bom',
-        shouldParse(parser, '\ufeff_:a <http://ex.org/b> "c".',
-            ['_:b0_a', 'http://ex.org/b', '"c"']));
+    it(
+      'should parse a single triple starting with Bom',
+      shouldParse(parser, '\ufeff_:a <http://ex.org/b> "c".',
+          ['_:b0_a', 'http://ex.org/b', '"c"'])
+    );
 
-    it('should not parse a single quad',
+    it(
+      'should not parse a single quad',
       shouldNotParse(parser, '_:a <http://ex.org/b> "c" <http://ex.org/g>.',
-                             'Expected punctuation to follow ""c"" on line 1.'));
+                             'Expected punctuation to follow ""c"" on line 1.')
+    );
 
-    it('should not parse object lists',
-        shouldNotParse(parser, '<http://example/s> <http://example/p> <http://example/o>, <http://example/o2> .',
-            'Unexpected "," on line 1.'));
+    it(
+      'should not parse object lists',
+      shouldNotParse(parser, '<http://example/s> <http://example/p> <http://example/o>, <http://example/o2> .',
+          'Unexpected "," on line 1.')
+    );
 
-    it('should not parse relative IRIs',
-      shouldNotParse(parser, '<a> <b> <c>.', 'Invalid IRI on line 1.'));
+    it(
+      'should not parse relative IRIs',
+      shouldNotParse(parser, '<a> <b> <c>.', 'Invalid IRI on line 1.')
+    );
 
-    it('should not parse a prefix declaration',
-      shouldNotParse(parser, '@prefix : <p#>.', 'Unexpected "@prefix" on line 1.'));
+    it(
+      'should not parse a prefix declaration',
+      shouldNotParse(parser, '@prefix : <p#>.', 'Unexpected "@prefix" on line 1.')
+    );
 
-    it('should not parse apostrophe literals',
+    it(
+      'should not parse apostrophe literals',
       shouldNotParse(parser, "_:a <http://ex.org/b> 'c'.",
-                             "Unexpected \"'c'.\" on line 1."));
+                             "Unexpected \"'c'.\" on line 1.")
+    );
 
-    it('should not parse triple-quoted literals',
+    it(
+      'should not parse triple-quoted literals',
       shouldNotParse(parser, '_:a <http://ex.org/b> """c""".',
-                             'Unexpected """"c"""." on line 1.'));
+                             'Unexpected """"c"""." on line 1.')
+    );
 
-    it('should not parse triple-apostrophe literals',
+    it(
+      'should not parse triple-apostrophe literals',
       shouldNotParse(parser, "_:a <http://ex.org/b> '''c'''.",
-                             "Unexpected \"'''c'''.\" on line 1."));
+                             "Unexpected \"'''c'''.\" on line 1.")
+    );
 
-    it('should not parse a variable',
-      shouldNotParse(parser, '?a ?b ?c.', 'Unexpected "?a" on line 1.'));
+    it(
+      'should not parse a variable',
+      shouldNotParse(parser, '?a ?b ?c.', 'Unexpected "?a" on line 1.')
+    );
 
-    it('should not parse an equality statement',
-      shouldNotParse(parser, '<urn:a:a> = <urn:b:b>.', 'Unexpected "=" on line 1.'));
+    it(
+      'should not parse an equality statement',
+      shouldNotParse(parser, '<urn:a:a> = <urn:b:b>.', 'Unexpected "=" on line 1.')
+    );
 
-    it('should not parse a right implication statement',
-      shouldNotParse(parser, '<urn:a:a> => <urn:b:b>.', 'Unexpected "=>" on line 1.'));
+    it(
+      'should not parse a right implication statement',
+      shouldNotParse(parser, '<urn:a:a> => <urn:b:b>.', 'Unexpected "=>" on line 1.')
+    );
 
-    it('should not parse a left implication statement',
-      shouldNotParse(parser, '<urn:a:a> <= <urn:b:b>.', 'Unexpected "<=" on line 1.'));
+    it(
+      'should not parse a left implication statement',
+      shouldNotParse(parser, '<urn:a:a> <= <urn:b:b>.', 'Unexpected "<=" on line 1.')
+    );
 
-    it('should not parse a formula as object',
-      shouldNotParse(parser, '<urn:a:a> <urn:b:b> {}.', 'Unexpected "{}." on line 1.'));
+    it(
+      'should not parse a formula as object',
+      shouldNotParse(parser, '<urn:a:a> <urn:b:b> {}.', 'Unexpected "{}." on line 1.')
+    );
 
-    it('should not parse @forSome',
-      shouldNotParse(parser, '@forSome <x>.', 'Unexpected "@forSome" on line 1.'));
+    it(
+      'should not parse @forSome',
+      shouldNotParse(parser, '@forSome <x>.', 'Unexpected "@forSome" on line 1.')
+    );
 
-    it('should not parse @forAll',
-      shouldNotParse(parser, '@forAll <x>.', 'Unexpected "@forAll" on line 1.'));
+    it(
+      'should not parse @forAll',
+      shouldNotParse(parser, '@forAll <x>.', 'Unexpected "@forAll" on line 1.')
+    );
 
-    it('should not parse RDF* in the subject position',
+    it(
+      'should not parse RDF* in the subject position',
       shouldNotParse(parser, '<<<a> <b> <c>>> <a> <b> .',
-        'Unexpected RDF* syntax on line 1.'));
+        'Unexpected RDF* syntax on line 1.')
+    );
 
-    it('should not parse RDF* in the object position',
+    it(
+      'should not parse RDF* in the object position',
       shouldNotParse(parser, '<http://ex.org/a> <http://ex.org/b> <<<a> <b> <c>>>.',
-        'Unexpected RDF* syntax on line 1.'));
+        'Unexpected RDF* syntax on line 1.')
+    );
   });
 
   describe('A Parser instance for the N-TriplesStar format', () => {
     function parser() { return new Parser({ baseIRI: BASE_IRI, format: 'N-TriplesStar' }); }
 
-    it('should parse RDF*',
+    it(
+      'should parse RDF*',
       shouldParse(parser, '<<_:a <http://example.org/b> _:c>> <http://example.org/a> _:b .',
-        [['_:b0_a', 'b', '_:b0_c'], 'a', '_:b0_b']));
+        [['_:b0_a', 'b', '_:b0_c'], 'a', '_:b0_b'])
+    );
 
-    it('should not parse nested quads',
+    it(
+      'should not parse nested quads',
       shouldNotParse(parser, '<<_:a <http://ex.org/b> _:b <http://ex.org/b>>> <http://ex.org/b> "c" .',
-        'Expected >> to follow "_:b0_b" on line 1.'));
+        'Expected >> to follow "_:b0_b" on line 1.')
+    );
 
-    it('should not parse annotated triples',
-        shouldNotParse(parser, '_:a <http://ex.org/b> _:c {| <http://ex.org/b1> "c1" |} .',
-            'Unexpected "{|" on line 1.'));
+    it(
+      'should not parse annotated triples',
+      shouldNotParse(parser, '_:a <http://ex.org/b> _:c {| <http://ex.org/b1> "c1" |} .',
+          'Unexpected "{|" on line 1.')
+    );
   });
 
   describe('A Parser instance for the N-Quads format', () => {
     function parser() { return new Parser({ baseIRI: BASE_IRI, format: 'N-Quads' }); }
 
-    it('should parse a single triple',
+    it(
+      'should parse a single triple',
       shouldParse(parser, '_:a <http://ex.org/b> "c".',
-                          ['_:b0_a', 'http://ex.org/b', '"c"']));
+                          ['_:b0_a', 'http://ex.org/b', '"c"'])
+    );
 
-    it('should parse a single quad',
+    it(
+      'should parse a single quad',
       shouldParse(parser, '_:a <http://ex.org/b> "c" <http://ex.org/g>.',
-                          ['_:b0_a', 'http://ex.org/b', '"c"', 'http://ex.org/g']));
+                          ['_:b0_a', 'http://ex.org/b', '"c"', 'http://ex.org/g'])
+    );
 
-    it('should not parse relative IRIs',
-      shouldNotParse(parser, '<a> <b> <c>.', 'Invalid IRI on line 1.'));
+    it(
+      'should not parse relative IRIs',
+      shouldNotParse(parser, '<a> <b> <c>.', 'Invalid IRI on line 1.')
+    );
 
-    it('should not parse a prefix declaration',
-      shouldNotParse(parser, '@prefix : <p#>.', 'Unexpected "@prefix" on line 1.'));
+    it(
+      'should not parse a prefix declaration',
+      shouldNotParse(parser, '@prefix : <p#>.', 'Unexpected "@prefix" on line 1.')
+    );
 
-    it('should not parse a variable',
-      shouldNotParse(parser, '?a ?b ?c.', 'Unexpected "?a" on line 1.'));
+    it(
+      'should not parse a variable',
+      shouldNotParse(parser, '?a ?b ?c.', 'Unexpected "?a" on line 1.')
+    );
 
-    it('should not parse an equality statement',
-      shouldNotParse(parser, '<urn:a:a> = <urn:b:b>.', 'Unexpected "=" on line 1.'));
+    it(
+      'should not parse an equality statement',
+      shouldNotParse(parser, '<urn:a:a> = <urn:b:b>.', 'Unexpected "=" on line 1.')
+    );
 
-    it('should not parse a right implication statement',
-      shouldNotParse(parser, '<urn:a:a> => <urn:b:b>.', 'Unexpected "=>" on line 1.'));
+    it(
+      'should not parse a right implication statement',
+      shouldNotParse(parser, '<urn:a:a> => <urn:b:b>.', 'Unexpected "=>" on line 1.')
+    );
 
-    it('should not parse a left implication statement',
-      shouldNotParse(parser, '<urn:a:a> <= <urn:b:b>.', 'Unexpected "<=" on line 1.'));
+    it(
+      'should not parse a left implication statement',
+      shouldNotParse(parser, '<urn:a:a> <= <urn:b:b>.', 'Unexpected "<=" on line 1.')
+    );
 
-    it('should not parse a formula as object',
-      shouldNotParse(parser, '<urn:a:a> <urn:b:b> {}.', 'Unexpected "{}." on line 1.'));
+    it(
+      'should not parse a formula as object',
+      shouldNotParse(parser, '<urn:a:a> <urn:b:b> {}.', 'Unexpected "{}." on line 1.')
+    );
 
-    it('should not parse @forSome',
-      shouldNotParse(parser, '@forSome <x>.', 'Unexpected "@forSome" on line 1.'));
+    it(
+      'should not parse @forSome',
+      shouldNotParse(parser, '@forSome <x>.', 'Unexpected "@forSome" on line 1.')
+    );
 
-    it('should not parse @forAll',
-      shouldNotParse(parser, '@forAll <x>.', 'Unexpected "@forAll" on line 1.'));
+    it(
+      'should not parse @forAll',
+      shouldNotParse(parser, '@forAll <x>.', 'Unexpected "@forAll" on line 1.')
+    );
 
-    it('should not parse RDF* in the subject position',
+    it(
+      'should not parse RDF* in the subject position',
       shouldNotParse(parser, '<<<a> <b> <c>>> <a> <b> .',
-        'Unexpected RDF* syntax on line 1.'));
+        'Unexpected RDF* syntax on line 1.')
+    );
 
-    it('should not parse RDF* in the object position',
+    it(
+      'should not parse RDF* in the object position',
       shouldNotParse(parser, '_:a <http://ex.org/b> <<<a> <b> <c>>>.',
-        'Unexpected RDF* syntax on line 1.'));
+        'Unexpected RDF* syntax on line 1.')
+    );
   });
 
   describe('A Parser instance for the N-QuadsStar format', () => {
     function parser() { return new Parser({ baseIRI: BASE_IRI, format: 'N-QuadsStar' }); }
 
-    it('should parse RDF*',
+    it(
+      'should parse RDF*',
       shouldParse(parser, '<<_:a <http://example.org/b> _:c>> <http://example.org/a> _:c .',
-        [['_:b0_a', 'b', '_:b0_c'], 'a', '_:b0_c']));
+        [['_:b0_a', 'b', '_:b0_c'], 'a', '_:b0_c'])
+    );
 
-    it('should not parse annotated triples',
-        shouldNotParse(parser, '_:a <http://ex.org/b> _:c {| <http://ex.org/b1> "c1" |} .',
-            'Unexpected "{|" on line 1.'));
+    it(
+      'should not parse annotated triples',
+      shouldNotParse(parser, '_:a <http://ex.org/b> _:c {| <http://ex.org/b1> "c1" |} .',
+          'Unexpected "{|" on line 1.')
+    );
   });
 
   describe('A Parser instance for the N3 format', () => {
     function parser() { return new Parser({ baseIRI: BASE_IRI, format: 'N3' }); }
 
-    it('should parse a single triple',
-      shouldParse(parser, '<a> <b> <c>.', ['a', 'b', 'c']));
+    it(
+      'should parse a single triple',
+      shouldParse(parser, '<a> <b> <c>.', ['a', 'b', 'c'])
+    );
 
-    it('should not parse a default graph',
-      shouldNotParse(parser, '{}', 'Expected entity but got eof on line 1.'));
+    it(
+      'should not parse a default graph',
+      shouldNotParse(parser, '{}', 'Expected entity but got eof on line 1.')
+    );
 
-    it('should not parse a named graph',
-      shouldNotParse(parser, '<g> {}', 'Expected entity but got { on line 1.'));
+    it(
+      'should not parse a named graph',
+      shouldNotParse(parser, '<g> {}', 'Expected entity but got { on line 1.')
+    );
 
-    it('should not parse a named graph with the GRAPH keyword',
-      shouldNotParse(parser, 'GRAPH <g> {}', 'Expected entity but got GRAPH on line 1.'));
+    it(
+      'should not parse a named graph with the GRAPH keyword',
+      shouldNotParse(parser, 'GRAPH <g> {}', 'Expected entity but got GRAPH on line 1.')
+    );
 
-    it('should not parse a quad',
-      shouldNotParse(parser, '<a> <b> <c> <d>.', 'Expected punctuation to follow "http://example.org/c" on line 1.'));
+    it(
+      'should not parse a quad',
+      shouldNotParse(parser, '<a> <b> <c> <d>.', 'Expected punctuation to follow "http://example.org/c" on line 1.')
+    );
 
-    it('allows a blank node in predicate position',
-      shouldParse(parser, '<a> [] <c>.', ['a', '_:b0', 'c']));
+    it(
+      'allows a blank node in predicate position',
+      shouldParse(parser, '<a> [] <c>.', ['a', '_:b0', 'c'])
+    );
 
-    it('allows a blank node label in predicate position',
-      shouldParse(parser, '<a> _:b <c>.', ['a', '_:b0_b', 'c']));
+    it(
+      'allows a blank node label in predicate position',
+      shouldParse(parser, '<a> _:b <c>.', ['a', '_:b0_b', 'c'])
+    );
 
-    it('allows a blank node with properties in predicate position',
+    it(
+      'allows a blank node with properties in predicate position',
       shouldParse(parser, '<a> [<p> <o>] <c>.',
                   ['a', '_:b0', 'c'],
-                  ['_:b0', 'p', 'o']));
+                  ['_:b0', 'p', 'o'])
+    );
 
-    it('should parse a variable',
-      shouldParse(parser, '?a ?b ?c.', ['?a', '?b', '?c']));
+    it(
+      'should parse a variable',
+      shouldParse(parser, '?a ?b ?c.', ['?a', '?b', '?c'])
+    );
 
-    it('should parse a simple equality',
-      shouldParse(parser, '<a> = <b>.',
-                  ['a', 'http://www.w3.org/2002/07/owl#sameAs', 'b']));
+    it('should parse a simple equality', shouldParse(parser, '<a> = <b>.',
+                ['a', 'http://www.w3.org/2002/07/owl#sameAs', 'b']));
 
-    it('should parse a simple right implication',
+    it(
+      'should parse a simple right implication',
       shouldParse(parser, '<a> => <b>.',
-                  ['a', 'http://www.w3.org/2000/10/swap/log#implies', 'b']));
+                  ['a', 'http://www.w3.org/2000/10/swap/log#implies', 'b'])
+    );
 
-    it('should parse a simple left implication',
+    it(
+      'should parse a simple left implication',
       shouldParse(parser, '<a> <= <b>.',
-                  ['b', 'http://www.w3.org/2000/10/swap/log#implies', 'a']));
+                  ['b', 'http://www.w3.org/2000/10/swap/log#implies', 'a'])
+    );
 
-    it('should parse a right implication between one-triple graphs',
+    it(
+      'should parse a right implication between one-triple graphs',
       shouldParse(parser, '{ ?a ?b <c>. } => { <d> <e> ?a }.',
                   ['_:b0', 'http://www.w3.org/2000/10/swap/log#implies', '_:b1'],
                   ['?a', '?b', 'c',  '_:b0'],
-                  ['d',  'e',  '?a', '_:b1']));
+                  ['d',  'e',  '?a', '_:b1'])
+    );
 
-    it('should parse a right implication between two-triple graphs',
+    it(
+      'should parse a right implication between two-triple graphs',
       shouldParse(parser, '{ ?a ?b <c>. <d> <e> <f>. } => { <d> <e> ?a, <f> }.',
                   ['_:b0', 'http://www.w3.org/2000/10/swap/log#implies', '_:b1'],
                   ['?a', '?b', 'c',  '_:b0'],
                   ['d',  'e',  'f',  '_:b0'],
                   ['d',  'e',  '?a', '_:b1'],
-                  ['d',  'e',  'f',  '_:b1']));
+                  ['d',  'e',  'f',  '_:b1'])
+    );
 
-    it('should parse a left implication between one-triple graphs',
+    it(
+      'should parse a left implication between one-triple graphs',
       shouldParse(parser, '{ ?a ?b <c>. } <= { <d> <e> ?a }.',
                   ['_:b1', 'http://www.w3.org/2000/10/swap/log#implies', '_:b0'],
                   ['?a', '?b', 'c',  '_:b0'],
-                  ['d',  'e',  '?a', '_:b1']));
+                  ['d',  'e',  '?a', '_:b1'])
+    );
 
-    it('should parse a left implication between two-triple graphs',
+    it(
+      'should parse a left implication between two-triple graphs',
       shouldParse(parser, '{ ?a ?b <c>. <d> <e> <f>. } <= { <d> <e> ?a, <f> }.',
                   ['_:b1', 'http://www.w3.org/2000/10/swap/log#implies', '_:b0'],
                   ['?a', '?b', 'c',  '_:b0'],
                   ['d',  'e',  'f',  '_:b0'],
                   ['d',  'e',  '?a', '_:b1'],
-                  ['d',  'e',  'f',  '_:b1']));
+                  ['d',  'e',  'f',  '_:b1'])
+    );
 
-    it('should parse an equality of one-triple graphs',
+    it(
+      'should parse an equality of one-triple graphs',
       shouldParse(parser, '{ ?a ?b <c>. } = { <d> <e> ?a }.',
                   ['_:b0', 'http://www.w3.org/2002/07/owl#sameAs', '_:b1'],
                   ['?a', '?b', 'c',  '_:b0'],
-                  ['d',  'e',  '?a', '_:b1']));
+                  ['d',  'e',  '?a', '_:b1'])
+    );
 
-    it('should parse an equality of two-triple graphs',
+    it(
+      'should parse an equality of two-triple graphs',
       shouldParse(parser, '{ ?a ?b <c>. <d> <e> <f>. } = { <d> <e> ?a, <f> }.',
                   ['_:b0', 'http://www.w3.org/2002/07/owl#sameAs', '_:b1'],
                   ['?a', '?b', 'c',  '_:b0'],
                   ['d',  'e',  'f',  '_:b0'],
                   ['d',  'e',  '?a', '_:b1'],
-                  ['d',  'e',  'f',  '_:b1']));
+                  ['d',  'e',  'f',  '_:b1'])
+    );
 
-    it('should parse nested implication graphs',
+    it(
+      'should parse nested implication graphs',
       shouldParse(parser, '{ { ?a ?b ?c }<={ ?d ?e ?f }. } <= { { ?g ?h ?i } => { ?j ?k ?l } }.',
                   ['_:b3', 'http://www.w3.org/2000/10/swap/log#implies', '_:b0'],
                   ['_:b2', 'http://www.w3.org/2000/10/swap/log#implies', '_:b1', '_:b0'],
@@ -1586,168 +2065,224 @@ describe('Parser', () => {
                   ['?d', '?e', '?f', '_:b2'],
                   ['_:b4', 'http://www.w3.org/2000/10/swap/log#implies', '_:b5', '_:b3'],
                   ['?g', '?h', '?i', '_:b4'],
-                  ['?j', '?k', '?l', '_:b5']));
+                  ['?j', '?k', '?l', '_:b5'])
+    );
 
-    it('should not reuse identifiers of blank nodes within and outside of formulas',
+    it(
+      'should not reuse identifiers of blank nodes within and outside of formulas',
       shouldParse(parser, '_:a _:b _:c. { _:a _:b _:c } => { { _:a _:b _:c } => { _:a _:b _:c } }.',
                   ['_:b0_a', '_:b0_b', '_:b0_c'],
                   ['_:b0', 'http://www.w3.org/2000/10/swap/log#implies', '_:b1', ''],
                   ['_:b0.a', '_:b0.b', '_:b0.c', '_:b0'],
                   ['_:b2', 'http://www.w3.org/2000/10/swap/log#implies', '_:b3', '_:b1'],
                   ['_:b2.a', '_:b2.b', '_:b2.c', '_:b2'],
-                  ['_:b3.a', '_:b3.b', '_:b3.c', '_:b3']));
+                  ['_:b3.a', '_:b3.b', '_:b3.c', '_:b3'])
+    );
 
-    it('should parse a @forSome statement',
+    it(
+      'should parse a @forSome statement',
       shouldParse(parser, '@forSome <x>. <x> <x> <x>.',
-                  ['_:b0', '_:b0', '_:b0']));
+                  ['_:b0', '_:b0', '_:b0'])
+    );
 
-    it('should parse a @forSome statement with multiple entities',
+    it(
+      'should parse a @forSome statement with multiple entities',
       shouldParse(parser, '@prefix a: <a:>. @base <b:>. @forSome a:x, <y>, a:z. a:x <y> a:z.',
-                  ['_:b0', '_:b1', '_:b2']));
+                  ['_:b0', '_:b1', '_:b2'])
+    );
 
-    it('should not parse a @forSome statement with an invalid prefix',
+    it(
+      'should not parse a @forSome statement with an invalid prefix',
       shouldNotParse(parser, '@forSome a:b.',
-                     'Undefined prefix "a:" on line 1.'));
+                     'Undefined prefix "a:" on line 1.')
+    );
 
-    it('should not parse a @forSome statement with a blank node',
+    it(
+      'should not parse a @forSome statement with a blank node',
       shouldNotParse(parser, '@forSome _:a.',
-                     'Unexpected blank on line 1.'));
+                     'Unexpected blank on line 1.')
+    );
 
-    it('should not parse a @forSome statement with a variable',
+    it(
+      'should not parse a @forSome statement with a variable',
       shouldNotParse(parser, '@forSome ?a.',
-                     'Unexpected var on line 1.'));
+                     'Unexpected var on line 1.')
+    );
 
-    it('should correctly scope @forSome statements',
+    it(
+      'should correctly scope @forSome statements',
       shouldParse(parser, '@forSome <x>. <x> <x> { @forSome <x>. <x> <x> <x>. }. <x> <x> <x>.',
                   ['_:b0', '_:b0', '_:b1'],
                   ['_:b2', '_:b2', '_:b2', '_:b1'],
-                  ['_:b0', '_:b0', '_:b0']));
+                  ['_:b0', '_:b0', '_:b0'])
+    );
 
-    it('should parse a @forAll statement',
+    it(
+      'should parse a @forAll statement',
       shouldParse(parser, '@forAll  <x>. <x> <x> <x>.',
-                  ['?b0', '?b0', '?b0']));
+                  ['?b0', '?b0', '?b0'])
+    );
 
-    it('should parse a @forAll statement with multiple entities',
+    it(
+      'should parse a @forAll statement with multiple entities',
       shouldParse(parser, '@prefix a: <a:>. @base <b:>. @forAll  a:x, <y>, a:z. a:x <y> a:z.',
-                  ['?b0', '?b1', '?b2']));
+                  ['?b0', '?b1', '?b2'])
+    );
 
-    it('should not parse a @forAll statement with an invalid prefix',
+    it(
+      'should not parse a @forAll statement with an invalid prefix',
       shouldNotParse(parser, '@forAll a:b.',
-                     'Undefined prefix "a:" on line 1.'));
+                     'Undefined prefix "a:" on line 1.')
+    );
 
-    it('should not parse a @forAll statement with a blank node',
+    it(
+      'should not parse a @forAll statement with a blank node',
       shouldNotParse(parser, '@forAll _:a.',
-                     'Unexpected blank on line 1.'));
+                     'Unexpected blank on line 1.')
+    );
 
-    it('should not parse a @forAll statement with a variable',
+    it(
+      'should not parse a @forAll statement with a variable',
       shouldNotParse(parser, '@forAll ?a.',
-                     'Unexpected var on line 1.'));
+                     'Unexpected var on line 1.')
+    );
 
-    it('should correctly scope @forAll statements',
+    it(
+      'should correctly scope @forAll statements',
       shouldParse(parser, '@forAll <x>. <x> <x> { @forAll <x>. <x> <x> <x>. }. <x> <x> <x>.',
                   ['?b0', '?b0', '_:b1'],
                   ['?b2', '?b2', '?b2', '_:b1'],
-                  ['?b0', '?b0', '?b0']));
+                  ['?b0', '?b0', '?b0'])
+    );
 
-    it('should parse a ! path of length 2 as subject',
+    it(
+      'should parse a ! path of length 2 as subject',
       shouldParse(parser, '@prefix : <ex:>. @prefix fam: <f:>.' +
                           ':joe!fam:mother a fam:Person.',
                   ['ex:joe', 'f:mother', '_:b0'],
-                  ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'f:Person']));
+                  ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'f:Person'])
+    );
 
-    it('should parse a ! path of length 4 as subject',
+    it(
+      'should parse a ! path of length 4 as subject',
       shouldParse(parser, '@prefix : <ex:>. @prefix fam: <f:>. @prefix loc: <l:>.' +
                           ':joe!fam:mother!loc:office!loc:zip loc:code 1234.',
                   ['ex:joe', 'f:mother', '_:b0'],
                   ['_:b0',   'l:office', '_:b1'],
                   ['_:b1',   'l:zip',    '_:b2'],
-                  ['_:b2',   'l:code',   '"1234"^^http://www.w3.org/2001/XMLSchema#integer']));
+                  ['_:b2',   'l:code',   '"1234"^^http://www.w3.org/2001/XMLSchema#integer'])
+    );
 
-    it('should parse a ! path of length 2 as object',
+    it(
+      'should parse a ! path of length 2 as object',
       shouldParse(parser, '@prefix : <ex:>. @prefix fam: <f:>.' +
                           '<x> <is> :joe!fam:mother.',
                   ['x', 'is', '_:b0'],
-                  ['ex:joe', 'f:mother', '_:b0']));
+                  ['ex:joe', 'f:mother', '_:b0'])
+    );
 
-    it('should parse a ! path of length 4 as object',
+    it(
+      'should parse a ! path of length 4 as object',
       shouldParse(parser, '@prefix : <ex:>. @prefix fam: <f:>. @prefix loc: <l:>.' +
                           '<x> <is> :joe!fam:mother!loc:office!loc:zip.',
                   ['x',      'is',       '_:b2'],
                   ['ex:joe', 'f:mother', '_:b0'],
                   ['_:b0',   'l:office', '_:b1'],
-                  ['_:b1',   'l:zip',    '_:b2']));
+                  ['_:b1',   'l:zip',    '_:b2'])
+    );
 
-    it('should parse a ^ path of length 2 as subject',
+    it(
+      'should parse a ^ path of length 2 as subject',
       shouldParse(parser, '@prefix : <ex:>. @prefix fam: <f:>.' +
                           ':joe^fam:son a fam:Person.',
                   ['_:b0', 'f:son', 'ex:joe'],
-                  ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'f:Person']));
+                  ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'f:Person'])
+    );
 
-    it('should parse a ^ path of length 4 as subject',
+    it(
+      'should parse a ^ path of length 4 as subject',
       shouldParse(parser, '@prefix : <ex:>. @prefix fam: <f:>.' +
                           ':joe^fam:son^fam:sister^fam:mother a fam:Person.',
                   ['_:b0', 'f:son',    'ex:joe'],
                   ['_:b1', 'f:sister', '_:b0'],
                   ['_:b2', 'f:mother', '_:b1'],
-                  ['_:b2', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'f:Person']));
+                  ['_:b2', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'f:Person'])
+    );
 
-    it('should parse a ^ path of length 2 as object',
+    it(
+      'should parse a ^ path of length 2 as object',
       shouldParse(parser, '@prefix : <ex:>. @prefix fam: <f:>.' +
                           '<x> <is> :joe^fam:son.',
                   ['x',    'is',    '_:b0'],
-                  ['_:b0', 'f:son', 'ex:joe']));
+                  ['_:b0', 'f:son', 'ex:joe'])
+    );
 
-    it('should parse a ^ path of length 4 as object',
+    it(
+      'should parse a ^ path of length 4 as object',
       shouldParse(parser, '@prefix : <ex:>. @prefix fam: <f:>.' +
                           '<x> <is> :joe^fam:son^fam:sister^fam:mother.',
                   ['x',    'is',       '_:b2'],
                   ['_:b0', 'f:son',    'ex:joe'],
                   ['_:b1', 'f:sister', '_:b0'],
-                  ['_:b2', 'f:mother', '_:b1']));
+                  ['_:b2', 'f:mother', '_:b1'])
+    );
 
-    it('should parse mixed !/^ paths as subject',
+    it(
+      'should parse mixed !/^ paths as subject',
       shouldParse(parser, '@prefix : <ex:>. @prefix fam: <f:>.' +
                           ':joe!fam:mother^fam:mother a fam:Person.',
                   ['ex:joe', 'f:mother', '_:b0'],
                   ['_:b1',   'f:mother', '_:b0'],
-                  ['_:b1', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'f:Person']));
+                  ['_:b1', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'f:Person'])
+    );
 
-    it('should parse mixed !/^ paths as object',
+    it(
+      'should parse mixed !/^ paths as object',
       shouldParse(parser, '@prefix : <ex:>. @prefix fam: <f:>.' +
                           '<x> <is> :joe!fam:mother^fam:mother.',
                   ['x', 'is', '_:b1'],
                   ['ex:joe', 'f:mother', '_:b0'],
-                  ['_:b1',   'f:mother', '_:b0']));
+                  ['_:b1',   'f:mother', '_:b0'])
+    );
 
-    it('should parse a ! path in a blank node as subject',
+    it(
+      'should parse a ! path in a blank node as subject',
       shouldParse(parser, '@prefix : <ex:>. @prefix fam: <f:>.' +
                           '[fam:knows :joe!fam:mother] a fam:Person.',
                   ['_:b0', 'f:knows', '_:b1'],
                   ['ex:joe', 'f:mother', '_:b1'],
-                  ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'f:Person']));
+                  ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'f:Person'])
+    );
 
-    it('should parse a ! path in a blank node as object',
+    it(
+      'should parse a ! path in a blank node as object',
       shouldParse(parser, '@prefix : <ex:>. @prefix fam: <f:>.' +
                           '<x> <is> [fam:knows :joe!fam:mother].',
                   ['x', 'is', '_:b0'],
                   ['_:b0', 'f:knows', '_:b1'],
-                  ['ex:joe', 'f:mother', '_:b1']));
+                  ['ex:joe', 'f:mother', '_:b1'])
+    );
 
-    it('should parse a ^ path in a blank node as subject',
+    it(
+      'should parse a ^ path in a blank node as subject',
       shouldParse(parser, '@prefix : <ex:>. @prefix fam: <f:>.' +
                           '[fam:knows :joe^fam:son] a fam:Person.',
                   ['_:b0', 'f:knows', '_:b1'],
                   ['_:b1', 'f:son', 'ex:joe'],
-                  ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'f:Person']));
+                  ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'f:Person'])
+    );
 
-    it('should parse a ^ path in a blank node as object',
+    it(
+      'should parse a ^ path in a blank node as object',
       shouldParse(parser, '@prefix : <ex:>. @prefix fam: <f:>.' +
                           '<x> <is> [fam:knows :joe^fam:son].',
                   ['x', 'is', '_:b0'],
                   ['_:b0', 'f:knows', '_:b1'],
-                  ['_:b1', 'f:son', 'ex:joe']));
+                  ['_:b1', 'f:son', 'ex:joe'])
+    );
 
-    it('should parse a ! path in a list as subject',
+    it(
+      'should parse a ! path in a list as subject',
       shouldParse(parser, '@prefix : <ex:>. @prefix fam: <f:>.' +
                           '(<x> :joe!fam:mother <y>) a :List.',
                   ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type',  'ex:List'],
@@ -1757,9 +2292,11 @@ describe('Parser', () => {
                   ['_:b1', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest',  '_:b3'],
                   ['_:b3', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', 'y'],
                   ['_:b3', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil'],
-                  ['ex:joe', 'f:mother', '_:b2']));
+                  ['ex:joe', 'f:mother', '_:b2'])
+    );
 
-    it('should parse a ! path in a list as object',
+    it(
+      'should parse a ! path in a list as object',
       shouldParse(parser, '@prefix : <ex:>. @prefix fam: <f:>.' +
                           '<l> <is> (<x> :joe!fam:mother <y>).',
                   ['l', 'is', '_:b0'],
@@ -1769,9 +2306,11 @@ describe('Parser', () => {
                   ['_:b1', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest',  '_:b3'],
                   ['_:b3', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', 'y'],
                   ['_:b3', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil'],
-                  ['ex:joe', 'f:mother', '_:b2']));
+                  ['ex:joe', 'f:mother', '_:b2'])
+    );
 
-    it('should parse a ^ path in a list as subject',
+    it(
+      'should parse a ^ path in a list as subject',
       shouldParse(parser, '@prefix : <ex:>. @prefix fam: <f:>.' +
                           '(<x> :joe^fam:son <y>) a :List.',
                   ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type',  'ex:List'],
@@ -1781,9 +2320,11 @@ describe('Parser', () => {
                   ['_:b1', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest',  '_:b3'],
                   ['_:b3', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', 'y'],
                   ['_:b3', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil'],
-                  ['_:b2', 'f:son', 'ex:joe']));
+                  ['_:b2', 'f:son', 'ex:joe'])
+    );
 
-    it('should parse a ^ path in a list as object',
+    it(
+      'should parse a ^ path in a list as object',
       shouldParse(parser, '@prefix : <ex:>. @prefix fam: <f:>.' +
                           '<l> <is> (<x> :joe^fam:son <y>).',
                   ['l', 'is', '_:b0'],
@@ -1793,79 +2334,102 @@ describe('Parser', () => {
                   ['_:b1', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest',  '_:b3'],
                   ['_:b3', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', 'y'],
                   ['_:b3', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil'],
-                  ['_:b2', 'f:son', 'ex:joe']));
+                  ['_:b2', 'f:son', 'ex:joe'])
+    );
 
-    it('should parse a formula as list item',
-        shouldParse(parser, '<a> <findAll> ( <b> { <b> a <type>. <b> <something> <foo> } <o> ).',
-        ['a', 'findAll', '_:b0'],
-        ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', 'b'],
-        ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', '_:b2'],
-        ['_:b2', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', 'o'],
-        ['_:b2', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil'],
-        ['b', 'something', 'foo', '_:b1'],
-        ['b', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'type', '_:b1']
-    ));
+    it(
+      'should parse a formula as list item',
+      shouldParse(parser, '<a> <findAll> ( <b> { <b> a <type>. <b> <something> <foo> } <o> ).',
+      ['a', 'findAll', '_:b0'],
+      ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', 'b'],
+      ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', '_:b2'],
+      ['_:b2', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', 'o'],
+      ['_:b2', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil'],
+      ['b', 'something', 'foo', '_:b1'],
+      ['b', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'type', '_:b1']
+  )
+    );
 
-    it('should not parse an invalid ! path',
-      shouldNotParse(parser, '<a>!"invalid" ', 'Expected entity but got literal on line 1.'));
+    it(
+      'should not parse an invalid ! path',
+      shouldNotParse(parser, '<a>!"invalid" ', 'Expected entity but got literal on line 1.')
+    );
 
-    it('should not parse an invalid ^ path',
-      shouldNotParse(parser, '<a>^"invalid" ', 'Expected entity but got literal on line 1.'));
+    it(
+      'should not parse an invalid ^ path',
+      shouldNotParse(parser, '<a>^"invalid" ', 'Expected entity but got literal on line 1.')
+    );
 
-    it('should parse literal as subject',
-        shouldParse(parser, '<a> <b> {1 <greaterThan> 0}.',
-            ['a', 'b', '_:b0'],
-            ['"1"^^http://www.w3.org/2001/XMLSchema#integer', 'greaterThan', '"0"^^http://www.w3.org/2001/XMLSchema#integer', '_:b0']
-        ));
+    it(
+      'should parse literal as subject',
+      shouldParse(parser, '<a> <b> {1 <greaterThan> 0}.',
+          ['a', 'b', '_:b0'],
+          ['"1"^^http://www.w3.org/2001/XMLSchema#integer', 'greaterThan', '"0"^^http://www.w3.org/2001/XMLSchema#integer', '_:b0']
+      )
+    );
 
-    it('should parse literals with datatype as subject',
-        shouldParse(parser, '<a> <b> {"a"^^<c> <greaterThan> "b"^^<c>}.',
-            ['a', 'b', '_:b0'],
-            ['"a"^^http://example.org/c', 'greaterThan', '"b"^^http://example.org/c', '_:b0']
-        ));
+    it(
+      'should parse literals with datatype as subject',
+      shouldParse(parser, '<a> <b> {"a"^^<c> <greaterThan> "b"^^<c>}.',
+          ['a', 'b', '_:b0'],
+          ['"a"^^http://example.org/c', 'greaterThan', '"b"^^http://example.org/c', '_:b0']
+      )
+    );
 
-    it('should parse literals with language as subject',
-        shouldParse(parser, '<a> <b> {"bonjour"@fr <sameAs> "hello"@en}.',
-            ['a', 'b', '_:b0'],
-            ['"bonjour"@fr', 'sameAs', '"hello"@en', '_:b0']
-        ));
+    it(
+      'should parse literals with language as subject',
+      shouldParse(parser, '<a> <b> {"bonjour"@fr <sameAs> "hello"@en}.',
+          ['a', 'b', '_:b0'],
+          ['"bonjour"@fr', 'sameAs', '"hello"@en', '_:b0']
+      )
+    );
 
-    it('should not parse RDF* in the subject position',
+    it(
+      'should not parse RDF* in the subject position',
       shouldNotParse(parser, '<<<a> <b> <c>>> <a> <b> .',
-        'Unexpected RDF* syntax on line 1.'));
+        'Unexpected RDF* syntax on line 1.')
+    );
 
-    it('should not parse RDF* in the object position',
+    it(
+      'should not parse RDF* in the object position',
       shouldNotParse(parser, '<a> <b> <<<a> <b> <c>>>.',
-        'Unexpected RDF* syntax on line 1.'));
+        'Unexpected RDF* syntax on line 1.')
+    );
 
-    it('should not parse RDF* with annotated syntax',
-        shouldNotParse(parser, '<a> <b> <c> {| <b> <c> |}.',
-            'Unexpected RDF* syntax on line 1.'));
+    it(
+      'should not parse RDF* with annotated syntax',
+      shouldNotParse(parser, '<a> <b> <c> {| <b> <c> |}.',
+          'Unexpected RDF* syntax on line 1.')
+    );
   });
 
   describe('A Parser instance for the N3Star format', () => {
     function parser() { return new Parser({ baseIRI: BASE_IRI, format: 'N3Star' }); }
 
-    it('should parse RDF*',
-      shouldParse(parser, '<<<a> <b> <c>>> <a> <b> .',
-        [['a', 'b', 'c'], 'a', 'b']));
+    it('should parse RDF*', shouldParse(parser, '<<<a> <b> <c>>> <a> <b> .',
+      [['a', 'b', 'c'], 'a', 'b']));
 
-    it('should not parse nested quads',
+    it(
+      'should not parse nested quads',
       shouldNotParse(parser, '<<_:a <http://ex.org/b> _:b <http://ex.org/b>>> <http://ex.org/b> "c" .',
-        'Expected >> to follow "_:.b" on line 1.'));
+        'Expected >> to follow "_:.b" on line 1.')
+    );
   });
 
   describe('A Parser instance for the N3 format with the explicitQuantifiers option', () => {
     function parser() { return new Parser({ baseIRI: BASE_IRI, format: 'N3', explicitQuantifiers: true }); }
 
-    it('should parse a @forSome statement',
+    it(
+      'should parse a @forSome statement',
       shouldParse(parser, '@forSome <x>. <x> <x> <x>.',
                   ['', 'http://www.w3.org/2000/10/swap/reify#forSome', '_:b0', 'urn:n3:quantifiers'],
                   ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', 'x', 'urn:n3:quantifiers'],
                   ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil', 'urn:n3:quantifiers'],
-                  ['x', 'x', 'x']));
+                  ['x', 'x', 'x'])
+    );
 
-    it('should parse a @forSome statement with multiple entities',
+    it(
+      'should parse a @forSome statement with multiple entities',
       shouldParse(parser, '@prefix a: <a:>. @base <b:>. @forSome a:x, <y>, a:z. a:x <y> a:z.',
                   ['', 'http://www.w3.org/2000/10/swap/reify#forSome', '_:b0',        'urn:n3:quantifiers'],
                   ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', 'a:x', 'urn:n3:quantifiers'],
@@ -1874,9 +2438,11 @@ describe('Parser', () => {
                   ['_:b1', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', '_:b2', 'urn:n3:quantifiers'],
                   ['_:b2', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', 'a:z', 'urn:n3:quantifiers'],
                   ['_:b2', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil', 'urn:n3:quantifiers'],
-                  ['a:x', 'b:y', 'a:z']));
+                  ['a:x', 'b:y', 'a:z'])
+    );
 
-    it('should correctly scope @forSome statements',
+    it(
+      'should correctly scope @forSome statements',
       shouldParse(parser, '@forSome <x>. <x> <x> { @forSome <x>. <x> <x> <x>. }. <x> <x> <x>.',
                   ['', 'http://www.w3.org/2000/10/swap/reify#forSome', '_:b0',      'urn:n3:quantifiers'],
                   ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', 'x', 'urn:n3:quantifiers'],
@@ -1886,16 +2452,20 @@ describe('Parser', () => {
                   ['_:b2', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', 'x', 'urn:n3:quantifiers'],
                   ['_:b2', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil', 'urn:n3:quantifiers'],
                   ['x', 'x', 'x', '_:b1'],
-                  ['x', 'x', 'x']));
+                  ['x', 'x', 'x'])
+    );
 
-    it('should parse a @forAll statement',
+    it(
+      'should parse a @forAll statement',
       shouldParse(parser, '@forAll <x>. <x> <x> <x>.',
                   ['', 'http://www.w3.org/2000/10/swap/reify#forAll', '_:b0',       'urn:n3:quantifiers'],
                   ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', 'x', 'urn:n3:quantifiers'],
                   ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil', 'urn:n3:quantifiers'],
-                  ['x', 'x', 'x']));
+                  ['x', 'x', 'x'])
+    );
 
-    it('should parse a @forAll statement with multiple entities',
+    it(
+      'should parse a @forAll statement with multiple entities',
       shouldParse(parser, '@prefix a: <a:>. @base <b:>. @forAll a:x, <y>, a:z. a:x <y> a:z.',
                   ['', 'http://www.w3.org/2000/10/swap/reify#forAll', '_:b0',         'urn:n3:quantifiers'],
                   ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', 'a:x', 'urn:n3:quantifiers'],
@@ -1904,9 +2474,11 @@ describe('Parser', () => {
                   ['_:b1', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', '_:b2', 'urn:n3:quantifiers'],
                   ['_:b2', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', 'a:z', 'urn:n3:quantifiers'],
                   ['_:b2', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil', 'urn:n3:quantifiers'],
-                  ['a:x', 'b:y', 'a:z']));
+                  ['a:x', 'b:y', 'a:z'])
+    );
 
-    it('should correctly scope @forAll statements',
+    it(
+      'should correctly scope @forAll statements',
       shouldParse(parser, '@forAll <x>. <x> <x> { @forAll <x>. <x> <x> <x>. }. <x> <x> <x>.',
                   ['', 'http://www.w3.org/2000/10/swap/reify#forAll', '_:b0',       'urn:n3:quantifiers'],
                   ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', 'x', 'urn:n3:quantifiers'],
@@ -1916,13 +2488,14 @@ describe('Parser', () => {
                   ['_:b2', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', 'x', 'urn:n3:quantifiers'],
                   ['_:b2', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil', 'urn:n3:quantifiers'],
                   ['x', 'x', 'x', '_:b1'],
-                  ['x', 'x', 'x']));
+                  ['x', 'x', 'x'])
+    );
   });
 
   describe('A Parser instance with a custom DataFactory', () => {
     const factory = {};
     let parser;
-    before(() => {
+    beforeAll(() => {
       factory.quad = function (s, p, o, g) { return { s: s, p: p, o: o, g: g }; };
       ['namedNode', 'blankNode', 'literal', 'variable', 'defaultGraph'].forEach(f => {
         factory[f] = function (n) { return n ? `${f[0]}-${n}` : f; };
@@ -1931,7 +2504,7 @@ describe('Parser', () => {
     });
 
     it('should use the custom factory', () => {
-      parser.parse('<a> ?b 1, _:d.').should.deep.equal([
+      expect(parser.parse('<a> ?b 1, _:d.')).toEqual([
         { s: 'n-http://example.org/a', p: 'v-b', o: 'l-1',    g: 'defaultGraph' },
         { s: 'n-http://example.org/a', p: 'v-b', o: 'b-b0_d', g: 'defaultGraph' },
       ]);
@@ -1950,12 +2523,12 @@ describe('Parser', () => {
         { :weather a :Raining } => { :weather a :Cloudy } .
       `);
 
-      quads.length.should.be.gt(0);
+      expect(quads.length).toBeGreaterThan(0);
 
       const g1 = DF.blankNode();
       const g2 = DF.blankNode();
 
-      isomorphic(quads, [
+      expect(isomorphic(quads, [
         DF.quad(
           DF.namedNode('http://example.com/weather'),
           DF.namedNode('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'),
@@ -1973,7 +2546,7 @@ describe('Parser', () => {
           DF.namedNode('http://www.w3.org/2000/10/swap/log#implies'),
           g2
         ),
-      ]).should.be.true;
+      ])).toBe(true);
     });
   });
 
@@ -1995,7 +2568,7 @@ describe('Parser', () => {
 
       const bnode = DF.blankNode();
 
-      isomorphic(quads, [
+      expect(isomorphic(quads, [
         DF.quad(
           DF.namedNode('http://example.com/weather'),
           DF.namedNode('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'),
@@ -2011,7 +2584,7 @@ describe('Parser', () => {
           DF.namedNode('http://example.com/name'),
           DF.literal('Thomas')
         ),
-      ]).should.be.true;
+      ])).toBe(true);
     });
   });
 
@@ -2456,11 +3029,11 @@ function shouldParse(parser, input) {
     const results = [];
     const items = expected.map(mapToQuad);
     new parser({ baseIRI: BASE_IRI }).parse(input, (error, triple) => {
-      expect(error).not.to.exist;
+      expect(error).toBeFalsy();
       if (triple)
         results.push(triple);
       else
-        toSortedJSON(results).should.equal(toSortedJSON(items)), done();
+        expect(toSortedJSON(results)).toBe(toSortedJSON(items)), done();
     });
   };
 }
@@ -2497,10 +3070,10 @@ function shouldNotParse(parser, input, expectedError, expectedContext) {
   return function (done) {
     new parser({ baseIRI: BASE_IRI }).parse(input, (error, triple) => {
       if (error) {
-        expect(triple).not.to.exist;
-        error.should.be.an.instanceof(Error);
-        error.message.should.eql(expectedError);
-        if (expectedContext) error.context.should.deep.equal(expectedContext);
+        expect(triple).toBeFalsy();
+        expect(error).toBeInstanceOf(Error);
+        expect(error.message).toEqual(expectedError);
+        if (expectedContext) expect(error.context).toEqual(expectedContext);
         done();
       }
       else if (!triple)
@@ -2512,7 +3085,7 @@ function shouldNotParse(parser, input, expectedError, expectedContext) {
 function itShouldResolve(baseIRI, relativeIri, expected) {
   let result;
   describe(`resolving <${relativeIri}> against <${baseIRI}>`, () => {
-    before(done => {
+    beforeAll(done => {
       try {
         const doc = `<urn:ex:s> <urn:ex:p> <${relativeIri}>.`;
         new Parser({ baseIRI }).parse(doc, (error, triple) => {
@@ -2524,7 +3097,7 @@ function itShouldResolve(baseIRI, relativeIri, expected) {
       catch (error) { done(error); }
     });
     it(`should result in ${expected}`, () => {
-      expect(result.object.value).to.equal(expected);
+      expect(result.object.value).toBe(expected);
     });
   });
 }

--- a/test/N3Store-test.js
+++ b/test/N3Store-test.js
@@ -7,20 +7,17 @@ import {
   termFromId, termToId,
 } from '../src/';
 import namespaces from '../src/IRIs';
-import chai, { expect } from 'chai';
 import { Readable } from 'readable-stream';
 import arrayifyStream from 'arrayify-stream';
-
-const should = chai.should();
 
 describe('Store', () => {
   describe('The Store export', () => {
     it('should be a function', () => {
-      Store.should.be.a('function');
+      expect(Store).toBeInstanceOf(Function);
     });
 
     it('should be an Store constructor', () => {
-      new Store().should.be.an.instanceof(Store);
+      expect(new Store()).toBeInstanceOf(Store);
     });
   });
 
@@ -28,15 +25,15 @@ describe('Store', () => {
     const store = new Store({});
 
     it('should have size 0', () => {
-      expect(store.size).to.eql(0);
+      expect(store.size).toEqual(0);
     });
 
     it('should be empty', () => {
-      store.getQuads().should.be.empty;
+      expect(store.getQuads()).toHaveLength(0);
     });
 
     describe('when importing a stream of 2 quads', () => {
-      before(done => {
+      beforeAll(done => {
         const stream = new ArrayReader([
           new Quad(new NamedNode('s1'), new NamedNode('p2'), new NamedNode('o2')),
           new Quad(new NamedNode('s1'), new NamedNode('p1'), new NamedNode('o1')),
@@ -45,11 +42,11 @@ describe('Store', () => {
         events.on('end', done);
       });
 
-      it('should have size 2', () => { store.size.should.eql(2); });
+      it('should have size 2', () => { expect(store.size).toEqual(2); });
     });
 
     describe('when removing a stream of 2 quads', () => {
-      before(done => {
+      beforeAll(done => {
         const stream = new ArrayReader([
           new Quad(new NamedNode('s1'), new NamedNode('p2'), new NamedNode('o2')),
           new Quad(new NamedNode('s1'), new NamedNode('p1'), new NamedNode('o1')),
@@ -58,11 +55,11 @@ describe('Store', () => {
         events.on('end', done);
       });
 
-      it('should have size 0', () => { store.size.should.eql(0); });
+      it('should have size 0', () => { expect(store.size).toEqual(0); });
     });
 
     describe('when importing a stream of 2 nested quads', () => {
-      before(done => {
+      beforeAll(done => {
         const stream = new ArrayReader([
           new Quad(new Quad(new NamedNode('s1'), new NamedNode('p2'), new NamedNode('o2')), new NamedNode('p2'), new NamedNode('o2')),
           new Quad(new NamedNode('s1'), new NamedNode('p1'), new Quad(new NamedNode('s1'), new NamedNode('p2'), new NamedNode('o2'))),
@@ -71,11 +68,11 @@ describe('Store', () => {
         events.on('end', done);
       });
 
-      it('should have size 2', () => { store.size.should.eql(2); });
+      it('should have size 2', () => { expect(store.size).toEqual(2); });
     });
 
     describe('when removing a stream of 2 nested quads', () => {
-      before(done => {
+      beforeAll(done => {
         const stream = new ArrayReader([
           new Quad(new Quad(new NamedNode('s1'), new NamedNode('p2'), new NamedNode('o2')), new NamedNode('p2'), new NamedNode('o2')),
           new Quad(new NamedNode('s1'), new NamedNode('p1'), new Quad(new NamedNode('s1'), new NamedNode('p2'), new NamedNode('o2'))),
@@ -84,18 +81,18 @@ describe('Store', () => {
         events.on('end', done);
       });
 
-      it('should have size 0', () => { store.size.should.eql(0); });
+      it('should have size 0', () => { expect(store.size).toEqual(0); });
     });
 
     describe('every', () => {
       describe('with no parameters and a callback always returning true', () => {
         it('should return false', () => {
-          store.every(alwaysTrue, null, null, null, null).should.be.false;
+          expect(store.every(alwaysTrue, null, null, null, null)).toBe(false);
         });
       });
       describe('with no parameters and a callback always returning false', () => {
         it('should return false', () => {
-          store.every(alwaysFalse, null, null, null, null).should.be.false;
+          expect(store.every(alwaysFalse, null, null, null, null)).toBe(false);
         });
       });
     });
@@ -103,40 +100,47 @@ describe('Store', () => {
     describe('some', () => {
       describe('with no parameters and a callback always returning true', () => {
         it('should return false', () => {
-          store.some(alwaysTrue, null, null, null, null).should.be.false;
+          expect(store.some(alwaysTrue, null, null, null, null)).toBe(false);
         });
       });
       describe('with no parameters and a callback always returning false', () => {
         it('should return false', () => {
-          store.some(alwaysFalse, null, null, null, null).should.be.false;
+          expect(store.some(alwaysFalse, null, null, null, null)).toBe(false);
         });
       });
     });
 
-    it('should still have size 0 (instead of null) after adding and removing a triple', () => {
-      expect(store.size).to.eql(0);
-      store.addQuad(new NamedNode('a'), new NamedNode('b'), new NamedNode('c')).should.be.true;
-      store.removeQuad(new NamedNode('a'), new NamedNode('b'), new NamedNode('c')).should.be.true;
-      expect(store.size).to.eql(0);
-    });
+    it(
+      'should still have size 0 (instead of null) after adding and removing a triple',
+      () => {
+        expect(store.size).toEqual(0);
+        expect(store.addQuad(new NamedNode('a'), new NamedNode('b'), new NamedNode('c'))).toBe(true);
+        expect(
+          store.removeQuad(new NamedNode('a'), new NamedNode('b'), new NamedNode('c'))
+        ).toBe(true);
+        expect(store.size).toEqual(0);
+      }
+    );
 
     it('should be able to generate unnamed blank nodes', () => {
-      store.createBlankNode().value.should.eql('b0');
-      store.createBlankNode().value.should.eql('b1');
+      expect(store.createBlankNode().value).toEqual('b0');
+      expect(store.createBlankNode().value).toEqual('b1');
 
-      store.addQuad('_:b0', '_:b1', '_:b2').should.be.true;
-      store.createBlankNode().value.should.eql('b3');
+      expect(store.addQuad('_:b0', '_:b1', '_:b2')).toBe(true);
+      expect(store.createBlankNode().value).toEqual('b3');
       store.removeQuads(store.getQuads());
     });
 
     it('should be able to generate named blank nodes', () => {
-      store.createBlankNode('blank').value.should.eql('blank');
-      store.createBlankNode('blank').value.should.eql('blank1');
-      store.createBlankNode('blank').value.should.eql('blank2');
+      expect(store.createBlankNode('blank').value).toEqual('blank');
+      expect(store.createBlankNode('blank').value).toEqual('blank1');
+      expect(store.createBlankNode('blank').value).toEqual('blank2');
     });
 
     it('should be able to store triples with generated blank nodes', () => {
-      store.addQuad(store.createBlankNode('x'), new NamedNode('b'), new NamedNode('c')).should.be.true;
+      expect(
+        store.addQuad(store.createBlankNode('x'), new NamedNode('b'), new NamedNode('c'))
+      ).toBe(true);
       shouldIncludeAll(store.getQuads(null, new NamedNode('b')), ['_:x', 'b', 'c'])();
       store.removeQuads(store.getQuads());
     });
@@ -152,125 +156,145 @@ describe('Store', () => {
     ]);
 
     it('should have size 5', () => {
-      store.size.should.eql(5);
+      expect(store.size).toEqual(5);
     });
 
     describe('adding a triple that already exists', () => {
       it('should return false', () => {
-        store.addQuad('s1', 'p1', 'o1').should.be.false;
+        expect(store.addQuad('s1', 'p1', 'o1')).toBe(false);
       });
 
       it('should not increase the size', () => {
-        store.size.should.eql(5);
+        expect(store.size).toEqual(5);
       });
 
       it('should return false', () => {
-        store.addQuad(new Quad('s1', 'p1', 'o1'), 'p1', 'o1').should.be.false;
+        expect(store.addQuad(new Quad('s1', 'p1', 'o1'), 'p1', 'o1')).toBe(false);
       });
 
       it('should not increase the size', () => {
-        store.size.should.eql(5);
+        expect(store.size).toEqual(5);
       });
     });
 
     describe('adding a triple that did not exist yet', () => {
       it('should return true', () => {
-        store.has(new Quad(new NamedNode('s1'), new NamedNode('p1'), new NamedNode('o4'))).should.be.false;
-        store.has(new NamedNode('s1'), new NamedNode('p1'), new NamedNode('o4')).should.be.false;
-        store.has(null, null, new NamedNode('o4')).should.be.false;
+        expect(
+          store.has(new Quad(new NamedNode('s1'), new NamedNode('p1'), new NamedNode('o4')))
+        ).toBe(false);
+        expect(store.has(new NamedNode('s1'), new NamedNode('p1'), new NamedNode('o4'))).toBe(false);
+        expect(store.has(null, null, new NamedNode('o4'))).toBe(false);
 
-        store.addQuad('s1', 'p1', 'o4').should.be.true;
+        expect(store.addQuad('s1', 'p1', 'o4')).toBe(true);
 
-        store.has(new Quad(new NamedNode('s1'), new NamedNode('p1'), new NamedNode('o4'))).should.be.true;
-        store.has(new NamedNode('s1'), new NamedNode('p1'), new NamedNode('o4')).should.be.true;
-        store.has(new NamedNode('s1'), new NamedNode('p1'), new NamedNode('o4'), new DefaultGraph()).should.be.true;
-        store.has(null, null, new NamedNode('o4')).should.be.true;
+        expect(
+          store.has(new Quad(new NamedNode('s1'), new NamedNode('p1'), new NamedNode('o4')))
+        ).toBe(true);
+        expect(store.has(new NamedNode('s1'), new NamedNode('p1'), new NamedNode('o4'))).toBe(true);
+        expect(
+          store.has(new NamedNode('s1'), new NamedNode('p1'), new NamedNode('o4'), new DefaultGraph())
+        ).toBe(true);
+        expect(store.has(null, null, new NamedNode('o4'))).toBe(true);
       });
 
       it('should increase the size', () => {
-        store.size.should.eql(6);
+        expect(store.size).toEqual(6);
       });
 
       it('should return true', () => {
-        store.addQuad(new Quad(new NamedNode('s1'), new NamedNode('p1'), new NamedNode('o1')), 'p1', 'o4').should.be.true;
+        expect(
+          store.addQuad(new Quad(new NamedNode('s1'), new NamedNode('p1'), new NamedNode('o1')), 'p1', 'o4')
+        ).toBe(true);
       });
 
       it('should increase the size', () => {
-        store.size.should.eql(7);
+        expect(store.size).toEqual(7);
       });
 
       it('should return self', () => {
-        should.equal(store.add(new Quad(new NamedNode('s2'), new NamedNode('p2'), new NamedNode('o2'))), store);
+        expect(
+          store.add(new Quad(new NamedNode('s2'), new NamedNode('p2'), new NamedNode('o2')))
+        ).toBe(store);
       });
 
       it('should increase the size', () => {
-        store.size.should.eql(8);
+        expect(store.size).toEqual(8);
       });
     });
 
     describe('removing an existing triple', () => {
       it('should return true', () => {
-        store.removeQuad('s1', 'p1', 'o4').should.be.true;
+        expect(store.removeQuad('s1', 'p1', 'o4')).toBe(true);
       });
 
       it('should decrease the size', () => {
-        store.size.should.eql(7);
+        expect(store.size).toEqual(7);
       });
 
       it('should return true', () => {
-        store.removeQuad(new Quad(new NamedNode('s1'), new NamedNode('p1'), new NamedNode('o1')), 'p1', 'o4').should.be.true;
+        expect(
+          store.removeQuad(new Quad(new NamedNode('s1'), new NamedNode('p1'), new NamedNode('o1')), 'p1', 'o4')
+        ).toBe(true);
       });
 
       it('should decrease the size', () => {
-        store.size.should.eql(6);
+        expect(store.size).toEqual(6);
       });
 
       it('should return self', () => {
-        should.equal(store.delete(new Quad(new NamedNode('s2'), new NamedNode('p2'), new NamedNode('o2'))), store);
+        expect(
+          store.delete(new Quad(new NamedNode('s2'), new NamedNode('p2'), new NamedNode('o2')))
+        ).toBe(store);
       });
 
       it('should increase the size', () => {
-        store.size.should.eql(5);
+        expect(store.size).toEqual(5);
       });
     });
 
     describe('removing a non-existing triple', () => {
       it('should return false', () => {
-        store.removeQuad('s1', 'p1', 'o5').should.be.false;
+        expect(store.removeQuad('s1', 'p1', 'o5')).toBe(false);
       });
 
       it('should not decrease the size', () => {
-        store.size.should.eql(5);
+        expect(store.size).toEqual(5);
       });
 
       it('should return false', () => {
-        store.removeQuad(new Quad(new NamedNode('s1'), new NamedNode('p1'), new NamedNode('o4')), 'p1', 'o1').should.be.false;
+        expect(
+          store.removeQuad(new Quad(new NamedNode('s1'), new NamedNode('p1'), new NamedNode('o4')), 'p1', 'o1')
+        ).toBe(false);
       });
 
       it('should not decrease the size', () => {
-        store.size.should.eql(5);
+        expect(store.size).toEqual(5);
       });
     });
 
     describe('removing matching quads', () => {
-      it('should return the removed quads',
+      it(
+        'should return the removed quads',
         forResultStream(shouldIncludeAll, () => { return store.removeMatches('s1', 'p1'); },
           ['s1', 'p1', 'o1'],
           ['s1', 'p1', 'o2'],
-          ['s1', 'p1', 'o3']));
+          ['s1', 'p1', 'o3'])
+      );
 
       it('should decrease the size', () => {
-        store.size.should.eql(2);
+        expect(store.size).toEqual(2);
       });
     });
 
     describe('removing a graph', () => {
-      it('should return the removed quads',
+      it(
+        'should return the removed quads',
         forResultStream(shouldIncludeAll, () => { return store.deleteGraph('g1'); },
-          ['s2', 'p2', 'o2', 'g1']));
+          ['s2', 'p2', 'o2', 'g1'])
+      );
 
       it('should decrease the size', () => {
-        store.size.should.eql(1);
+        expect(store.size).toEqual(1);
       });
     });
   });
@@ -287,18 +311,20 @@ describe('Store', () => {
       ]);
     });
 
-    it('should return the removed quads',
+    it(
+      'should return the removed quads',
       forResultStream(shouldIncludeAll, () => { return store.removeMatches(null, 'p2', 'o2'); },
-        [termToId(new Quad(new NamedNode('s1'), new NamedNode('p1'), new NamedNode('o1'))), 'p2', 'o2']));
+        [termToId(new Quad(new NamedNode('s1'), new NamedNode('p1'), new NamedNode('o1'))), 'p2', 'o2'])
+    );
 
     it('should decrease the size', () => {
-      store.size.should.eql(5);
+      expect(store.size).toEqual(5);
     });
 
     it('should match RDF* and normal quads at the same time', done => {
       const stream = store.removeMatches(null, 'p1', 'o2');
       stream.on('end', () => {
-        store.size.should.eql(3);
+        expect(store.size).toEqual(3);
         done();
       });
     });
@@ -306,7 +332,7 @@ describe('Store', () => {
     it('should allow matching using a quad', done => {
       const stream = store.removeMatches(termToId(new Quad(new NamedNode('s1'), new NamedNode('p1'), new NamedNode('o1'))));
       stream.on('end', () => {
-        store.size.should.eql(1);
+        expect(store.size).toEqual(1);
         done();
       });
     });
@@ -314,39 +340,40 @@ describe('Store', () => {
 
   describe('A Store with 7 elements', () => {
     const store = new Store();
-    store.addQuad('s1', 'p1', 'o1').should.be.true;
-    store.addQuad({ subject: 's1', predicate: 'p1', object: 'o2' }).should.be.true;
+    expect(store.addQuad('s1', 'p1', 'o1')).toBe(true);
+    expect(store.addQuad({ subject: 's1', predicate: 'p1', object: 'o2' })).toBe(true);
     store.addQuads([
       { subject: 's1', predicate: 'p2', object: 'o2' },
       { subject: 's2', predicate: 'p1', object: 'o1' },
     ]);
-    store.addQuad('s1', 'p1', 'o1', 'c4').should.be.true;
+    expect(store.addQuad('s1', 'p1', 'o1', 'c4')).toBe(true);
     store.addQuad(new Quad('s2', 'p2', 'o2'), 'p1', 'o3');
-    should.equal(store.add(new Quad('s2', 'p2', 'o2')), store);
+    expect(store.add(new Quad('s2', 'p2', 'o2'))).toBe(store);
 
     it('should have size 7', () => {
-      store.size.should.eql(7);
+      expect(store.size).toEqual(7);
     });
 
     describe('when searched without parameters', () => {
-      it('should return all items',
-        shouldIncludeAll(store.getQuads(),
-                         ['s1', 'p1', 'o1'],
-                         ['s1', 'p1', 'o2'],
-                         ['s1', 'p2', 'o2'],
-                         ['s2', 'p1', 'o1'],
-                         ['s1', 'p1', 'o1', 'c4'],
-                         [termToId(new Quad('s2', 'p2', 'o2')), 'p1', 'o3'],
-                         ['s2', 'p2', 'o2']));
+      it('should return all items', shouldIncludeAll(store.getQuads(),
+                       ['s1', 'p1', 'o1'],
+                       ['s1', 'p1', 'o2'],
+                       ['s1', 'p2', 'o2'],
+                       ['s2', 'p1', 'o1'],
+                       ['s1', 'p1', 'o1', 'c4'],
+                       [termToId(new Quad('s2', 'p2', 'o2')), 'p1', 'o3'],
+                       ['s2', 'p2', 'o2']));
     });
 
     describe('when searched with an existing subject parameter', () => {
-      it('should return all items with this subject in all graphs',
+      it(
+        'should return all items with this subject in all graphs',
         shouldIncludeAll(store.getQuads(new NamedNode('s1'), null, null),
                          ['s1', 'p1', 'o1'],
                          ['s1', 'p1', 'o2'],
                          ['s1', 'p2', 'o2'],
-                         ['s1', 'p1', 'o1', 'c4']));
+                         ['s1', 'p1', 'o1', 'c4'])
+      );
     });
 
     describe('when searched with a non-existing subject parameter', () => {
@@ -358,13 +385,15 @@ describe('Store', () => {
     });
 
     describe('when searched with an existing predicate parameter', () => {
-      it('should return all items with this predicate in all graphs',
+      it(
+        'should return all items with this predicate in all graphs',
         shouldIncludeAll(store.getQuads(null, new NamedNode('p1'), null),
                          ['s1', 'p1', 'o1'],
                          ['s1', 'p1', 'o2'],
                          ['s2', 'p1', 'o1'],
                          ['s1', 'p1', 'o1', 'c4'],
-                         [termToId(new Quad('s2', 'p2', 'o2')), 'p1', 'o3']));
+                         [termToId(new Quad('s2', 'p2', 'o2')), 'p1', 'o3'])
+      );
     });
 
     describe('when searched with a non-existing predicate parameter', () => {
@@ -372,11 +401,13 @@ describe('Store', () => {
     });
 
     describe('when searched with an existing object parameter', () => {
-      it('should return all items with this object in all graphs',
+      it(
+        'should return all items with this object in all graphs',
         shouldIncludeAll(store.getQuads(null, null, new NamedNode('o1')),
                          ['s1', 'p1', 'o1'],
                          ['s2', 'p1', 'o1'],
-                         ['s1', 'p1', 'o1', 'c4']));
+                         ['s1', 'p1', 'o1', 'c4'])
+      );
     });
 
     describe('when searched with a non-existing object parameter', () => {
@@ -384,11 +415,13 @@ describe('Store', () => {
     });
 
     describe('when searched with existing subject and predicate parameters', () => {
-      it('should return all items with this subject and predicate in all graphs',
+      it(
+        'should return all items with this subject and predicate in all graphs',
         shouldIncludeAll(store.getQuads(new NamedNode('s1'), new NamedNode('p1'), null),
                          ['s1', 'p1', 'o1'],
                          ['s1', 'p1', 'o2'],
-                         ['s1', 'p1', 'o1', 'c4']));
+                         ['s1', 'p1', 'o1', 'c4'])
+      );
     });
 
     describe('when searched with non-existing subject and predicate parameters', () => {
@@ -396,10 +429,12 @@ describe('Store', () => {
     });
 
     describe('when searched with existing subject and object parameters', () => {
-      it('should return all items with this subject and object in all graphs',
+      it(
+        'should return all items with this subject and object in all graphs',
         shouldIncludeAll(store.getQuads(new NamedNode('s1'), null, new NamedNode('o1')),
                          ['s1', 'p1', 'o1'],
-                         ['s1', 'p1', 'o1', 'c4']));
+                         ['s1', 'p1', 'o1', 'c4'])
+      );
     });
 
     describe('when searched with non-existing subject and object parameters', () => {
@@ -407,11 +442,13 @@ describe('Store', () => {
     });
 
     describe('when searched with existing predicate and object parameters', () => {
-      it('should return all items with this predicate and object in all graphs',
+      it(
+        'should return all items with this predicate and object in all graphs',
         shouldIncludeAll(store.getQuads(null, new NamedNode('p1'), new NamedNode('o1')),
                          ['s1', 'p1', 'o1'],
                          ['s2', 'p1', 'o1'],
-                         ['s1', 'p1', 'o1', 'c4']));
+                         ['s1', 'p1', 'o1', 'c4'])
+      );
     });
 
     describe('when searched with non-existing predicate and object parameters in the default graph', () => {
@@ -419,10 +456,12 @@ describe('Store', () => {
     });
 
     describe('when searched with existing subject, predicate, and object parameters', () => {
-      it('should return all items with this subject, predicate, and object in all graphs',
+      it(
+        'should return all items with this subject, predicate, and object in all graphs',
         shouldIncludeAll(store.getQuads(new NamedNode('s1'), new NamedNode('p1'), new NamedNode('o1')),
                          ['s1', 'p1', 'o1'],
-                         ['s1', 'p1', 'o1', 'c4']));
+                         ['s1', 'p1', 'o1', 'c4'])
+      );
     });
 
     describe('when searched with a non-existing triple', () => {
@@ -430,20 +469,24 @@ describe('Store', () => {
     });
 
     describe('when searched with the default graph parameter', () => {
-      it('should return all items in the default graph',
+      it(
+        'should return all items in the default graph',
         shouldIncludeAll(store.getQuads(null, null, null, new DefaultGraph()),
                          ['s1', 'p1', 'o1'],
                          ['s1', 'p1', 'o2'],
                          ['s1', 'p2', 'o2'],
                          ['s2', 'p1', 'o1'],
                          [termToId(new Quad('s2', 'p2', 'o2')), 'p1', 'o3'],
-                         ['s2', 'p2', 'o2']));
+                         ['s2', 'p2', 'o2'])
+      );
     });
 
     describe('when searched with an existing named graph parameter', () => {
-      it('should return all items in that graph',
+      it(
+        'should return all items in that graph',
         shouldIncludeAll(store.getQuads(null, null, null, new NamedNode('c4')),
-                         ['s1', 'p1', 'o1', 'c4']));
+                         ['s1', 'p1', 'o1', 'c4'])
+      );
     });
 
     describe('when searched with a non-existing named graph parameter', () => {
@@ -455,63 +498,67 @@ describe('Store', () => {
         it('should return an object implementing the DatasetCore interface', () => {
           const dataset = store.match();
 
-          dataset.add.should.be.a('function');
-          dataset.delete.should.be.a('function');
-          dataset.has.should.be.a('function');
-          dataset.match.should.be.a('function');
-          dataset[Symbol.iterator].should.be.a('function');
+          expect(dataset.add).toBeInstanceOf(Function);
+          expect(dataset.delete).toBeInstanceOf(Function);
+          expect(dataset.has).toBeInstanceOf(Function);
+          expect(dataset.match).toBeInstanceOf(Function);
+          expect(dataset[Symbol.iterator]).toBeInstanceOf(Function);
         });
 
-        it('should return an object implementing the Readable stream interface', () => {
-          const stream = store.match();
+        it(
+          'should return an object implementing the Readable stream interface',
+          () => {
+            const stream = store.match();
 
-          stream.addListener.should.be.a('function');
-          stream.emit.should.be.a('function');
-          should.equal(stream.propertyIsEnumerable('destroyed'), false);
-          stream.destroyed.should.equal(false);
-          stream.destroy.should.be.a('function');
-          stream.eventNames.should.be.a('function');
-          stream.getMaxListeners.should.be.a('function');
-          stream.listenerCount.should.be.a('function');
-          stream.listeners.should.be.a('function');
-          stream.isPaused.should.be.a('function');
-          should.equal(stream.isPaused(), false);
-          stream.off.should.be.a('function');
-          stream.on.should.be.a('function');
-          stream.once.should.be.a('function');
-          stream.pause.should.be.a('function');
-          stream.pipe.should.be.a('function');
-          stream.prependListener.should.be.a('function');
-          stream.prependOnceListener.should.be.a('function');
-          stream.rawListeners.should.be.a('function');
-          stream.read.should.be.a('function');
-          stream.readable.should.equal(true);
-          should.equal(stream.propertyIsEnumerable('readableBuffer'), false);
-          should.exist(stream.readableBuffer);
-          // Readable from 'readable-stream' does not implement the `readableEncoding` property.
-          // stream.readableEncoding.should.equal(???);
-          // Readable from 'readable-stream' does not implement the `readableEnded` property.
-          // stream.readableEnded.should.equal(false);
-          should.equal(stream.propertyIsEnumerable('readableFlowing'), false);
-          should.equal(stream.readableFlowing, null);
-          should.equal(stream.propertyIsEnumerable('readableHighWaterMark'), false);
-          stream.readableHighWaterMark.should.equal(16);
-          should.equal(stream.propertyIsEnumerable('readableLength'), false);
-          stream.readableLength.should.equal(0);
-          // Readable from 'readable-stream' does not implement the `readableObjectMode` property.
-          // stream.readableObjectMode.should.equal(true);
-          stream.removeAllListeners.should.be.a('function');
-          stream.removeListener.should.be.a('function');
-          stream.resume.should.be.a('function');
-          stream.setEncoding.should.be.a('function');
-          stream.setMaxListeners.should.be.a('function');
-          stream.unpipe.should.be.a('function');
-          stream.unshift.should.be.a('function');
-          stream.wrap.should.be.a('function');
-          stream[Symbol.asyncIterator].should.be.a('function');
-        });
+            expect(typeof stream.addListener).toEqual('function');
+            expect(typeof stream.emit).toEqual('function');
+            expect(stream.propertyIsEnumerable('destroyed')).toBe(false);
+            expect(stream.destroyed).toBe(false);
+            expect(typeof stream.destroy).toEqual('function');
+            expect(typeof stream.eventNames).toEqual('function');
+            expect(typeof stream.getMaxListeners).toEqual('function');
+            expect(typeof stream.listenerCount).toEqual('function');
+            expect(typeof stream.listeners).toEqual('function');
+            expect(typeof stream.isPaused).toEqual('function');
+            expect(stream.isPaused()).toBe(false);
+            expect(typeof stream.off).toEqual('function');
+            expect(typeof stream.on).toEqual('function');
+            expect(typeof stream.once).toEqual('function');
+            expect(typeof stream.pause).toEqual('function');
+            expect(typeof stream.pipe).toEqual('function');
+            expect(typeof stream.prependListener).toEqual('function');
+            expect(typeof stream.prependOnceListener).toEqual('function');
+            expect(typeof stream.rawListeners).toEqual('function');
+            expect(typeof stream.read).toEqual('function');
+            expect(stream.readable).toBe(true);
+            expect(stream.propertyIsEnumerable('readableBuffer')).toBe(false);
+            expect(stream.readableBuffer).toBeDefined();
+            // Readable from 'readable-stream' does not implement the `readableEncoding` property.
+            // stream.readableEncoding.should.equal(???);
+            // Readable from 'readable-stream' does not implement the `readableEnded` property.
+            // stream.readableEnded.should.equal(false);
+            expect(stream.propertyIsEnumerable('readableFlowing')).toBe(false);
+            expect(stream.readableFlowing).toBeNull();
+            expect(stream.propertyIsEnumerable('readableHighWaterMark')).toBe(false);
+            expect(stream.readableHighWaterMark).toBe(16);
+            expect(stream.propertyIsEnumerable('readableLength')).toBe(false);
+            expect(stream.readableLength).toBe(0);
+            // Readable from 'readable-stream' does not implement the `readableObjectMode` property.
+            // stream.readableObjectMode.should.equal(true);
+            expect(typeof stream.removeAllListeners).toEqual('function');
+            expect(typeof stream.removeListener).toEqual('function');
+            expect(typeof stream.resume).toEqual('function');
+            expect(typeof stream.setEncoding).toEqual('function');
+            expect(typeof stream.setMaxListeners).toEqual('function');
+            expect(typeof stream.unpipe).toEqual('function');
+            expect(typeof stream.unshift).toEqual('function');
+            expect(typeof stream.wrap).toEqual('function');
+            expect(typeof stream[Symbol.asyncIterator]).toEqual('function');
+          }
+        );
 
-        it('should return all items',
+        it(
+          'should return all items',
           forResultStream(shouldIncludeAll, store.match(),
             ['s1', 'p1', 'o1'],
             ['s1', 'p1', 'o2'],
@@ -519,16 +566,19 @@ describe('Store', () => {
             ['s2', 'p1', 'o1'],
             ['s1', 'p1', 'o1', 'c4'],
             [termToId(new Quad('s2', 'p2', 'o2')), 'p1', 'o3'],
-            ['s2', 'p2', 'o2']));
+            ['s2', 'p2', 'o2'])
+        );
       });
 
       describe('with an existing subject parameter', () => {
-        it('should return all items with this subject in all graphs',
+        it(
+          'should return all items with this subject in all graphs',
           forResultStream(shouldIncludeAll, store.match(new NamedNode('s1'), null, null),
             ['s1', 'p1', 'o1'],
             ['s1', 'p1', 'o2'],
             ['s1', 'p2', 'o2'],
-            ['s1', 'p1', 'o1', 'c4']));
+            ['s1', 'p1', 'o1', 'c4'])
+        );
 
         it('should return an object implementing the DatasetCore interface', () => {
           const subject = new NamedNode('s1');
@@ -537,13 +587,13 @@ describe('Store', () => {
           let count = 0;
           for (const quad of dataset) {
             count += 1;
-            should.equal(quad.subject.equals(subject), true);
+            expect(quad.subject.equals(subject)).toBe(true);
           }
 
-          should.equal(count, 4);
-          should.equal(dataset.size, count);
+          expect(count).toBe(4);
+          expect(dataset.size).toBe(count);
 
-          should.equal(dataset.has(new Quad('s2', 'p1', 'o1')), false);
+          expect(dataset.has(new Quad('s2', 'p1', 'o1'))).toBe(false);
           dataset.add(new Quad('s2', 'p1', 'o1'));
 
           count = 0;
@@ -551,9 +601,9 @@ describe('Store', () => {
           for (const _quad of dataset) {
             count += 1;
           }
-          should.equal(count, 5);
+          expect(count).toBe(5);
 
-          should.equal(dataset.has(new Quad('s2', 'p1', 'o1')), true);
+          expect(dataset.has(new Quad('s2', 'p1', 'o1'))).toBe(true);
 
           const nextDataset = dataset.match(new NamedNode('s2'));
           nextDataset.add(new Quad('s2', 'p2', 'o2'));
@@ -563,15 +613,15 @@ describe('Store', () => {
           for (const _quad of nextDataset) {
             count += 1;
           }
-          should.equal(count, 2);
+          expect(count).toBe(2);
 
-          should.equal(nextDataset.has(new Quad('s2', 'p1', 'o1')), true);
-          should.equal(nextDataset.has(new Quad('s2', 'p2', 'o2')), true);
+          expect(nextDataset.has(new Quad('s2', 'p1', 'o1'))).toBe(true);
+          expect(nextDataset.has(new Quad('s2', 'p2', 'o2'))).toBe(true);
 
           nextDataset.delete(new Quad('s2', 'p1', 'o1'));
           nextDataset.delete(new Quad('s2', 'p2', 'o2'));
-          should.equal(nextDataset.has(new Quad('s2', 'p1', 'o1')), false);
-          should.equal(nextDataset.has(new Quad('s2', 'p2', 'o2')), false);
+          expect(nextDataset.has(new Quad('s2', 'p1', 'o1'))).toBe(false);
+          expect(nextDataset.has(new Quad('s2', 'p2', 'o2'))).toBe(false);
         });
       });
 
@@ -582,321 +632,384 @@ describe('Store', () => {
 
     describe('getSubjects', () => {
       describe('with existing predicate, object and graph parameters', () => {
-        it('should return all subjects with this predicate, object and graph', () => {
-          store.getSubjects(new NamedNode('p1'), new NamedNode('o1'), new NamedNode('c4')).should.have.deep.members([new NamedNode('s1')]);
-        });
+        it(
+          'should return all subjects with this predicate, object and graph',
+          () => {
+            expect(
+              store.getSubjects(new NamedNode('p1'), new NamedNode('o1'), new NamedNode('c4'))
+            ).toEqual(expect.arrayContaining([new NamedNode('s1')]));
+          }
+        );
       });
 
       describe('with existing predicate and object parameters', () => {
         it('should return all subjects with this predicate and object', () => {
-          store.getSubjects(new NamedNode('p2'), new NamedNode('o2'), null).should.have.deep.members([new NamedNode('s1'), new NamedNode('s2')]);
+          expect(store.getSubjects(new NamedNode('p2'), new NamedNode('o2'), null)).toEqual(expect.arrayContaining([new NamedNode('s1'), new NamedNode('s2')]));
         });
       });
 
       describe('with existing predicate and graph parameters', () => {
         it('should return all subjects with this predicate and graph', () => {
-          store.getSubjects(new NamedNode('p1'), null, new DefaultGraph()).should.have.deep.members([new NamedNode('s1'), new NamedNode('s2'), new Quad(new NamedNode('s2'), new NamedNode('p2'), new NamedNode('o2'))]);
+          expect(store.getSubjects(new NamedNode('p1'), null, new DefaultGraph())).toEqual(expect.arrayContaining(
+            [new NamedNode('s1'), new NamedNode('s2'), new Quad(new NamedNode('s2'), new NamedNode('p2'), new NamedNode('o2'))]
+          ));
         });
       });
 
       describe('with existing object and graph parameters', () => {
         it('should return all subjects with this object and graph', () => {
-          store.getSubjects(null, new NamedNode('o1'), new DefaultGraph()).should.have.deep.members([new NamedNode('s1'), new NamedNode('s2')]);
+          expect(store.getSubjects(null, new NamedNode('o1'), new DefaultGraph())).toEqual(expect.arrayContaining([new NamedNode('s1'), new NamedNode('s2')]));
         });
       });
 
       describe('with an existing predicate parameter', () => {
         it('should return all subjects with this predicate', () => {
-          store.getSubjects(new NamedNode('p1'), null, null).should.have.deep.members([new NamedNode('s1'), new NamedNode('s2'),  new Quad(new NamedNode('s2'), new NamedNode('p2'), new NamedNode('o2'))]);
+          expect(store.getSubjects(new NamedNode('p1'), null, null)).toEqual(expect.arrayContaining(
+            [new NamedNode('s1'), new NamedNode('s2'),  new Quad(new NamedNode('s2'), new NamedNode('p2'), new NamedNode('o2'))]
+          ));
         });
       });
 
       describe('with an existing object parameter', () => {
         it('should return all subjects with this object', () => {
-          store.getSubjects(null, new NamedNode('o1'), null).should.have.deep.members([new NamedNode('s1'), new NamedNode('s2')]);
+          expect(store.getSubjects(null, new NamedNode('o1'), null)).toEqual(expect.arrayContaining([new NamedNode('s1'), new NamedNode('s2')]));
         });
       });
 
       describe('with an existing graph parameter', () => {
         it('should return all subjects in the graph', () => {
-          store.getSubjects(null, null, new NamedNode('c4')).should.have.deep.members([new NamedNode('s1')]);
+          expect(store.getSubjects(null, null, new NamedNode('c4'))).toEqual(expect.arrayContaining([new NamedNode('s1')]));
         });
       });
 
       describe('with no parameters', () => {
         it('should return all subjects', () => {
-          store.getSubjects(null, null, null).should.have.deep.members([new NamedNode('s1'), new NamedNode('s2'),  new Quad(new NamedNode('s2'), new NamedNode('p2'), new NamedNode('o2'))]);
+          expect(store.getSubjects(null, null, null)).toEqual(expect.arrayContaining(
+            [new NamedNode('s1'), new NamedNode('s2'),  new Quad(new NamedNode('s2'), new NamedNode('p2'), new NamedNode('o2'))]
+          ));
         });
       });
     });
 
     describe('getPredicates', () => {
       describe('with existing subject, object and graph parameters', () => {
-        it('should return all predicates with this subject, object and graph', () => {
-          store.getPredicates(new NamedNode('s1'), new NamedNode('o1'), new NamedNode('c4')).should.have.deep.members([new NamedNode('p1')]);
-        });
+        it(
+          'should return all predicates with this subject, object and graph',
+          () => {
+            expect(
+              store.getPredicates(new NamedNode('s1'), new NamedNode('o1'), new NamedNode('c4'))
+            ).toEqual(expect.arrayContaining([new NamedNode('p1')]));
+          }
+        );
       });
 
       describe('with existing subject and object parameters', () => {
         it('should return all predicates with this subject and object', () => {
-          store.getPredicates(new NamedNode('s1'), new NamedNode('o2'), null).should.have.deep.members([new NamedNode('p1'), new NamedNode('p2')]);
+          expect(store.getPredicates(new NamedNode('s1'), new NamedNode('o2'), null)).toEqual(expect.arrayContaining([new NamedNode('p1'), new NamedNode('p2')]));
         });
       });
 
       describe('with existing subject and graph parameters', () => {
         it('should return all predicates with this subject and graph', () => {
-          store.getPredicates(new NamedNode('s1'), null, new DefaultGraph()).should.have.deep.members([new NamedNode('p1'), new NamedNode('p2')]);
+          expect(store.getPredicates(new NamedNode('s1'), null, new DefaultGraph())).toEqual(expect.arrayContaining([new NamedNode('p1'), new NamedNode('p2')]));
         });
       });
 
       describe('with existing object and graph parameters', () => {
         it('should return all predicates with this object and graph', () => {
-          store.getPredicates(null, new NamedNode('o1'), new DefaultGraph()).should.have.deep.members([new NamedNode('p1')]);
+          expect(store.getPredicates(null, new NamedNode('o1'), new DefaultGraph())).toEqual(expect.arrayContaining([new NamedNode('p1')]));
         });
       });
 
       describe('with an existing subject parameter', () => {
         it('should return all predicates with this subject', () => {
-          store.getPredicates(new NamedNode('s2'), null, null).should.have.deep.members([new NamedNode('p1'), new NamedNode('p2')]);
+          expect(store.getPredicates(new NamedNode('s2'), null, null)).toEqual(expect.arrayContaining([new NamedNode('p1'), new NamedNode('p2')]));
         });
       });
 
       describe('with an existing object parameter', () => {
         it('should return all predicates with this object', () => {
-          store.getPredicates(null, new NamedNode('o1'), null).should.have.deep.members([new NamedNode('p1')]);
+          expect(store.getPredicates(null, new NamedNode('o1'), null)).toEqual(expect.arrayContaining([new NamedNode('p1')]));
         });
       });
 
       describe('with an existing graph parameter', () => {
         it('should return all predicates in the graph', () => {
-          store.getPredicates(null, null, new NamedNode('c4')).should.have.deep.members([new NamedNode('p1')]);
+          expect(store.getPredicates(null, null, new NamedNode('c4'))).toEqual(expect.arrayContaining([new NamedNode('p1')]));
         });
       });
 
       describe('with no parameters', () => {
         it('should return all predicates', () => {
-          store.getPredicates(null, null, null).should.have.deep.members([new NamedNode('p1'), new NamedNode('p2')]);
+          expect(store.getPredicates(null, null, null)).toEqual(expect.arrayContaining([new NamedNode('p1'), new NamedNode('p2')]));
         });
       });
     });
 
     describe('getObjects', () => {
       describe('with existing subject, predicate and graph parameters', () => {
-        it('should return all objects with this subject, predicate and graph', () => {
-          store.getObjects(new NamedNode('s1'), new NamedNode('p1'), new DefaultGraph()).should.have.deep.members([new NamedNode('o1'), new NamedNode('o2')]);
-        });
+        it(
+          'should return all objects with this subject, predicate and graph',
+          () => {
+            expect(
+              store.getObjects(new NamedNode('s1'), new NamedNode('p1'), new DefaultGraph())
+            ).toEqual(expect.arrayContaining([new NamedNode('o1'), new NamedNode('o2')]));
+          }
+        );
       });
 
       describe('with existing subject and predicate parameters', () => {
         it('should return all objects with this subject and predicate', () => {
-          store.getObjects(new NamedNode('s1'), new NamedNode('p1'), null).should.have.deep.members([new NamedNode('o1'), new NamedNode('o2')]);
+          expect(store.getObjects(new NamedNode('s1'), new NamedNode('p1'), null)).toEqual(expect.arrayContaining([new NamedNode('o1'), new NamedNode('o2')]));
         });
       });
 
       describe('with existing subject and graph parameters', () => {
         it('should return all objects with this subject and graph', () => {
-          store.getObjects(new NamedNode('s1'), null, new DefaultGraph()).should.have.deep.members([new NamedNode('o1'), new NamedNode('o2')]);
+          expect(store.getObjects(new NamedNode('s1'), null, new DefaultGraph())).toEqual(expect.arrayContaining([new NamedNode('o1'), new NamedNode('o2')]));
         });
       });
 
       describe('with existing predicate and graph parameters', () => {
         it('should return all objects with this predicate and graph', () => {
-          store.getObjects(null, new NamedNode('p1'), new DefaultGraph()).should.have.deep.members([new NamedNode('o1'), new NamedNode('o2'), new NamedNode('o3')]);
+          expect(store.getObjects(null, new NamedNode('p1'), new DefaultGraph())).toEqual(
+            expect.arrayContaining([new NamedNode('o1'), new NamedNode('o2'), new NamedNode('o3')])
+          );
         });
       });
 
       describe('with an existing subject parameter', () => {
         it('should return all objects with this subject', () => {
-          store.getObjects(new NamedNode('s1'), null, null).should.have.deep.members([new NamedNode('o1'), new NamedNode('o2')]);
+          expect(store.getObjects(new NamedNode('s1'), null, null)).toEqual(expect.arrayContaining([new NamedNode('o1'), new NamedNode('o2')]));
         });
       });
 
       describe('with an existing predicate parameter', () => {
         it('should return all objects with this predicate', () => {
-          store.getObjects(null, new NamedNode('p1'), null).should.have.deep.members([new NamedNode('o1'), new NamedNode('o2'),  new NamedNode('o3')]);
+          expect(store.getObjects(null, new NamedNode('p1'), null)).toEqual(
+            expect.arrayContaining([new NamedNode('o1'), new NamedNode('o2'),  new NamedNode('o3')])
+          );
         });
       });
 
       describe('with an existing graph parameter', () => {
         it('should return all objects in the graph', () => {
-          store.getObjects(null, null, new NamedNode('c4')).should.have.deep.members([new NamedNode('o1')]);
+          expect(store.getObjects(null, null, new NamedNode('c4'))).toEqual(expect.arrayContaining([new NamedNode('o1')]));
         });
       });
 
       describe('with no parameters', () => {
         it('should return all objects', () => {
-          store.getObjects(null, null, null).should.have.deep.members([new NamedNode('o1'), new NamedNode('o2'), new NamedNode('o3')]);
+          expect(store.getObjects(null, null, null)).toEqual(
+            expect.arrayContaining([new NamedNode('o1'), new NamedNode('o2'), new NamedNode('o3')])
+          );
         });
       });
     });
 
     describe('getGraphs', () => {
       describe('with existing subject, predicate and object parameters', () => {
-        it('should return all graphs with this subject, predicate and object', () => {
-          store.getGraphs(new NamedNode('s1'), new NamedNode('p1'), new NamedNode('o1')).should.have.deep.members([new NamedNode('c4'), new DefaultGraph()]);
-        });
+        it(
+          'should return all graphs with this subject, predicate and object',
+          () => {
+            expect(
+              store.getGraphs(new NamedNode('s1'), new NamedNode('p1'), new NamedNode('o1'))
+            ).toEqual(expect.arrayContaining([new NamedNode('c4'), new DefaultGraph()]));
+          }
+        );
       });
 
       describe('with existing subject and predicate parameters', () => {
         it('should return all graphs with this subject and predicate', () => {
-          store.getGraphs(new NamedNode('s1'), new NamedNode('p1'), null).should.have.deep.members([new NamedNode('c4'),  new DefaultGraph()]);
+          expect(store.getGraphs(new NamedNode('s1'), new NamedNode('p1'), null)).toEqual(expect.arrayContaining([new NamedNode('c4'),  new DefaultGraph()]));
         });
       });
 
       describe('with existing subject and object parameters', () => {
         it('should return all graphs with this subject and object', () => {
-          store.getGraphs(new NamedNode('s1'), null, new NamedNode('o2')).should.have.deep.members([new DefaultGraph()]);
+          expect(store.getGraphs(new NamedNode('s1'), null, new NamedNode('o2'))).toEqual(expect.arrayContaining([new DefaultGraph()]));
         });
       });
 
       describe('with existing predicate and object parameters', () => {
         it('should return all graphs with this predicate and object', () => {
-          store.getGraphs(null, new NamedNode('p1'), new NamedNode('o1')).should.have.deep.members([new DefaultGraph(), new NamedNode('c4')]);
+          expect(store.getGraphs(null, new NamedNode('p1'), new NamedNode('o1'))).toEqual(expect.arrayContaining([new DefaultGraph(), new NamedNode('c4')]));
         });
       });
 
       describe('with an existing subject parameter', () => {
         it('should return all graphs with this subject', () => {
-          store.getGraphs(new NamedNode('s1'), null, null).should.have.deep.members([new NamedNode('c4'), new DefaultGraph()]);
+          expect(store.getGraphs(new NamedNode('s1'), null, null)).toEqual(expect.arrayContaining([new NamedNode('c4'), new DefaultGraph()]));
         });
       });
 
       describe('with an existing predicate parameter', () => {
         it('should return all graphs with this predicate', () => {
-          store.getGraphs(null, new NamedNode('p1'), null).should.have.deep.members([new NamedNode('c4'), new DefaultGraph()]);
+          expect(store.getGraphs(null, new NamedNode('p1'), null)).toEqual(expect.arrayContaining([new NamedNode('c4'), new DefaultGraph()]));
         });
       });
 
       describe('with an existing object parameter', () => {
         it('should return all graphs with this object', () => {
-          store.getGraphs(null, null, new NamedNode('o2')).should.have.deep.members([new DefaultGraph()]);
+          expect(store.getGraphs(null, null, new NamedNode('o2'))).toEqual(expect.arrayContaining([new DefaultGraph()]));
         });
       });
 
       describe('with no parameters', () => {
         it('should return all graphs', () => {
-          store.getGraphs(null, null, null).should.have.deep.members([new NamedNode('c4'), new DefaultGraph()]);
+          expect(store.getGraphs(null, null, null)).toEqual(expect.arrayContaining([new NamedNode('c4'), new DefaultGraph()]));
         });
       });
     });
 
     describe('forEach', () => {
       describe('with existing subject, predicate, object and graph parameters', () => {
-        it('should have iterated all items with this subject, predicate, object and graph',
+        it(
+          'should have iterated all items with this subject, predicate, object and graph',
           shouldIncludeAll(collect(store, 'forEach', 's1', 'p1', 'o2', ''),
-                           ['s1', 'p1', 'o2', '']));
+                           ['s1', 'p1', 'o2', ''])
+        );
       });
 
       describe('with existing subject, predicate and object parameters', () => {
-        it('should have iterated all items with this subject, predicate and object',
+        it(
+          'should have iterated all items with this subject, predicate and object',
           shouldIncludeAll(collect(store, 'forEach', 's1', 'p2', 'o2', null),
-                           ['s1', 'p2', 'o2', '']));
+                           ['s1', 'p2', 'o2', ''])
+        );
       });
 
       describe('with existing subject, predicate and graph parameters', () => {
-        it('should have iterated all items with this subject, predicate and graph',
+        it(
+          'should have iterated all items with this subject, predicate and graph',
           shouldIncludeAll(collect(store, 'forEach', 's1', 'p1', null, ''),
                            ['s1', 'p1', 'o1', ''],
-                           ['s1', 'p1', 'o2', '']));
+                           ['s1', 'p1', 'o2', ''])
+        );
       });
 
       describe('with existing subject, object and graph parameters', () => {
-        it('should have iterated all items with this subject, object and graph',
+        it(
+          'should have iterated all items with this subject, object and graph',
           shouldIncludeAll(collect(store, 'forEach', 's1', null, 'o2', ''),
                            ['s1', 'p1', 'o2', ''],
-                           ['s1', 'p2', 'o2', '']));
+                           ['s1', 'p2', 'o2', ''])
+        );
       });
 
       describe('with existing predicate, object and graph parameters', () => {
-        it('should have iterated all items with this predicate, object and graph',
+        it(
+          'should have iterated all items with this predicate, object and graph',
           shouldIncludeAll(collect(store, 'forEach', null, 'p1', 'o1', ''),
                            ['s1', 'p1', 'o1', ''],
-                           ['s2', 'p1', 'o1', '']));
+                           ['s2', 'p1', 'o1', ''])
+        );
       });
 
       describe('with existing subject and predicate parameters', () => {
-        it('should iterate all items with this subject and predicate',
+        it(
+          'should iterate all items with this subject and predicate',
           shouldIncludeAll(collect(store, 'forEach', 's1', 'p1', null, null),
                            ['s1', 'p1', 'o1', ''],
                            ['s1', 'p1', 'o2', ''],
-                           ['s1', 'p1', 'o1', 'c4']));
+                           ['s1', 'p1', 'o1', 'c4'])
+        );
       });
 
       describe('with existing subject and object parameters', () => {
-        it('should iterate all items with this subject and predicate',
+        it(
+          'should iterate all items with this subject and predicate',
           shouldIncludeAll(collect(store, 'forEach', 's1', null, 'o2', null),
                            ['s1', 'p1', 'o2', ''],
-                           ['s1', 'p2', 'o2', '']));
+                           ['s1', 'p2', 'o2', ''])
+        );
       });
 
       describe('with existing subject and graph parameters', () => {
-        it('should iterate all items with this subject and graph',
+        it(
+          'should iterate all items with this subject and graph',
           shouldIncludeAll(collect(store, 'forEach', 's1', null, null, 'c4'),
-                         ['s1', 'p1', 'o1', 'c4']));
+                         ['s1', 'p1', 'o1', 'c4'])
+        );
       });
 
       describe('with existing predicate and object parameters', () => {
-        it('should iterate all items with this predicate and object',
+        it(
+          'should iterate all items with this predicate and object',
           shouldIncludeAll(collect(store, 'forEach', null, 'p1', 'o1', null),
                            ['s1', 'p1', 'o1', ''],
                            ['s2', 'p1', 'o1', ''],
-                           ['s1', 'p1', 'o1', 'c4']));
+                           ['s1', 'p1', 'o1', 'c4'])
+        );
       });
 
       describe('with existing predicate and graph parameters', () => {
-        it('should iterate all items with this predicate and graph',
-        shouldIncludeAll(collect(store, 'forEach', null, 'p1', null, ''),
-                           ['s1', 'p1', 'o1', ''],
-                           ['s1', 'p1', 'o2', ''],
-                           ['s2', 'p1', 'o1', ''],
-                           [termToId(new Quad('s2', 'p2', 'o2')), 'p1', 'o3', '']));
+        it(
+          'should iterate all items with this predicate and graph',
+          shouldIncludeAll(collect(store, 'forEach', null, 'p1', null, ''),
+                             ['s1', 'p1', 'o1', ''],
+                             ['s1', 'p1', 'o2', ''],
+                             ['s2', 'p1', 'o1', ''],
+                             [termToId(new Quad('s2', 'p2', 'o2')), 'p1', 'o3', ''])
+        );
       });
 
       describe('with existing object and graph parameters', () => {
-        it('should iterate all items with this object and graph',
+        it(
+          'should iterate all items with this object and graph',
           shouldIncludeAll(collect(store, 'forEach', null, null, 'o1', ''),
                            ['s1', 'p1', 'o1', ''],
-                           ['s2', 'p1', 'o1', '']));
+                           ['s2', 'p1', 'o1', ''])
+        );
       });
 
       describe('with an existing subject parameter', () => {
-        it('should iterate all items with this subject',
+        it(
+          'should iterate all items with this subject',
           shouldIncludeAll(collect(store, 'forEach', 's2', null, null, null),
                          ['s2', 'p1', 'o1', ''],
-                         ['s2', 'p2', 'o2', '']));
+                         ['s2', 'p2', 'o2', ''])
+        );
       });
 
       describe('with an existing predicate parameter', () => {
-        it('should iterate all items with this predicate',
+        it(
+          'should iterate all items with this predicate',
           shouldIncludeAll(collect(store, 'forEach', null, 'p1', null, null),
                            ['s1', 'p1', 'o1', ''],
                            ['s1', 'p1', 'o2', ''],
                            ['s2', 'p1', 'o1', ''],
                            ['s1', 'p1', 'o1', 'c4'],
-                           [termToId(new Quad('s2', 'p2', 'o2')), 'p1', 'o3', '']));
+                           [termToId(new Quad('s2', 'p2', 'o2')), 'p1', 'o3', ''])
+        );
       });
 
       describe('with an existing object parameter', () => {
-        it('should iterate all items with this object',
+        it(
+          'should iterate all items with this object',
           shouldIncludeAll(collect(store, 'forEach', null, null, 'o1', null),
                            ['s1', 'p1', 'o1', ''],
                            ['s2', 'p1', 'o1', ''],
-                           ['s1', 'p1', 'o1', 'c4']));
+                           ['s1', 'p1', 'o1', 'c4'])
+        );
       });
 
       describe('with an existing graph parameter', () => {
-        it('should iterate all items with this graph',
+        it(
+          'should iterate all items with this graph',
           shouldIncludeAll(collect(store, 'forEach', null, null, null, ''),
                            ['s1', 'p1', 'o1'],
                            ['s1', 'p1', 'o2'],
                            ['s1', 'p2', 'o2'],
                            ['s2', 'p1', 'o1'],
                            ['s2', 'p2', 'o2'],
-                           [termToId(new Quad('s2', 'p2', 'o2')), 'p1', 'o3', '']));
+                           [termToId(new Quad('s2', 'p2', 'o2')), 'p1', 'o3', ''])
+        );
       });
 
       describe('with no parameters', () => {
-        it('should iterate all items',
+        it(
+          'should iterate all items',
           shouldIncludeAll(collect(store, 'forEach', null, null, null, null),
                            ['s1', 'p1', 'o1'],
                            ['s1', 'p1', 'o2'],
@@ -904,98 +1017,111 @@ describe('Store', () => {
                            ['s2', 'p1', 'o1'],
                            ['s2', 'p2', 'o2'],
                            ['s1', 'p1', 'o1', 'c4'],
-                           [termToId(new Quad('s2', 'p2', 'o2')), 'p1', 'o3', '']));
+                           [termToId(new Quad('s2', 'p2', 'o2')), 'p1', 'o3', ''])
+        );
       });
     });
 
     describe('forSubjects', () => {
       describe('with existing predicate, object and graph parameters', () => {
-        it('should iterate all subjects with this predicate, object and graph', () => {
-          collect(store, 'forSubjects', 'p1', 'o1', '').should.have.deep.members([new NamedNode('s1'), new NamedNode('s2')]);
-        });
+        it(
+          'should iterate all subjects with this predicate, object and graph',
+          () => {
+            expect(collect(store, 'forSubjects', 'p1', 'o1', '')).toEqual(expect.arrayContaining([new NamedNode('s1'), new NamedNode('s2')]));
+          }
+        );
       });
       describe('with a non-existing predicate', () => {
         it('should be empty', () => {
-          collect(store, 'forSubjects', 'p3', null, null).should.be.empty;
+          expect(collect(store, 'forSubjects', 'p3', null, null)).toHaveLength(0);
         });
       });
       describe('with a non-existing object', () => {
         it('should be empty', () => {
-          collect(store, 'forSubjects', null, 'o4', null).should.be.empty;
+          expect(collect(store, 'forSubjects', null, 'o4', null)).toHaveLength(0);
         });
       });
       describe('with a non-existing graph', () => {
         it('should be empty', () => {
-          collect(store, 'forSubjects', null, null, 'g2').should.be.empty;
+          expect(collect(store, 'forSubjects', null, null, 'g2')).toHaveLength(0);
         });
       });
     });
 
     describe('forPredicates', () => {
       describe('with existing subject, object and graph parameters', () => {
-        it('should iterate all predicates with this subject, object and graph', () => {
-          collect(store, 'forPredicates', 's1', 'o2', '').should.have.deep.members([new NamedNode('p1'), new NamedNode('p2')]);
-        });
+        it(
+          'should iterate all predicates with this subject, object and graph',
+          () => {
+            expect(collect(store, 'forPredicates', 's1', 'o2', '')).toEqual(expect.arrayContaining([new NamedNode('p1'), new NamedNode('p2')]));
+          }
+        );
       });
       describe('with a non-existing subject', () => {
         it('should be empty', () => {
-          collect(store, 'forPredicates', 's3', null, null).should.be.empty;
+          expect(collect(store, 'forPredicates', 's3', null, null)).toHaveLength(0);
         });
       });
       describe('with a non-existing object', () => {
         it('should be empty', () => {
-          collect(store, 'forPredicates', null, 'o4', null).should.be.empty;
+          expect(collect(store, 'forPredicates', null, 'o4', null)).toHaveLength(0);
         });
       });
       describe('with a non-existing graph', () => {
         it('should be empty', () => {
-          collect(store, 'forPredicates', null, null, 'g2').should.be.empty;
+          expect(collect(store, 'forPredicates', null, null, 'g2')).toHaveLength(0);
         });
       });
     });
 
     describe('forObjects', () => {
       describe('with existing subject, predicate and graph parameters', () => {
-        it('should iterate all objects with this subject, predicate and graph', () => {
-          collect(store, 'forObjects', 's1', 'p1', '').should.have.deep.members([new NamedNode('o1'), new NamedNode('o2')]);
-        });
+        it(
+          'should iterate all objects with this subject, predicate and graph',
+          () => {
+            expect(collect(store, 'forObjects', 's1', 'p1', '')).toEqual(expect.arrayContaining([new NamedNode('o1'), new NamedNode('o2')]));
+          }
+        );
       });
       describe('with a non-existing subject', () => {
         it('should be empty', () => {
-          collect(store, 'forObjects', 's3', null, null).should.be.empty;
+          expect(collect(store, 'forObjects', 's3', null, null)).toHaveLength(0);
         });
       });
       describe('with a non-existing predicate', () => {
         it('should be empty', () => {
-          collect(store, 'forObjects', null, 'p3', null).should.be.empty;
+          expect(collect(store, 'forObjects', null, 'p3', null)).toHaveLength(0);
         });
       });
       describe('with a non-existing graph', () => {
         it('should be empty', () => {
-          collect(store, 'forObjects', null, null, 'g2').should.be.empty;
+          expect(collect(store, 'forObjects', null, null, 'g2')).toHaveLength(0);
         });
       });
     });
 
     describe('forGraphs', () => {
       describe('with existing subject, predicate and object parameters', () => {
-        it('should iterate all graphs with this subject, predicate and object', () => {
-          collect(store, 'forGraphs', 's1', 'p1', 'o1').should.have.deep.members([new DefaultGraph(), new NamedNode('c4')]);
-        });
+        it(
+          'should iterate all graphs with this subject, predicate and object',
+          () => {
+            expect(collect(store, 'forGraphs', 's1', 'p1', 'o1')).toEqual(expect.arrayContaining([new DefaultGraph(), new NamedNode('c4')]));
+          }
+        );
       });
       describe('with a non-existing subject', () => {
         it('should be empty', () => {
-          collect(store, 'forObjects', 's3', null, null).should.be.empty;
+          expect(collect(store, 'forObjects', 's3', null, null)).toHaveLength(0);
         });
       });
       describe('with a non-existing predicate', () => {
         it('should be empty', () => {
-          collect(store, 'forObjects', null, 'p3', null).should.be.empty;
+          expect(collect(store, 'forObjects', null, 'p3', null)).toHaveLength(0);
         });
       });
       describe('with a non-existing graph', () => {
         it('should be empty', () => {
-          collect(store, 'forPredicates', null, null, 'g2').should.be.empty;
+          expect(collect(store, 'forPredicates', null, null, 'g2')).toHaveLength(0);
         });
       });
     });
@@ -1006,17 +1132,17 @@ describe('Store', () => {
 
       describe('with no parameters and a callback always returning true', () => {
         it('should return true', () => {
-          store.every(alwaysTrue, null, null, null, null).should.be.true;
+          expect(store.every(alwaysTrue, null, null, null, null)).toBe(true);
         });
       });
       describe('with no parameters and a callback always returning false', () => {
         it('should return false', () => {
-          store.every(alwaysFalse, null, null, null, null).should.be.false;
+          expect(store.every(alwaysFalse, null, null, null, null)).toBe(false);
         });
       });
       describe('with no parameters and a callback that returns false after 3 calls', () => {
         it('should return false', () => {
-          store.every(thirdTimeFalse, null, null, null, null).should.be.false;
+          expect(store.every(thirdTimeFalse, null, null, null, null)).toBe(false);
         });
       });
     });
@@ -1027,55 +1153,54 @@ describe('Store', () => {
 
       describe('with no parameters and a callback always returning true', () => {
         it('should return true', () => {
-          store.some(alwaysTrue, null, null, null, null).should.be.true;
+          expect(store.some(alwaysTrue, null, null, null, null)).toBe(true);
         });
       });
       describe('with no parameters and a callback always returning false', () => {
         it('should return false', () => {
-          store.some(alwaysFalse, null, null, null, null).should.be.false;
+          expect(store.some(alwaysFalse, null, null, null, null)).toBe(false);
         });
       });
       describe('with no parameters and a callback that returns true after 3 calls', () => {
         it('should return false', () => {
-          store.some(thirdTimeFalse, null, null, null, null).should.be.true;
+          expect(store.some(thirdTimeFalse, null, null, null, null)).toBe(true);
         });
       });
       describe('with a non-existing subject', () => {
         it('should return true', () => {
-          store.some(null, new NamedNode('s3'), null, null, null).should.be.false;
+          expect(store.some(null, new NamedNode('s3'), null, null, null)).toBe(false);
         });
       });
       describe('with a non-existing predicate', () => {
         it('should return false', () => {
-          store.some(null, null, new NamedNode('p3'), null, null).should.be.false;
+          expect(store.some(null, null, new NamedNode('p3'), null, null)).toBe(false);
         });
       });
       describe('with a non-existing object', () => {
         it('should return false', () => {
-          store.some(null, null, null, new NamedNode('o4'), null).should.be.false;
+          expect(store.some(null, null, null, new NamedNode('o4'), null)).toBe(false);
         });
       });
       describe('with a non-existing graph', () => {
         it('should return false', () => {
-          store.some(null, null, null, null, new NamedNode('g2')).should.be.false;
+          expect(store.some(null, null, null, null, new NamedNode('g2'))).toBe(false);
         });
       });
     });
 
     describe('when destructured', () => {
-      it('should destructure all quads',
-        shouldIncludeAll(
-          () => {
-            const [a, b, c, d, e, f, g] = store;
-            return [a, b, c, d, e, f, g];
-          },
-          ['s1', 'p1', 'o1'],
-          ['s1', 'p1', 'o2'],
-          ['s1', 'p2', 'o2'],
-          ['s2', 'p1', 'o1'],
-          ['s2', 'p2', 'o2'],
-          ['s1', 'p1', 'o1', 'c4'],
-          [termToId(new Quad('s2', 'p2', 'o2')), 'p1', 'o3']));
+      it('should destructure all quads', shouldIncludeAll(
+        () => {
+          const [a, b, c, d, e, f, g] = store;
+          return [a, b, c, d, e, f, g];
+        },
+        ['s1', 'p1', 'o1'],
+        ['s1', 'p1', 'o2'],
+        ['s1', 'p2', 'o2'],
+        ['s2', 'p1', 'o1'],
+        ['s2', 'p2', 'o2'],
+        ['s1', 'p1', 'o1', 'c4'],
+        [termToId(new Quad('s2', 'p2', 'o2')), 'p1', 'o3']));
     });
 
     describe('when iterated with for...of', () => {
@@ -1085,289 +1210,371 @@ describe('Store', () => {
         for (const quad of store) {
           count += 1;
         }
-        should.equal(count, 7);
+        expect(count).toBe(7);
       });
     });
 
     describe('when spread', () => {
-      it('should spread all quads',
-        shouldIncludeAll(
-          [...store],
-          ['s1', 'p1', 'o1'],
-          ['s1', 'p1', 'o2'],
-          ['s1', 'p2', 'o2'],
-          ['s2', 'p1', 'o1'],
-          ['s1', 'p1', 'o1', 'c4'],
-          [termToId(new Quad('s2', 'p2', 'o2')), 'p1', 'o3'],
-          ['s2', 'p2', 'o2']));
+      it('should spread all quads', shouldIncludeAll(
+        [...store],
+        ['s1', 'p1', 'o1'],
+        ['s1', 'p1', 'o2'],
+        ['s1', 'p2', 'o2'],
+        ['s2', 'p1', 'o1'],
+        ['s1', 'p1', 'o1', 'c4'],
+        [termToId(new Quad('s2', 'p2', 'o2')), 'p1', 'o3'],
+        ['s2', 'p2', 'o2']));
     });
 
     describe('when yield starred', () => {
-      it('should yield all quads',
-        shouldIncludeAll(
-          () => {
-            function* yieldAll() {
-              yield* store;
-            }
-            return Array.from(yieldAll());
-          },
-          ['s1', 'p1', 'o1'],
-          ['s1', 'p1', 'o2'],
-          ['s1', 'p2', 'o2'],
-          ['s2', 'p1', 'o1'],
-          ['s2', 'p2', 'o2'],
-          ['s1', 'p1', 'o1', 'c4'],
-          [termToId(new Quad('s2', 'p2', 'o2')), 'p1', 'o3']));
+      it('should yield all quads', shouldIncludeAll(
+        () => {
+          function* yieldAll() {
+            yield* store;
+          }
+          return Array.from(yieldAll());
+        },
+        ['s1', 'p1', 'o1'],
+        ['s1', 'p1', 'o2'],
+        ['s1', 'p2', 'o2'],
+        ['s2', 'p1', 'o1'],
+        ['s2', 'p2', 'o2'],
+        ['s1', 'p1', 'o1', 'c4'],
+        [termToId(new Quad('s2', 'p2', 'o2')), 'p1', 'o3']));
     });
 
     describe('when counted without parameters', () => {
       it('should count all items in all graphs', () => {
-        store.countQuads().should.equal(7);
+        expect(store.countQuads()).toBe(7);
       });
     });
 
     describe('when counted with an existing subject parameter', () => {
       it('should count all items with this subject in all graphs', () => {
-        store.countQuads(new NamedNode('s1'), null, null).should.equal(4);
+        expect(store.countQuads(new NamedNode('s1'), null, null)).toBe(4);
       });
     });
 
     describe('when counted with a non-existing subject parameter', () => {
       it('should be empty', () => {
-        store.countQuads(new NamedNode('s3'), null, null).should.equal(0);
+        expect(store.countQuads(new NamedNode('s3'), null, null)).toBe(0);
       });
     });
 
     describe('when counted with a non-existing subject parameter that exists elsewhere', () => {
       it('should be empty', () => {
-        store.countQuads(new NamedNode('p1'), null, null).should.equal(0);
+        expect(store.countQuads(new NamedNode('p1'), null, null)).toBe(0);
       });
     });
 
     describe('when counted with an existing predicate parameter', () => {
       it('should count all items with this predicate in all graphs', () => {
-        store.countQuads(null, new NamedNode('p1'), null).should.equal(5);
+        expect(store.countQuads(null, new NamedNode('p1'), null)).toBe(5);
       });
     });
 
     describe('when counted with a non-existing predicate parameter', () => {
       it('should be empty', () => {
-        store.countQuads(null, new NamedNode('p3'), null).should.equal(0);
+        expect(store.countQuads(null, new NamedNode('p3'), null)).toBe(0);
       });
     });
 
     describe('when counted with an existing object parameter', () => {
       it('should count all items with this object in all graphs', () => {
-        store.countQuads(null, null, 'o1').should.equal(3);
+        expect(store.countQuads(null, null, 'o1')).toBe(3);
       });
     });
 
     describe('when counted with a non-existing object parameter', () => {
       it('should be empty', () => {
-        store.countQuads(null, null, 'o4').should.equal(0);
+        expect(store.countQuads(null, null, 'o4')).toBe(0);
       });
     });
 
     describe('when counted with existing subject and predicate parameters', () => {
-      it('should count all items with this subject and predicate in all graphs', () => {
-        store.countQuads('s1', 'p1', null).should.equal(3);
-      });
+      it(
+        'should count all items with this subject and predicate in all graphs',
+        () => {
+          expect(store.countQuads('s1', 'p1', null)).toBe(3);
+        }
+      );
     });
 
     describe('when counted with non-existing subject and predicate parameters', () => {
       it('should be empty', () => {
-        store.countQuads('s2', 'p3', null).should.equal(0);
+        expect(store.countQuads('s2', 'p3', null)).toBe(0);
       });
     });
 
     describe('when counted with existing subject and object parameters', () => {
-      it('should count all items with this subject and object in all graphs', () => {
-        store.countQuads('s1', null, 'o1').should.equal(2);
-      });
+      it(
+        'should count all items with this subject and object in all graphs',
+        () => {
+          expect(store.countQuads('s1', null, 'o1')).toBe(2);
+        }
+      );
     });
 
     describe('when counted with non-existing subject and object parameters', () => {
       it('should be empty', () => {
-        store.countQuads('s2', null, 'o3').should.equal(0);
+        expect(store.countQuads('s2', null, 'o3')).toBe(0);
       });
     });
 
     describe('when counted with existing predicate and object parameters', () => {
-      it('should count all items with this predicate and object in all graphs', () => {
-        store.countQuads(null, 'p1', 'o1').should.equal(3);
-      });
+      it(
+        'should count all items with this predicate and object in all graphs',
+        () => {
+          expect(store.countQuads(null, 'p1', 'o1')).toBe(3);
+        }
+      );
     });
 
     describe('when counted with non-existing predicate and object parameters', () => {
       it('should be empty', () => {
-        store.countQuads(null, 'p2', 'o3').should.equal(0);
+        expect(store.countQuads(null, 'p2', 'o3')).toBe(0);
       });
     });
 
     describe('when counted with existing subject, predicate, and object parameters', () => {
-      it('should count all items with this subject, predicate, and object in all graphs', () => {
-        store.countQuads('s1', 'p1', 'o1').should.equal(2);
-      });
+      it(
+        'should count all items with this subject, predicate, and object in all graphs',
+        () => {
+          expect(store.countQuads('s1', 'p1', 'o1')).toBe(2);
+        }
+      );
     });
 
     describe('when counted with a non-existing triple', () => {
       it('should be empty', () => {
-        store.countQuads('s2', 'p2', 'o1').should.equal(0);
+        expect(store.countQuads('s2', 'p2', 'o1')).toBe(0);
       });
     });
 
     describe('when counted with the default graph parameter', () => {
       it('should count all items in the default graph', () => {
-        store.countQuads(null, null, null, new DefaultGraph()).should.equal(6);
+        expect(store.countQuads(null, null, null, new DefaultGraph())).toBe(6);
       });
     });
 
     describe('when counted with an existing named graph parameter', () => {
       it('should count all items in that graph', () => {
-        store.countQuads(null, null, null, 'c4').should.equal(1);
+        expect(store.countQuads(null, null, null, 'c4')).toBe(1);
       });
     });
 
     describe('when counted with a non-existing named graph parameter', () => {
       it('should be empty', () => {
-        store.countQuads(null, null, null, 'c5').should.equal(0);
+        expect(store.countQuads(null, null, null, 'c5')).toBe(0);
       });
     });
 
     describe('when trying to remove a triple with a non-existing subject', () => {
-      before(() => { store.removeQuad(new NamedNode('s0'), new NamedNode('p1'), new NamedNode('o1')).should.be.false; });
-      it('should still have size 7', () => { store.size.should.eql(7); });
+      beforeAll(
+        () => {
+          expect(
+          store.removeQuad(new NamedNode('s0'), new NamedNode('p1'), new NamedNode('o1'))
+        ).toBe(false);
+        }
+      );
+      it('should still have size 7', () => { expect(store.size).toEqual(7); });
     });
 
     describe('when trying to remove a triple with a non-existing predicate', () => {
-      before(() => { store.removeQuad(new NamedNode('s1'), new NamedNode('p0'), new NamedNode('o1')).should.be.false; });
-      it('should still have size 7', () => { store.size.should.eql(7); });
+      beforeAll(
+        () => {
+          expect(
+          store.removeQuad(new NamedNode('s1'), new NamedNode('p0'), new NamedNode('o1'))
+        ).toBe(false);
+        }
+      );
+      it('should still have size 7', () => { expect(store.size).toEqual(7); });
     });
 
     describe('when trying to remove a triple with a non-existing object', () => {
-      before(() => { store.removeQuad(new NamedNode('s1'), new NamedNode('p1'), new NamedNode('o0')).should.be.false; });
-      it('should still have size 7', () => { store.size.should.eql(7); });
+      beforeAll(
+        () => {
+          expect(
+          store.removeQuad(new NamedNode('s1'), new NamedNode('p1'), new NamedNode('o0'))
+        ).toBe(false);
+        }
+      );
+      it('should still have size 7', () => { expect(store.size).toEqual(7); });
     });
 
     describe('when trying to remove a triple for which no subjects exist', () => {
-      before(() => { store.removeQuad(new NamedNode('o1'), new NamedNode('p1'), new NamedNode('o1')).should.be.false; });
-      it('should still have size 7', () => { store.size.should.eql(7); });
+      beforeAll(
+        () => {
+          expect(
+          store.removeQuad(new NamedNode('o1'), new NamedNode('p1'), new NamedNode('o1'))
+        ).toBe(false);
+        }
+      );
+      it('should still have size 7', () => { expect(store.size).toEqual(7); });
     });
 
     describe('when trying to remove a triple for which no predicates exist', () => {
-      before(() => { store.removeQuad(new NamedNode('s1'), new NamedNode('s1'), new NamedNode('o1')).should.be.false; });
-      it('should still have size 7', () => { store.size.should.eql(7); });
+      beforeAll(
+        () => {
+          expect(
+          store.removeQuad(new NamedNode('s1'), new NamedNode('s1'), new NamedNode('o1'))
+        ).toBe(false);
+        }
+      );
+      it('should still have size 7', () => { expect(store.size).toEqual(7); });
     });
 
     describe('when trying to remove a triple for which no objects exist', () => {
-      before(() => { store.removeQuad(new NamedNode('s1'), new NamedNode('p1'), new NamedNode('s1')).should.be.false; });
-      it('should still have size 7', () => { store.size.should.eql(7); });
+      beforeAll(
+        () => {
+          expect(
+          store.removeQuad(new NamedNode('s1'), new NamedNode('p1'), new NamedNode('s1'))
+        ).toBe(false);
+        }
+      );
+      it('should still have size 7', () => { expect(store.size).toEqual(7); });
     });
 
     describe('when trying to remove a triple that does not exist', () => {
-      before(() => { store.removeQuad(new NamedNode('s1'), new NamedNode('p2'), new NamedNode('o1')).should.be.false; });
-      it('should still have size 7', () => { store.size.should.eql(7); });
+      beforeAll(
+        () => {
+          expect(
+          store.removeQuad(new NamedNode('s1'), new NamedNode('p2'), new NamedNode('o1'))
+        ).toBe(false);
+        }
+      );
+      it('should still have size 7', () => { expect(store.size).toEqual(7); });
     });
 
     describe('when trying to remove an incomplete triple', () => {
-      before(() => { store.removeQuad(new NamedNode('s1'), null, null).should.be.false; });
-      it('should still have size 7', () => { store.size.should.eql(7); });
+      beforeAll(
+        () => { expect(store.removeQuad(new NamedNode('s1'), null, null)).toBe(false); }
+      );
+      it('should still have size 7', () => { expect(store.size).toEqual(7); });
     });
 
     describe('when trying to remove a triple with a non-existing graph', () => {
-      before(() => { store.removeQuad(new NamedNode('s1'), new NamedNode('p1'), new NamedNode('o1'), new NamedNode('c0')).should.be.false; });
-      it('should still have size 7', () => { store.size.should.eql(7); });
+      beforeAll(
+        () => {
+          expect(
+          store.removeQuad(new NamedNode('s1'), new NamedNode('p1'), new NamedNode('o1'), new NamedNode('c0'))
+        ).toBe(false);
+        }
+      );
+      it('should still have size 7', () => { expect(store.size).toEqual(7); });
     });
 
     describe('when removing an existing triple', () => {
-      before(() => { store.removeQuad(new NamedNode('s1'), new NamedNode('p1'), new NamedNode('o1')).should.be.true; });
+      beforeAll(
+        () => {
+          expect(
+          store.removeQuad(new NamedNode('s1'), new NamedNode('p1'), new NamedNode('o1'))
+        ).toBe(true);
+        }
+      );
 
-      it('should have size 6', () => { store.size.should.eql(6); });
+      it('should have size 6', () => { expect(store.size).toEqual(6); });
 
-      it('should not contain that triple anymore',
+      it(
+        'should not contain that triple anymore',
         shouldIncludeAll(() => { return store.getQuads(); },
                          ['s1', 'p1', 'o2'],
                          ['s1', 'p2', 'o2'],
                          ['s2', 'p1', 'o1'],
                          ['s2', 'p2', 'o2'],
                          ['s1', 'p1', 'o1', 'c4'],
-                         [termToId(new Quad('s2', 'p2', 'o2')), 'p1', 'o3', '']));
+                         [termToId(new Quad('s2', 'p2', 'o2')), 'p1', 'o3', ''])
+      );
     });
 
     describe('when removing an existing triple from a named graph', () => {
-      before(() => { store.removeQuad(new NamedNode('s1'), new NamedNode('p1'), new NamedNode('o1'), new NamedNode('c4')).should.be.true; });
+      beforeAll(
+        () => {
+          expect(
+          store.removeQuad(new NamedNode('s1'), new NamedNode('p1'), new NamedNode('o1'), new NamedNode('c4'))
+        ).toBe(true);
+        }
+      );
 
-      it('should have size 5', () => { store.size.should.eql(5); });
+      it('should have size 5', () => { expect(store.size).toEqual(5); });
 
       itShouldBeEmpty(() => { return store.getQuads(null, null, null, 'c4'); });
     });
 
     describe('when removing multiple triples', () => {
-      before(() => {
+      beforeAll(() => {
         store.removeQuads([
           new Quad(new NamedNode('s1'), new NamedNode('p2'), new NamedNode('o2')),
           new Quad(new NamedNode('s2'), new NamedNode('p1'), new NamedNode('o1')),
         ]);
       });
 
-      it('should have size 3', () => { store.size.should.eql(3); });
+      it('should have size 3', () => { expect(store.size).toEqual(3); });
 
-      it('should not contain those triples anymore',
+      it(
+        'should not contain those triples anymore',
         shouldIncludeAll(() => { return store.getQuads(); },
                          ['s1', 'p1', 'o2'],
                          ['s2', 'p2', 'o2'],
-                         [termToId(new Quad('s2', 'p2', 'o2')), 'p1', 'o3', '']));
+                         [termToId(new Quad('s2', 'p2', 'o2')), 'p1', 'o3', ''])
+      );
     });
 
     describe('when adding and removing a triple', () => {
-      before(() => {
-        store.addQuad(new NamedNode('a'), new NamedNode('b'), new NamedNode('c')).should.be.true;
-        store.removeQuad(new NamedNode('a'), new NamedNode('b'), new NamedNode('c')).should.be.true;
+      beforeAll(() => {
+        expect(store.addQuad(new NamedNode('a'), new NamedNode('b'), new NamedNode('c'))).toBe(true);
+        expect(
+          store.removeQuad(new NamedNode('a'), new NamedNode('b'), new NamedNode('c'))
+        ).toBe(true);
       });
 
-      it('should have an unchanged size', () => { store.size.should.eql(3); });
+      it('should have an unchanged size', () => { expect(store.size).toEqual(3); });
     });
   });
 
   describe('A Store containing a blank node', () => {
     const store = new Store();
     const b1 = store.createBlankNode();
-    store.addQuad(new NamedNode('s1'), new NamedNode('p1'), b1).should.be.true;
+    expect(store.addQuad(new NamedNode('s1'), new NamedNode('p1'), b1)).toBe(true);
 
     describe('when searched with more than one variable', () => {
-      it('should return a triple with the blank node as an object',
+      it(
+        'should return a triple with the blank node as an object',
         shouldIncludeAll(store.getQuads(),
-                         ['s1', 'p1', `_:${b1.value}`]));
+                         ['s1', 'p1', `_:${b1.value}`])
+      );
     });
 
     describe('when searched with one variable', () => {
-      it('should return a triple with the blank node as an object',
+      it(
+        'should return a triple with the blank node as an object',
         shouldIncludeAll(store.getQuads('s1', 'p1'),
-                         ['s1', 'p1', `_:${b1.value}`]));
+                         ['s1', 'p1', `_:${b1.value}`])
+      );
     });
   });
 
   describe('A Store with a custom DataFactory', () => {
     const factory = {};
     let store;
-    before(() => {
+    beforeAll(() => {
       factory.quad = function (s, p, o, g) { return { s: s, p: p, o: o, g: g }; };
       ['namedNode', 'blankNode', 'literal', 'variable', 'defaultGraph'].forEach(f => {
         factory[f] = function (n) { return n ? `${f[0]}-${n}` : f; };
       });
 
       store = new Store({ factory: factory });
-      store.addQuad('s1', 'p1', 'o1').should.be.true;
-      store.addQuad({ subject: 's1', predicate: 'p1', object: 'o2' }).should.be.true;
+      expect(store.addQuad('s1', 'p1', 'o1')).toBe(true);
+      expect(store.addQuad({ subject: 's1', predicate: 'p1', object: 'o2' })).toBe(true);
       store.addQuads([
         { subject: 's1', predicate: 'p2', object: 'o2' },
         { subject: 's2', predicate: 'p1', object: 'o1' },
       ]);
-      store.addQuad('s1', 'p1', 'o1', 'c4').should.be.true;
+      expect(store.addQuad('s1', 'p1', 'o1', 'c4')).toBe(true);
     });
 
     it('should use the factory when returning quads', () => {
-      store.getQuads().should.deep.equal([
+      expect(store.getQuads()).toEqual([
         { s: 'n-s1', p: 'n-p1', o: 'n-o1', g: 'defaultGraph' },
         { s: 'n-s1', p: 'n-p1', o: 'n-o2', g: 'defaultGraph' },
         { s: 'n-s1', p: 'n-p2', o: 'n-o2', g: 'defaultGraph' },
@@ -1381,23 +1588,26 @@ describe('Store', () => {
     const store = new Store();
 
     it('should implement the DatasetCore interface', () => {
-      store.add.should.be.a('function');
-      store.delete.should.be.a('function');
-      store.has.should.be.a('function');
-      store.match.should.be.a('function');
-      store[Symbol.iterator].should.be.a('function');
+      expect(store.add).toBeInstanceOf(Function);
+      expect(store.delete).toBeInstanceOf(Function);
+      expect(store.has).toBeInstanceOf(Function);
+      expect(store.match).toBeInstanceOf(Function);
+      expect(store[Symbol.iterator]).toBeInstanceOf(Function);
     });
 
     // Test inspired by http://www.devthought.com/2012/01/18/an-object-is-not-a-hash/.
     // The value `__proto__` is not supported however – fixing it introduces too much overhead.
-    it('should be able to contain entities with JavaScript object property names', () => {
-      store.addQuad('toString', 'valueOf', 'toLocaleString', 'hasOwnProperty').should.be.true;
-      shouldIncludeAll(store.getQuads(null, null, null, 'hasOwnProperty'),
-                       ['toString', 'valueOf', 'toLocaleString', 'hasOwnProperty'])();
-    });
+    it(
+      'should be able to contain entities with JavaScript object property names',
+      () => {
+        expect(store.addQuad('toString', 'valueOf', 'toLocaleString', 'hasOwnProperty')).toBe(true);
+        shouldIncludeAll(store.getQuads(null, null, null, 'hasOwnProperty'),
+                         ['toString', 'valueOf', 'toLocaleString', 'hasOwnProperty'])();
+      }
+    );
 
     it('should be able to contain entities named "null"', () => {
-      store.addQuad('null', 'null', 'null', 'null').should.be.true;
+      expect(store.addQuad('null', 'null', 'null', 'null')).toBe(true);
       shouldIncludeAll(store.getQuads(null, null, null, 'null'), ['null', 'null', 'null', 'null'])();
     });
   });
@@ -1405,7 +1615,7 @@ describe('Store', () => {
   describe('A Store containing a well-formed rdf:Collection as subject', () => {
     const store = new Store();
     const listElements = addList(store, new NamedNode('element1'), new Literal('"element2"'));
-    store.addQuad(listElements[0], new NamedNode('p1'), new NamedNode('o1')).should.be.true;
+    expect(store.addQuad(listElements[0], new NamedNode('p1'), new NamedNode('o1'))).toBe(true);
     const listItemsJSON = {
       b0: [
         { termType: 'NamedNode', value: 'element1' },
@@ -1416,26 +1626,27 @@ describe('Store', () => {
 
     describe('extractLists without remove', () => {
       const lists = store.extractLists();
-      it('should not delete triples',
-        shouldIncludeAll(store.getQuads(),
-          [`_:${listElements[0].value}`, 'p1', 'o1'],
-          [`_:${listElements[0].value}`, namespaces.rdf.first, 'element1'],
-          [`_:${listElements[0].value}`, namespaces.rdf.rest, `_:${listElements[1].value}`],
-          [`_:${listElements[1].value}`, namespaces.rdf.first, '"element2"'],
-          [`_:${listElements[1].value}`, namespaces.rdf.rest, namespaces.rdf.nil]
-        ));
+      it('should not delete triples', shouldIncludeAll(store.getQuads(),
+        [`_:${listElements[0].value}`, 'p1', 'o1'],
+        [`_:${listElements[0].value}`, namespaces.rdf.first, 'element1'],
+        [`_:${listElements[0].value}`, namespaces.rdf.rest, `_:${listElements[1].value}`],
+        [`_:${listElements[1].value}`, namespaces.rdf.first, '"element2"'],
+        [`_:${listElements[1].value}`, namespaces.rdf.rest, namespaces.rdf.nil]
+      ));
       it('should generate a list of Collections', () => {
-        expect(listsToJSON(lists)).to.deep.equal(listItemsJSON);
+        expect(listsToJSON(lists)).toEqual(listItemsJSON);
       });
     });
 
     describe('extractLists with remove', () => {
       const lists = store.extractLists({ remove: true });
-      it('should remove the first/rest triples and return the list members',
+      it(
+        'should remove the first/rest triples and return the list members',
         shouldIncludeAll(store.getQuads(),
-                         [`_:${listElements[0].value}`, 'p1', 'o1']));
+                         [`_:${listElements[0].value}`, 'p1', 'o1'])
+      );
       it('should generate a list of Collections', () => {
-        expect(listsToJSON(lists)).to.deep.equal(listItemsJSON);
+        expect(listsToJSON(lists)).toEqual(listItemsJSON);
       });
     });
   });
@@ -1443,7 +1654,7 @@ describe('Store', () => {
   describe('A Store containing a well-formed rdf:Collection as object', () => {
     const store = new Store();
     const listElements = addList(store, new NamedNode('element1'), new Literal('"element2"'));
-    store.addQuad(new NamedNode('s1'), new NamedNode('p1'), listElements[0]).should.be.true;
+    expect(store.addQuad(new NamedNode('s1'), new NamedNode('p1'), listElements[0])).toBe(true);
     const listItemsJSON = {
       b0: [
         { termType: 'NamedNode', value: 'element1' },
@@ -1454,26 +1665,27 @@ describe('Store', () => {
 
     describe('extractLists without remove', () => {
       const lists = store.extractLists();
-      it('should not delete triples',
-        shouldIncludeAll(store.getQuads(),
-          ['s1', 'p1', `_:${listElements[0].value}`],
-          [`_:${listElements[0].value}`, namespaces.rdf.first, 'element1'],
-          [`_:${listElements[0].value}`, namespaces.rdf.rest, `_:${listElements[1].value}`],
-          [`_:${listElements[1].value}`, namespaces.rdf.first, '"element2"'],
-          [`_:${listElements[1].value}`, namespaces.rdf.rest, namespaces.rdf.nil]
-        ));
+      it('should not delete triples', shouldIncludeAll(store.getQuads(),
+        ['s1', 'p1', `_:${listElements[0].value}`],
+        [`_:${listElements[0].value}`, namespaces.rdf.first, 'element1'],
+        [`_:${listElements[0].value}`, namespaces.rdf.rest, `_:${listElements[1].value}`],
+        [`_:${listElements[1].value}`, namespaces.rdf.first, '"element2"'],
+        [`_:${listElements[1].value}`, namespaces.rdf.rest, namespaces.rdf.nil]
+      ));
       it('should generate a list of Collections', () => {
-        expect(listsToJSON(lists)).to.deep.equal(listItemsJSON);
+        expect(listsToJSON(lists)).toEqual(listItemsJSON);
       });
     });
 
     describe('extractLists with remove', () => {
       const lists = store.extractLists({ remove: true });
-      it('should remove the first/rest triples and return the list members',
+      it(
+        'should remove the first/rest triples and return the list members',
         shouldIncludeAll(store.getQuads(),
-                         ['s1', 'p1', `_:${listElements[0].value}`]));
+                         ['s1', 'p1', `_:${listElements[0].value}`])
+      );
       it('should generate a list of Collections', () => {
-        expect(listsToJSON(lists)).to.deep.equal(listItemsJSON);
+        expect(listsToJSON(lists)).toEqual(listItemsJSON);
       });
     });
   });
@@ -1485,119 +1697,136 @@ describe('Store', () => {
 
     describe('extractLists without remove', () => {
       const lists = store.extractLists();
-      it('should not delete triples',
-        shouldIncludeAll(store.getQuads(),
-          ['s1', 'p1', 'o1'],
-          [`_:${listElements[0].value}`, namespaces.rdf.first, 'element1'],
-          [`_:${listElements[0].value}`, namespaces.rdf.rest, `_:${listElements[1].value}`],
-          [`_:${listElements[1].value}`, namespaces.rdf.first, '"element2"'],
-          [`_:${listElements[1].value}`, namespaces.rdf.rest, namespaces.rdf.nil]
-        ));
+      it('should not delete triples', shouldIncludeAll(store.getQuads(),
+        ['s1', 'p1', 'o1'],
+        [`_:${listElements[0].value}`, namespaces.rdf.first, 'element1'],
+        [`_:${listElements[0].value}`, namespaces.rdf.rest, `_:${listElements[1].value}`],
+        [`_:${listElements[1].value}`, namespaces.rdf.first, '"element2"'],
+        [`_:${listElements[1].value}`, namespaces.rdf.rest, namespaces.rdf.nil]
+      ));
       it('should generate a list of Collections', () => {
-        expect(listsToJSON(lists)).to.deep.equal({});
+        expect(listsToJSON(lists)).toEqual({});
       });
     });
 
     describe('extractLists with remove', () => {
       const lists = store.extractLists({ remove: true });
-      it('should remove the first/rest triples and return the list members',
+      it(
+        'should remove the first/rest triples and return the list members',
         shouldIncludeAll(store.getQuads(),
-                         ['s1', 'p1', 'o1']));
+                         ['s1', 'p1', 'o1'])
+      );
       it('should generate a list of Collections', () => {
-        expect(listsToJSON(lists)).to.deep.equal({});
+        expect(listsToJSON(lists)).toEqual({});
       });
     });
   });
 
   describe('A Store containing a rdf:Collection without first', () => {
     const store = new Store();
-    store.addQuad(store.createBlankNode(), new NamedNode(namespaces.rdf.rest), namespaces.rdf.nil).should.be.true;
+    expect(
+      store.addQuad(store.createBlankNode(), new NamedNode(namespaces.rdf.rest), namespaces.rdf.nil)
+    ).toBe(true);
 
     it('extractLists throws an error', () => {
-      expect(() => store.extractLists()).throws('b0 has no list head');
+      expect(() => store.extractLists()).toThrowError('b0 has no list head');
     });
   });
 
   describe('A Store containing an rdf:Collection with multiple rdf:first arcs on head', () => {
     const store = new Store();
     const listElements = addList(store, store.createBlankNode(), store.createBlankNode());
-    store.addQuad(listElements[0], new NamedNode(namespaces.rdf.first), store.createBlankNode()).should.be.true;
+    expect(
+      store.addQuad(listElements[0], new NamedNode(namespaces.rdf.first), store.createBlankNode())
+    ).toBe(true);
 
     it('extractLists throws an error', () => {
-      expect(() => store.extractLists()).throws('b2 has multiple rdf:first arcs');
+      expect(() => store.extractLists()).toThrowError('b2 has multiple rdf:first arcs');
     });
   });
 
   describe('A Store containing an rdf:Collection with multiple rdf:first arcs on tail', () => {
     const store = new Store();
     const listElements = addList(store, store.createBlankNode(), store.createBlankNode());
-    store.addQuad(listElements[1], new NamedNode(namespaces.rdf.first), store.createBlankNode()).should.be.true;
+    expect(
+      store.addQuad(listElements[1], new NamedNode(namespaces.rdf.first), store.createBlankNode())
+    ).toBe(true);
 
     it('extractLists throws an error', () => {
-      expect(() => store.extractLists()).throws('b3 has multiple rdf:first arcs');
+      expect(() => store.extractLists()).toThrowError('b3 has multiple rdf:first arcs');
     });
   });
 
   describe('A Store containing an rdf:Collection with multiple rdf:rest arcs on head', () => {
     const store = new Store();
     const listElements = addList(store, store.createBlankNode(), store.createBlankNode());
-    store.addQuad(listElements[0], new NamedNode(namespaces.rdf.rest), store.createBlankNode()).should.be.true;
+    expect(
+      store.addQuad(listElements[0], new NamedNode(namespaces.rdf.rest), store.createBlankNode())
+    ).toBe(true);
 
     it('extractLists throws an error', () => {
-      expect(() => store.extractLists()).throws('b2 has multiple rdf:rest arcs');
+      expect(() => store.extractLists()).toThrowError('b2 has multiple rdf:rest arcs');
     });
   });
 
   describe('A Store containing an rdf:Collection with multiple rdf:rest arcs on tail', () => {
     const store = new Store();
     const listElements = addList(store, store.createBlankNode(), store.createBlankNode());
-    store.addQuad(listElements[1], new NamedNode(namespaces.rdf.rest), store.createBlankNode()).should.be.true;
+    expect(
+      store.addQuad(listElements[1], new NamedNode(namespaces.rdf.rest), store.createBlankNode())
+    ).toBe(true);
 
     it('extractLists throws an error', () => {
-      expect(() => store.extractLists()).throws('b3 has multiple rdf:rest arcs');
+      expect(() => store.extractLists()).toThrowError('b3 has multiple rdf:rest arcs');
     });
   });
 
   describe('A Store containing an rdf:Collection with non-list arcs out', () => {
     const store = new Store();
     const listElements = addList(store, store.createBlankNode(), store.createBlankNode(), store.createBlankNode());
-    store.addQuad(listElements[1], new NamedNode('http://a.example/foo'), store.createBlankNode()).should.be.true;
+    expect(
+      store.addQuad(listElements[1], new NamedNode('http://a.example/foo'), store.createBlankNode())
+    ).toBe(true);
 
     it('extractLists throws an error', () => {
-      expect(() => store.extractLists()).throws('b4 can\'t be subject and object');
+      expect(() => store.extractLists()).toThrowError('b4 can\'t be subject and object');
     });
   });
 
   describe('A Store containing an rdf:Collection with multiple incoming rdf:rest arcs', () => {
     const store = new Store();
     const listElements = addList(store, store.createBlankNode(), store.createBlankNode(), store.createBlankNode());
-    store.addQuad(store.createBlankNode(), new NamedNode(namespaces.rdf.rest), listElements[1]).should.be.true;
+    expect(
+      store.addQuad(store.createBlankNode(), new NamedNode(namespaces.rdf.rest), listElements[1])
+    ).toBe(true);
 
     it('extractLists throws an error', () => {
-      expect(() => store.extractLists()).throws('b4 has incoming rdf:rest arcs');
+      expect(() => store.extractLists()).toThrowError('b4 has incoming rdf:rest arcs');
     });
   });
 
   describe('A Store containing an rdf:Collection with co-references out of head', () => {
     const store = new Store();
     const listElements = addList(store, store.createBlankNode(), store.createBlankNode(), store.createBlankNode());
-    store.addQuad(listElements[0], new NamedNode('p1'), new NamedNode('o1')).should.be.true;
-    store.addQuad(listElements[0], new NamedNode('p1'), new NamedNode('o2')).should.be.true;
+    expect(store.addQuad(listElements[0], new NamedNode('p1'), new NamedNode('o1'))).toBe(true);
+    expect(store.addQuad(listElements[0], new NamedNode('p1'), new NamedNode('o2'))).toBe(true);
 
     it('extractLists throws an error', () => {
-      expect(() => store.extractLists()).throws('b3 has non-list arcs out');
+      expect(() => store.extractLists()).toThrowError('b3 has non-list arcs out');
     });
   });
 
   describe('A Store containing an rdf:Collection with co-references into head', () => {
     const store = new Store();
     const listElements = addList(store, store.createBlankNode(), store.createBlankNode(), store.createBlankNode());
-    store.addQuad(new NamedNode('s1'), new NamedNode('p1'), listElements[0]).should.be.true;
-    store.addQuad(new NamedNode('s2'), new NamedNode(namespaces.rdf.rest), listElements[0]).should.be.true;
-    store.addQuad(new NamedNode('s2'), new NamedNode('p1'), listElements[0]).should.be.true;
+    expect(store.addQuad(new NamedNode('s1'), new NamedNode('p1'), listElements[0])).toBe(true);
+    expect(
+      store.addQuad(new NamedNode('s2'), new NamedNode(namespaces.rdf.rest), listElements[0])
+    ).toBe(true);
+    expect(store.addQuad(new NamedNode('s2'), new NamedNode('p1'), listElements[0])).toBe(true);
 
     it('extractLists throws an error', () => {
-      expect(() => store.extractLists()).throws('b3 can\'t have coreferences');
+      expect(() => store.extractLists()).toThrowError('b3 can\'t have coreferences');
     });
   });
 
@@ -1609,30 +1838,37 @@ describe('Store', () => {
       store.createBlankNode(),
       store.createBlankNode(),
     ];
-    store.addQuad(listElements[0], new NamedNode(namespaces.rdf.first), member0).should.be.true;
-    store.addQuad(listElements[0], new NamedNode(namespaces.rdf.rest), listElements[1], new NamedNode('g1')).should.be.true;
-    store.addQuad(listElements[1], new NamedNode(namespaces.rdf.first), member1).should.be.true;
-    store.addQuad(listElements[1], new NamedNode(namespaces.rdf.rest), new NamedNode(namespaces.rdf.nil)).should.be.true;
-    store.addQuad(new NamedNode('s1'), new NamedNode('p1'), listElements[0]).should.be.true;
+    expect(
+      store.addQuad(listElements[0], new NamedNode(namespaces.rdf.first), member0)
+    ).toBe(true);
+    expect(
+      store.addQuad(listElements[0], new NamedNode(namespaces.rdf.rest), listElements[1], new NamedNode('g1'))
+    ).toBe(true);
+    expect(
+      store.addQuad(listElements[1], new NamedNode(namespaces.rdf.first), member1)
+    ).toBe(true);
+    expect(
+      store.addQuad(listElements[1], new NamedNode(namespaces.rdf.rest), new NamedNode(namespaces.rdf.nil))
+    ).toBe(true);
+    expect(store.addQuad(new NamedNode('s1'), new NamedNode('p1'), listElements[0])).toBe(true);
 
     describe('extractLists without ignoreErrors', () => {
       it('extractLists throws an error', () => {
-        expect(() => store.extractLists()).throws('b0 not confined to single graph');
+        expect(() => store.extractLists()).toThrowError('b0 not confined to single graph');
       });
     });
 
     describe('extractLists with ignoreErrors', () => {
       const lists = store.extractLists({ ignoreErrors: true });
-      it('should not delete triples',
-        shouldIncludeAll(store.getQuads(),
-          ['s1', 'p1', `_:${listElements[0].value}`],
-          [`_:${listElements[0].value}`, namespaces.rdf.first, 'element1'],
-          [`_:${listElements[0].value}`, namespaces.rdf.rest, `_:${listElements[1].value}`, 'g1'],
-          [`_:${listElements[1].value}`, namespaces.rdf.first, '"element2"'],
-          [`_:${listElements[1].value}`, namespaces.rdf.rest, namespaces.rdf.nil]
-        ));
+      it('should not delete triples', shouldIncludeAll(store.getQuads(),
+        ['s1', 'p1', `_:${listElements[0].value}`],
+        [`_:${listElements[0].value}`, namespaces.rdf.first, 'element1'],
+        [`_:${listElements[0].value}`, namespaces.rdf.rest, `_:${listElements[1].value}`, 'g1'],
+        [`_:${listElements[1].value}`, namespaces.rdf.first, '"element2"'],
+        [`_:${listElements[1].value}`, namespaces.rdf.rest, namespaces.rdf.nil]
+      ));
       it('should generate an empty list of Collections', () => {
-        expect(listsToJSON(lists)).to.deep.equal({});
+        expect(listsToJSON(lists)).toEqual({});
       });
     });
   });
@@ -1646,23 +1882,29 @@ describe('Store', () => {
       ]);
     });
 
-    it('should include added elements in match if iteration has not yet started', () => {
-      const m = store.match(null, null, null, null);
-      store.add(new Quad(new NamedNode('s1'), new NamedNode('p1'), new NamedNode('o2')));
-      [...m].should.have.length(3);
-      [...store.match(null, null, null, null)].should.have.length(3);
-    });
+    it(
+      'should include added elements in match if iteration has not yet started',
+      () => {
+        const m = store.match(null, null, null, null);
+        store.add(new Quad(new NamedNode('s1'), new NamedNode('p1'), new NamedNode('o2')));
+        expect([...m]).toHaveLength(3);
+        expect([...store.match(null, null, null, null)]).toHaveLength(3);
+      }
+    );
 
-    it('should still include results of original match after iterating while adding new data', () => {
-      const m = store.match(null, null, null, null)[Symbol.iterator]();
-      m.next().value.should.deep.equal(new Quad(new NamedNode('s1'), new NamedNode('p1'), new NamedNode('o1')));
-      store.add(new Quad(new NamedNode('s1'), new NamedNode('p1'), new NamedNode('o0')));
-      store.add(new Quad(new NamedNode('s1'), new NamedNode('p1'), new NamedNode('o2')));
-      store.add(new Quad(new NamedNode('s1'), new NamedNode('p1'), new NamedNode('o4')));
-      m.next().value.should.deep.equal(new Quad(new NamedNode('s1'), new NamedNode('p1'), new NamedNode('o3')));
-      m.next().done.should.be.true;
-      [...store.match(null, null, null, null)].should.have.length(5);
-    });
+    it(
+      'should still include results of original match after iterating while adding new data',
+      () => {
+        const m = store.match(null, null, null, null)[Symbol.iterator]();
+        expect(m.next().value).toEqual(new Quad(new NamedNode('s1'), new NamedNode('p1'), new NamedNode('o1')));
+        store.add(new Quad(new NamedNode('s1'), new NamedNode('p1'), new NamedNode('o0')));
+        store.add(new Quad(new NamedNode('s1'), new NamedNode('p1'), new NamedNode('o2')));
+        store.add(new Quad(new NamedNode('s1'), new NamedNode('p1'), new NamedNode('o4')));
+        expect(m.next().value).toEqual(new Quad(new NamedNode('s1'), new NamedNode('p1'), new NamedNode('o3')));
+        expect(m.next().done).toBe(true);
+        expect([...store.match(null, null, null, null)]).toHaveLength(5);
+      }
+    );
   });
 });
 
@@ -1683,7 +1925,7 @@ function collect(store, method, arg1, arg2, arg3, arg4) {
 function itShouldBeEmpty(result) {
   it('should be empty', () => {
     if (typeof result === 'function') result = result();
-    result.should.be.empty;
+    expect(Object.keys(result)).toHaveLength(0);
   });
 }
 
@@ -1694,9 +1936,9 @@ function shouldIncludeAll(result) {
   return function () {
     if (typeof result === 'function') result = result();
     result = result.map(r => { return r.toJSON(); });
-    result.should.have.length(items.length);
+    expect(result).toHaveLength(items.length);
     for (let i = 0; i < items.length; i++)
-      result.should.include.something.that.deep.equals(items[i].toJSON());
+      expect(result).toContainEqual(items[i].toJSON());
   };
 }
 

--- a/test/N3StreamParser-test.js
+++ b/test/N3StreamParser-test.js
@@ -4,11 +4,11 @@ import { Readable, Writable } from 'readable-stream';
 describe('StreamParser', () => {
   describe('The StreamParser export', () => {
     it('should be a function', () => {
-      StreamParser.should.be.a('function');
+      expect(typeof StreamParser).toEqual('function');
     });
 
     it('should be a StreamParser constructor', () => {
-      new StreamParser().should.be.an.instanceof(StreamParser);
+      expect(new StreamParser()).toBeInstanceOf(StreamParser);
     });
   });
 
@@ -19,32 +19,50 @@ describe('StreamParser', () => {
 
     it('parses the Bom starting stream', shouldParse(['\ufeff'], 0));
 
-    it('parses the Bom starting stream when first chunk ""', shouldParse(['', '\ufeff'], 0));
+    it(
+      'parses the Bom starting stream when first chunk ""',
+      shouldParse(['', '\ufeff'], 0)
+    );
 
     it('parses one triple', shouldParse(['<a> <b> <c>.'], 1));
 
-    it('parses two triples', shouldParse(['<a> <b>', ' <c>. <d> <e> ', '<f>.'], 2));
+    it(
+      'parses two triples',
+      shouldParse(['<a> <b>', ' <c>. <d> <e> ', '<f>.'], 2)
+    );
 
-    it('should parse decimals that are split across chunks in the stream',
-      shouldParse('<sub> <pred> 11.2 .'.match(/.{1,2}/g), 1));
+    it(
+      'should parse decimals that are split across chunks in the stream',
+      shouldParse('<sub> <pred> 11.2 .'.match(/.{1,2}/g), 1)
+    );
 
-    it('should parse non-breaking spaces that are split across chunks in the stream correctly', done => {
-      const buffer = Buffer.from('<sub> <pred> " " .'),
-          chunks = [buffer, buffer.slice(0, 15), buffer.slice(15, buffer.length)];
-      shouldParse(chunks, 2, triples => {
-        triples[0].should.deep.equal(triples[1]);
-      })(done);
-    });
+    it(
+      'should parse non-breaking spaces that are split across chunks in the stream correctly',
+      done => {
+        const buffer = Buffer.from('<sub> <pred> " " .'),
+            chunks = [buffer, buffer.slice(0, 15), buffer.slice(15, buffer.length)];
+        shouldParse(chunks, 2, triples => {
+          expect(triples[0]).toEqual(triples[1]);
+        })(done);
+      }
+    );
 
-    it("doesn't parse an invalid stream",
-      shouldNotParse(['z.'], 'Unexpected "z." on line 1.'), { token: undefined, line: 1, previousToken: undefined });
+    it(
+      "doesn't parse an invalid stream",
+      shouldNotParse(['z.'], 'Unexpected "z." on line 1.'),
+      { token: undefined, line: 1, previousToken: undefined }
+    );
 
-    it('Should Not parse Bom in middle stream',
-        shouldNotParse(['<a> <b>', '\ufeff', '<c>.'], 'Unexpected "" on line 1.'));
+    it(
+      'Should Not parse Bom in middle stream',
+      shouldNotParse(['<a> <b>', '\ufeff', '<c>.'], 'Unexpected "" on line 1.')
+    );
 
-    it('emits "prefix" events',
+    it(
+      'emits "prefix" events',
       shouldEmitPrefixes(['@prefix a: <http://a.org/#>. a:a a:b a:c. @prefix b: <http://b.org/#>.'],
-                         { a: new NamedNode('http://a.org/#'), b: new NamedNode('http://b.org/#') }));
+                         { a: new NamedNode('http://a.org/#'), b: new NamedNode('http://b.org/#') })
+    );
 
     it('passes an error', () => {
       const input = new Readable(), parser = new StreamParser();
@@ -53,7 +71,7 @@ describe('StreamParser', () => {
       parser.on('error', e => { error = e; });
       parser.import(input);
       input.emit('error', new Error());
-      expect(error).to.be.an.instanceof(Error);
+      expect(error).toBeInstanceOf(Error);
     });
   });
 });
@@ -65,11 +83,11 @@ function shouldParse(chunks, expectedLength, validateTriples) {
         inputStream = new ArrayReader(chunks),
         parser = new StreamParser(),
         outputStream = new ArrayWriter(triples);
-    parser.import(inputStream).should.equal(parser);
+    expect(parser.import(inputStream)).toBe(parser);
     parser.pipe(outputStream);
     parser.on('error', done);
     parser.on('end', () => {
-      triples.should.have.length(expectedLength);
+      expect(triples).toHaveLength(expectedLength);
       if (validateTriples) validateTriples(triples);
       done();
     });
@@ -84,9 +102,9 @@ function shouldNotParse(chunks, expectedMessage, expectedContext) {
     inputStream.pipe(parser);
     parser.pipe(outputStream);
     parser.on('error', error => {
-      error.should.be.an.instanceof(Error);
-      error.message.should.equal(expectedMessage);
-      if (expectedContext) error.context.should.deep.equal(expectedContext);
+      expect(error).toBeInstanceOf(Error);
+      expect(error.message).toBe(expectedMessage);
+      if (expectedContext) expect(error.context).toEqual(expectedContext);
       done();
     });
   };
@@ -102,7 +120,7 @@ function shouldEmitPrefixes(chunks, expectedPrefixes) {
     parser.on('prefix', (prefix, iri) => { prefixes[prefix] = iri; });
     parser.on('error', done);
     parser.on('end', error => {
-      prefixes.should.deep.equal(expectedPrefixes);
+      expect(prefixes).toEqual(expectedPrefixes);
       done(error);
     });
   };

--- a/test/N3StreamWriter-test.js
+++ b/test/N3StreamWriter-test.js
@@ -4,37 +4,34 @@ import { Readable, Writable } from 'readable-stream';
 describe('StreamWriter', () => {
   describe('The StreamWriter export', () => {
     it('should be a function', () => {
-      StreamWriter.should.be.a('function');
+      expect(typeof StreamWriter).toEqual('function');
     });
 
     it('should be a StreamWriter constructor', () => {
-      new StreamWriter().should.be.an.instanceof(StreamWriter);
+      expect(new StreamWriter()).toBeInstanceOf(StreamWriter);
     });
   });
 
   describe('A StreamWriter instance', () => {
-    it('should serialize 0 triples',
-      shouldSerialize(''));
+    it('should serialize 0 triples', shouldSerialize(''));
 
-    it('should serialize 1 triple',
-      shouldSerialize(['abc', 'def', 'ghi'],
-                      '<abc> <def> <ghi>.\n'));
+    it('should serialize 1 triple', shouldSerialize(['abc', 'def', 'ghi'],
+                    '<abc> <def> <ghi>.\n'));
 
-    it('should serialize 2 triples',
-      shouldSerialize(['abc', 'def', 'ghi'],
-                      ['jkl', 'mno', 'pqr'],
-                      '<abc> <def> <ghi>.\n' +
-                      '<jkl> <mno> <pqr>.\n'));
+    it('should serialize 2 triples', shouldSerialize(['abc', 'def', 'ghi'],
+                    ['jkl', 'mno', 'pqr'],
+                    '<abc> <def> <ghi>.\n' +
+                    '<jkl> <mno> <pqr>.\n'));
 
-    it('should serialize 3 triples',
-      shouldSerialize(['abc', 'def', 'ghi'],
-                      ['jkl', 'mno', 'pqr'],
-                      ['stu', 'vwx', 'yz'],
-                      '<abc> <def> <ghi>.\n' +
-                      '<jkl> <mno> <pqr>.\n' +
-                      '<stu> <vwx> <yz>.\n'));
+    it('should serialize 3 triples', shouldSerialize(['abc', 'def', 'ghi'],
+                    ['jkl', 'mno', 'pqr'],
+                    ['stu', 'vwx', 'yz'],
+                    '<abc> <def> <ghi>.\n' +
+                    '<jkl> <mno> <pqr>.\n' +
+                    '<stu> <vwx> <yz>.\n'));
 
-    it('should use prefixes when possible',
+    it(
+      'should use prefixes when possible',
       shouldSerialize({ prefixes: { a: 'http://a.org/', b: new NamedNode('http://a.org/b#'), c: 'http://a.org/b' } },
                       ['http://a.org/bc', 'http://a.org/b#ef', 'http://a.org/bhi'],
                       ['http://a.org/bc/de', 'http://a.org/b#e#f', 'http://a.org/b#x/t'],
@@ -44,7 +41,8 @@ describe('StreamWriter', () => {
                       '@prefix c: <http://a.org/b>.\n\n' +
                       'a:bc b:ef a:bhi.\n' +
                       '<http://a.org/bc/de> <http://a.org/b#e#f> <http://a.org/b#x/t>.\n' +
-                      '<http://a.org/3a> <http://a.org/b#3a> b:a3.\n'));
+                      '<http://a.org/3a> <http://a.org/b#3a> b:a3.\n')
+    );
 
     it('should take over prefixes from the input stream', done => {
       const inputStream = new Readable(),
@@ -60,7 +58,7 @@ describe('StreamWriter', () => {
 
       writer.on('error', done);
       writer.on('end', () => {
-        outputStream.result.should.equal('@prefix a: <http://a.org/>.\n\n' +
+        expect(outputStream.result).toBe('@prefix a: <http://a.org/>.\n\n' +
                                          '@prefix b: <http://b.org/>.\n\n');
         done();
       });
@@ -74,7 +72,7 @@ describe('StreamWriter', () => {
     writer.on('error', e => { error = e; });
     writer.import(input);
     input.emit('error', new Error());
-    expect(error).to.be.an.instanceof(Error);
+    expect(error).toBeInstanceOf(Error);
   });
 });
 
@@ -92,11 +90,11 @@ function shouldSerialize(/* options?, tripleArrays..., expectedResult */) {
     const inputStream = new ArrayReader(tripleArrays),
         writer = new StreamWriter(options),
         outputStream = new StringWriter();
-    writer.import(inputStream).should.equal(writer);
+    expect(writer.import(inputStream)).toBe(writer);
     writer.pipe(outputStream);
     writer.on('error', done);
     writer.on('end', () => {
-      outputStream.result.should.equal(expectedResult);
+      expect(outputStream.result).toBe(expectedResult);
       done();
     });
   };

--- a/test/N3Util-test.js
+++ b/test/N3Util-test.js
@@ -5,205 +5,209 @@ const { namedNode, blankNode, literal, variable, defaultGraph, quad } = DataFact
 describe('Util', () => {
   describe('isNamedNode', () => {
     it('matches an IRI', () => {
-      Util.isNamedNode(namedNode('http://example.org/')).should.be.true;
+      expect(Util.isNamedNode(namedNode('http://example.org/'))).toBe(true);
     });
 
     it('matches an empty IRI', () => {
-      Util.isNamedNode(namedNode('')).should.be.true;
+      expect(Util.isNamedNode(namedNode(''))).toBe(true);
     });
 
     it('does not match a literal', () => {
-      Util.isNamedNode(literal('http://example.org/')).should.be.false;
+      expect(Util.isNamedNode(literal('http://example.org/'))).toBe(false);
     });
 
     it('does not match a blank node', () => {
-      Util.isNamedNode(blankNode('x')).should.be.false;
+      expect(Util.isNamedNode(blankNode('x'))).toBe(false);
     });
 
     it('does not match a variable', () => {
-      Util.isNamedNode(variable('x')).should.be.false;
+      expect(Util.isNamedNode(variable('x'))).toBe(false);
     });
 
     it('does not match null', () => {
-      expect(Util.isNamedNode(null)).to.be.false;
+      expect(Util.isNamedNode(null)).toBe(false);
     });
 
     it('does not match undefined', () => {
-      expect(Util.isNamedNode(undefined)).to.be.false;
+      expect(Util.isNamedNode(undefined)).toBe(false);
     });
   });
 
   describe('isLiteral', () => {
     it('matches a literal', () => {
-      Util.isLiteral(literal('http://example.org/')).should.be.true;
+      expect(Util.isLiteral(literal('http://example.org/'))).toBe(true);
     });
 
     it('matches a literal with a language', () => {
-      Util.isLiteral(literal('English', 'en')).should.be.true;
+      expect(Util.isLiteral(literal('English', 'en'))).toBe(true);
     });
 
     it('matches a literal with a language that contains a number', () => {
-      Util.isLiteral(literal('English', '@es-419')).should.be.true;
+      expect(Util.isLiteral(literal('English', '@es-419'))).toBe(true);
     });
 
     it('matches a literal with a type', () => {
-      Util.isLiteral(literal('3', 'http://www.w3.org/2001/XMLSchema#integer')).should.be.true;
+      expect(Util.isLiteral(literal('3', 'http://www.w3.org/2001/XMLSchema#integer'))).toBe(true);
     });
 
     it('matches a literal with a newline', () => {
-      Util.isLiteral(literal('a\nb')).should.be.true;
+      expect(Util.isLiteral(literal('a\nb'))).toBe(true);
     });
 
     it('matches a literal with a cariage return', () => {
-      Util.isLiteral(literal('a\rb')).should.be.true;
+      expect(Util.isLiteral(literal('a\rb'))).toBe(true);
     });
 
     it('does not match an IRI', () => {
-      Util.isLiteral(namedNode('http://example.org/')).should.be.false;
+      expect(Util.isLiteral(namedNode('http://example.org/'))).toBe(false);
     });
 
     it('does not match a blank node', () => {
-      Util.isLiteral(blankNode('_:x')).should.be.false;
+      expect(Util.isLiteral(blankNode('_:x'))).toBe(false);
     });
 
     it('does not match a variable', () => {
-      Util.isLiteral(variable('x')).should.be.false;
+      expect(Util.isLiteral(variable('x'))).toBe(false);
     });
 
     it('does not match null', () => {
-      expect(Util.isLiteral(null)).to.be.false;
+      expect(Util.isLiteral(null)).toBe(false);
     });
 
     it('does not match undefined', () => {
-      expect(Util.isLiteral(undefined)).to.be.false;
+      expect(Util.isLiteral(undefined)).toBe(false);
     });
   });
 
   describe('isBlankNode', () => {
     it('matches a blank node', () => {
-      Util.isBlankNode(blankNode('x')).should.be.true;
+      expect(Util.isBlankNode(blankNode('x'))).toBe(true);
     });
 
     it('does not match an IRI', () => {
-      Util.isBlankNode(namedNode('http://example.org/')).should.be.false;
+      expect(Util.isBlankNode(namedNode('http://example.org/'))).toBe(false);
     });
 
     it('does not match a literal', () => {
-      Util.isBlankNode(literal('http://example.org/')).should.be.false;
+      expect(Util.isBlankNode(literal('http://example.org/'))).toBe(false);
     });
 
     it('does not match a variable', () => {
-      Util.isBlankNode(variable('x')).should.be.false;
+      expect(Util.isBlankNode(variable('x'))).toBe(false);
     });
 
     it('does not match null', () => {
-      expect(Util.isBlankNode(null)).to.be.false;
+      expect(Util.isBlankNode(null)).toBe(false);
     });
 
     it('does not match undefined', () => {
-      expect(Util.isBlankNode(undefined)).to.be.false;
+      expect(Util.isBlankNode(undefined)).toBe(false);
     });
   });
 
   describe('isVariable', () => {
     it('matches a variable', () => {
-      Util.isVariable(variable('x')).should.be.true;
+      expect(Util.isVariable(variable('x'))).toBe(true);
     });
 
     it('does not match an IRI', () => {
-      Util.isVariable(namedNode('http://example.org/')).should.be.false;
+      expect(Util.isVariable(namedNode('http://example.org/'))).toBe(false);
     });
 
     it('does not match a literal', () => {
-      Util.isVariable(literal('http://example.org/')).should.be.false;
+      expect(Util.isVariable(literal('http://example.org/'))).toBe(false);
     });
 
     it('does not match a blank node', () => {
-      Util.isNamedNode(blankNode('x')).should.be.false;
+      expect(Util.isNamedNode(blankNode('x'))).toBe(false);
     });
 
     it('does not match null', () => {
-      expect(Util.isVariable(null)).to.be.false;
+      expect(Util.isVariable(null)).toBe(false);
     });
 
     it('does not match undefined', () => {
-      expect(Util.isVariable(undefined)).to.be.false;
+      expect(Util.isVariable(undefined)).toBe(false);
     });
   });
 
   describe('isDefaultGraph', () => {
     it('does not match a blank node', () => {
-      Util.isDefaultGraph(blankNode('x')).should.be.false;
+      expect(Util.isDefaultGraph(blankNode('x'))).toBe(false);
     });
 
     it('does not match an IRI', () => {
-      Util.isDefaultGraph(namedNode('http://example.org/')).should.be.false;
+      expect(Util.isDefaultGraph(namedNode('http://example.org/'))).toBe(false);
     });
 
     it('does not match a literal', () => {
-      Util.isDefaultGraph(literal('http://example.org/')).should.be.false;
+      expect(Util.isDefaultGraph(literal('http://example.org/'))).toBe(false);
     });
 
     it('does not match null', () => {
-      expect(Util.isVariable(null)).to.be.false;
+      expect(Util.isVariable(null)).toBe(false);
     });
 
     it('does not match undefined', () => {
-      expect(Util.isVariable(undefined)).to.be.false;
+      expect(Util.isVariable(undefined)).toBe(false);
     });
   });
 
   describe('inDefaultGraph', () => {
     it('does not match a blank node', () => {
-      Util.inDefaultGraph(quad(null, null, null, blankNode('x'))).should.be.false;
+      expect(Util.inDefaultGraph(quad(null, null, null, blankNode('x')))).toBe(false);
     });
 
     it('does not match an IRI', () => {
-      Util.inDefaultGraph(quad(null, null, null, namedNode('http://example.org/'))).should.be.false;
+      expect(
+        Util.inDefaultGraph(quad(null, null, null, namedNode('http://example.org/')))
+      ).toBe(false);
     });
 
     it('does not match a literal', () => {
-      Util.inDefaultGraph(quad(null, null, null, literal('http://example.org/'))).should.be.false;
+      expect(
+        Util.inDefaultGraph(quad(null, null, null, literal('http://example.org/')))
+      ).toBe(false);
     });
 
     it('matches null', () => {
-      Util.inDefaultGraph(quad(null, null, null, null)).should.be.true;
+      expect(Util.inDefaultGraph(quad(null, null, null, null))).toBe(true);
     });
 
     it('matches undefined', () => {
-      Util.inDefaultGraph(quad(null, null, null, undefined)).should.be.true;
+      expect(Util.inDefaultGraph(quad(null, null, null, undefined))).toBe(true);
     });
 
     it('matches the default graph', () => {
-      Util.inDefaultGraph(quad(null, null, null, defaultGraph())).should.be.true;
+      expect(Util.inDefaultGraph(quad(null, null, null, defaultGraph()))).toBe(true);
     });
   });
 
   describe('prefix', () => {
     const rdfs = Util.prefix('http://www.w3.org/2000/01/rdf-schema#');
     it('should return a function', () => {
-      expect(rdfs).to.be.an.instanceof(Function);
+      expect(rdfs).toBeInstanceOf(Function);
     });
 
     describe('the function', () => {
       it('should expand the prefix', () => {
-        expect(rdfs('label')).to.deep.equal(namedNode('http://www.w3.org/2000/01/rdf-schema#label'));
+        expect(rdfs('label')).toEqual(namedNode('http://www.w3.org/2000/01/rdf-schema#label'));
       });
 
       it('should expand a NamedNode prefix', () => {
         const rdfs = Util.prefix(namedNode('http://www.w3.org/2000/01/rdf-schema#'));
-        expect(rdfs('label')).to.deep.equal(namedNode('http://www.w3.org/2000/01/rdf-schema#label'));
+        expect(rdfs('label')).toEqual(namedNode('http://www.w3.org/2000/01/rdf-schema#label'));
       });
 
       it('should expand a Literal prefix', () => {
         const rdfs = Util.prefix(literal('http://www.w3.org/2000/01/rdf-schema#'));
-        expect(rdfs('label')).to.deep.equal(namedNode('http://www.w3.org/2000/01/rdf-schema#label'));
+        expect(rdfs('label')).toEqual(namedNode('http://www.w3.org/2000/01/rdf-schema#label'));
       });
 
       it('should use a custom factory when specified', () => {
         const factory = { namedNode: function (s) { return `n-${s}`; } };
         const rdfs = Util.prefix('http://www.w3.org/2000/01/rdf-schema#', factory);
-        expect(rdfs('label')).to.equal('n-http://www.w3.org/2000/01/rdf-schema#label');
+        expect(rdfs('label')).toBe('n-http://www.w3.org/2000/01/rdf-schema#label');
       });
     });
   });
@@ -212,24 +216,24 @@ describe('Util', () => {
     describe('called without arguments', () => {
       const prefixes = Util.prefixes();
       it('should return a function', () => {
-        expect(prefixes).to.be.an.instanceof(Function);
+        expect(prefixes).toBeInstanceOf(Function);
       });
 
       describe('the function', () => {
         it('should not expand non-registered prefixes', () => {
-          expect(() => { prefixes('foo'); }).to.throw('Unknown prefix: foo');
+          expect(() => { prefixes('foo'); }).toThrow('Unknown prefix: foo');
         });
 
         it('should allow registering prefixes', () => {
           const p = prefixes('rdfs', 'http://www.w3.org/2000/01/rdf-schema#');
           const rdfs = prefixes('rdfs');
-          expect(p).to.exist;
-          expect(p).to.equal(rdfs);
+          expect(p).toBeDefined();
+          expect(p).toBe(rdfs);
         });
 
         it('should expand the newly registered prefix', () => {
           const rdfs = prefixes('rdfs');
-          expect(rdfs('label')).to.deep.equal(namedNode('http://www.w3.org/2000/01/rdf-schema#label'));
+          expect(rdfs('label')).toEqual(namedNode('http://www.w3.org/2000/01/rdf-schema#label'));
         });
       });
     });
@@ -240,29 +244,29 @@ describe('Util', () => {
         owl: 'http://www.w3.org/2002/07/owl#',
       });
       it('should return a function', () => {
-        expect(prefixes).to.be.an.instanceof(Function);
+        expect(prefixes).toBeInstanceOf(Function);
       });
 
       describe('the function', () => {
         it('should expand registered prefixes', () => {
-          expect(prefixes('rdfs')('label')).to.deep.equal(namedNode('http://www.w3.org/2000/01/rdf-schema#label'));
-          expect(prefixes('owl')('sameAs')).to.deep.equal(namedNode('http://www.w3.org/2002/07/owl#sameAs'));
+          expect(prefixes('rdfs')('label')).toEqual(namedNode('http://www.w3.org/2000/01/rdf-schema#label'));
+          expect(prefixes('owl')('sameAs')).toEqual(namedNode('http://www.w3.org/2002/07/owl#sameAs'));
         });
 
         it('should not expand non-registered prefixes', () => {
-          expect(() => { prefixes('foo'); }).to.throw('Unknown prefix: foo');
+          expect(() => { prefixes('foo'); }).toThrow('Unknown prefix: foo');
         });
 
         it('should allow registering prefixes', () => {
           const p = prefixes('my', 'http://example.org/#');
           const my = prefixes('my');
-          expect(p).to.exist;
-          expect(p).to.equal(my);
+          expect(p).toBeDefined();
+          expect(p).toBe(my);
         });
 
         it('should expand the newly registered prefix', () => {
           const my = prefixes('my');
-          expect(my('me')).to.deep.equal(namedNode('http://example.org/#me'));
+          expect(my('me')).toEqual(namedNode('http://example.org/#me'));
         });
       });
     });
@@ -272,7 +276,7 @@ describe('Util', () => {
       const prefixes = Util.prefixes({ my: 'http://example.org/#' }, factory);
 
       it('should use the custom factory', () => {
-        expect(prefixes('my')('foo')).to.equal('n-http://example.org/#foo');
+        expect(prefixes('my')('foo')).toBe('n-http://example.org/#foo');
       });
     });
   });

--- a/test/N3Writer-test.js
+++ b/test/N3Writer-test.js
@@ -13,191 +13,255 @@ const { xsd } = namespaces;
 describe('Writer', () => {
   describe('The Writer export', () => {
     it('should be a function', () => {
-      Writer.should.be.a('function');
+      expect(Writer).toBeInstanceOf(Function);
     });
 
     it('should be a Writer constructor', () => {
-      new Writer().should.be.an.instanceof(Writer);
+      expect(new Writer()).toBeInstanceOf(Writer);
     });
   });
 
   describe('A Writer instance', () => {
     it('should serialize a single triple', () => {
       const writer = new Writer();
-      writer.quadToString(new NamedNode('a'), new NamedNode('b'), new NamedNode('c')).should.equal('<a> <b> <c> .\n');
+      expect(
+        writer.quadToString(new NamedNode('a'), new NamedNode('b'), new NamedNode('c'))
+      ).toBe('<a> <b> <c> .\n');
     });
 
     it('should serialize a single quad', () => {
       const writer = new Writer();
-      writer.quadToString(new NamedNode('a'), new NamedNode('b'), new NamedNode('c'), new NamedNode('g')).should.equal('<a> <b> <c> <g> .\n');
+      expect(
+        writer.quadToString(new NamedNode('a'), new NamedNode('b'), new NamedNode('c'), new NamedNode('g'))
+      ).toBe('<a> <b> <c> <g> .\n');
     });
 
     it('should serialize an array of triples', () => {
       const writer = new Writer();
       const triples = [new Quad(new NamedNode('a'), new NamedNode('b'), new NamedNode('c')),
         new Quad(new NamedNode('d'), new NamedNode('e'), new NamedNode('f'))];
-      writer.quadsToString(triples).should.equal('<a> <b> <c> .\n<d> <e> <f> .\n');
+      expect(writer.quadsToString(triples)).toBe('<a> <b> <c> .\n<d> <e> <f> .\n');
     });
 
 
-    it('should serialize 0 triples',
-      shouldSerialize(''));
+    it('should serialize 0 triples', shouldSerialize(''));
 
-    it('should serialize 1 triple',
-      shouldSerialize(['abc', 'def', 'ghi'],
-                      '<abc> <def> <ghi>.\n'));
+    it('should serialize 1 triple', shouldSerialize(['abc', 'def', 'ghi'],
+                    '<abc> <def> <ghi>.\n'));
 
-    it('should serialize 2 triples',
-      shouldSerialize(['abc', 'def', 'ghi'],
-                      ['jkl', 'mno', 'pqr'],
-                      '<abc> <def> <ghi>.\n' +
-                      '<jkl> <mno> <pqr>.\n'));
+    it('should serialize 2 triples', shouldSerialize(['abc', 'def', 'ghi'],
+                    ['jkl', 'mno', 'pqr'],
+                    '<abc> <def> <ghi>.\n' +
+                    '<jkl> <mno> <pqr>.\n'));
 
-    it('should serialize 3 triples',
-      shouldSerialize(['abc', 'def', 'ghi'],
-                      ['jkl', 'mno', 'pqr'],
-                      ['stu', 'vwx', 'yz'],
-                      '<abc> <def> <ghi>.\n' +
-                      '<jkl> <mno> <pqr>.\n' +
-                      '<stu> <vwx> <yz>.\n'));
+    it('should serialize 3 triples', shouldSerialize(['abc', 'def', 'ghi'],
+                    ['jkl', 'mno', 'pqr'],
+                    ['stu', 'vwx', 'yz'],
+                    '<abc> <def> <ghi>.\n' +
+                    '<jkl> <mno> <pqr>.\n' +
+                    '<stu> <vwx> <yz>.\n'));
 
-    it('should serialize a literal',
-      shouldSerialize(['a', 'b', '"cde"'],
-                      '<a> <b> "cde".\n'));
+    it('should serialize a literal', shouldSerialize(['a', 'b', '"cde"'],
+                    '<a> <b> "cde".\n'));
 
-    it('should serialize a literal with a type',
+    it(
+      'should serialize a literal with a type',
       shouldSerialize(['a', 'b', '"cde"^^fgh'],
-                      '<a> <b> "cde"^^<fgh>.\n'));
+                      '<a> <b> "cde"^^<fgh>.\n')
+    );
 
-    it('should serialize a literal with a language',
+    it(
+      'should serialize a literal with a language',
       shouldSerialize(['a', 'b', '"cde"@en-us'],
-                      '<a> <b> "cde"@en-us.\n'));
+                      '<a> <b> "cde"@en-us.\n')
+    );
 
     // e.g. http://vocab.getty.edu/aat/300264727.ttl
-    it('should serialize a literal with an artificial language',
-       shouldSerialize(['a', 'b', '"cde"@qqq-002'],
-                        '<a> <b> "cde"@qqq-002.\n'));
+    it(
+      'should serialize a literal with an artificial language',
+      shouldSerialize(['a', 'b', '"cde"@qqq-002'],
+                       '<a> <b> "cde"@qqq-002.\n')
+    );
 
-    it('should serialize a literal containing a single quote',
+    it(
+      'should serialize a literal containing a single quote',
       shouldSerialize(['a', 'b', '"c\'de"'],
-                      '<a> <b> "c\'de".\n'));
+                      '<a> <b> "c\'de".\n')
+    );
 
-    it('should serialize a literal containing a double quote',
+    it(
+      'should serialize a literal containing a double quote',
       shouldSerialize(['a', 'b', '"c"de"'],
-                      '<a> <b> "c\\"de".\n'));
+                      '<a> <b> "c\\"de".\n')
+    );
 
-    it('should serialize a literal containing a backspace',
+    it(
+      'should serialize a literal containing a backspace',
       shouldSerialize(['a', 'b', '"c\\de"'],
-                      '<a> <b> "c\\\\de".\n'));
+                      '<a> <b> "c\\\\de".\n')
+    );
 
-    it('should serialize a literal containing a tab character',
+    it(
+      'should serialize a literal containing a tab character',
       shouldSerialize(['a', 'b', '"c\tde"'],
-                      '<a> <b> "c\\tde".\n'));
+                      '<a> <b> "c\\tde".\n')
+    );
 
-    it('should serialize a literal containing a newline character',
+    it(
+      'should serialize a literal containing a newline character',
       shouldSerialize(['a', 'b', '"c\nde"'],
-                      '<a> <b> "c\\nde".\n'));
+                      '<a> <b> "c\\nde".\n')
+    );
 
-    it('should serialize a literal containing a cariage return character',
+    it(
+      'should serialize a literal containing a cariage return character',
       shouldSerialize(['a', 'b', '"c\rde"'],
-                      '<a> <b> "c\\rde".\n'));
+                      '<a> <b> "c\\rde".\n')
+    );
 
-    it('should serialize a literal containing a backspace character',
+    it(
+      'should serialize a literal containing a backspace character',
       shouldSerialize(['a', 'b', '"c\bde"'],
-                      '<a> <b> "c\\bde".\n'));
+                      '<a> <b> "c\\bde".\n')
+    );
 
-    it('should serialize a literal containing a form feed character',
+    it(
+      'should serialize a literal containing a form feed character',
       shouldSerialize(['a', 'b', '"c\fde"'],
-                      '<a> <b> "c\\fde".\n'));
+                      '<a> <b> "c\\fde".\n')
+    );
 
-    it('should serialize a literal containing a line separator',
+    it(
+      'should serialize a literal containing a line separator',
       shouldSerialize(['a', 'b', '"c\u2028de"'],
-                      '<a> <b> "c\u2028de".\n'));
+                      '<a> <b> "c\u2028de".\n')
+    );
 
-    it('should serialize a literal containing a paragraph separator',
+    it(
+      'should serialize a literal containing a paragraph separator',
       shouldSerialize(['a', 'b', '"c\u2029de"'],
-                      '<a> <b> "c\u2029de".\n'));
+                      '<a> <b> "c\u2029de".\n')
+    );
 
-    it('should serialize a literal containing special unicode characters',
+    it(
+      'should serialize a literal containing special unicode characters',
       shouldSerialize(['a', 'b', '"c\u0000\u0001"'],
-                      '<a> <b> "c\\u0000\\u0001".\n'));
+                      '<a> <b> "c\\u0000\\u0001".\n')
+    );
 
-    it('should serialize a true boolean literal',
+    it(
+      'should serialize a true boolean literal',
       shouldSerialize(['a', 'b', `"true"^^${xsd.boolean}`],
-                      '<a> <b> true.\n'));
+                      '<a> <b> true.\n')
+    );
 
-    it('should serialize a false boolean literal',
+    it(
+      'should serialize a false boolean literal',
       shouldSerialize(['a', 'b', `"false"^^${xsd.boolean}`],
-                      '<a> <b> false.\n'));
+                      '<a> <b> false.\n')
+    );
 
-    it('should serialize an invalid boolean literal',
+    it(
+      'should serialize an invalid boolean literal',
       shouldSerialize(['a', 'b', `"invalid"^^${xsd.boolean}`],
-                      `<a> <b> "invalid"^^<${xsd.boolean}>.\n`));
+                      `<a> <b> "invalid"^^<${xsd.boolean}>.\n`)
+    );
 
-    it('should serialize an integer literal',
+    it(
+      'should serialize an integer literal',
       shouldSerialize(['a', 'b', `"123"^^${xsd.integer}`],
-                      '<a> <b> 123.\n'));
+                      '<a> <b> 123.\n')
+    );
 
-    it('should serialize a positive integer literal',
+    it(
+      'should serialize a positive integer literal',
       shouldSerialize(['a', 'b', `"+123"^^${xsd.integer}`],
-                      '<a> <b> +123.\n'));
+                      '<a> <b> +123.\n')
+    );
 
-    it('should serialize a negative integer literal',
+    it(
+      'should serialize a negative integer literal',
       shouldSerialize(['a', 'b', `"-123"^^${xsd.integer}`],
-                      '<a> <b> -123.\n'));
+                      '<a> <b> -123.\n')
+    );
 
-    it('should serialize an invalid integer literal',
+    it(
+      'should serialize an invalid integer literal',
       shouldSerialize(['a', 'b', `"invalid"^^${xsd.integer}`],
-                      `<a> <b> "invalid"^^<${xsd.integer}>.\n`));
+                      `<a> <b> "invalid"^^<${xsd.integer}>.\n`)
+    );
 
-    it('should serialize a decimal literal',
+    it(
+      'should serialize a decimal literal',
       shouldSerialize(['a', 'b', `"123.456"^^${xsd.decimal}`],
-                      '<a> <b> 123.456.\n'));
+                      '<a> <b> 123.456.\n')
+    );
 
-    it('should serialize a positive decimal literal',
+    it(
+      'should serialize a positive decimal literal',
       shouldSerialize(['a', 'b', `"+123.456"^^${xsd.decimal}`],
-                      '<a> <b> +123.456.\n'));
+                      '<a> <b> +123.456.\n')
+    );
 
-    it('should serialize a negative decimal literal',
+    it(
+      'should serialize a negative decimal literal',
       shouldSerialize(['a', 'b', `"-123.456"^^${xsd.decimal}`],
-                      '<a> <b> -123.456.\n'));
+                      '<a> <b> -123.456.\n')
+    );
 
-    it('should serialize an invalid decimal literal',
+    it(
+      'should serialize an invalid decimal literal',
       shouldSerialize(['a', 'b', `"invalid"^^${xsd.decimal}`],
-                      `<a> <b> "invalid"^^<${xsd.decimal}>.\n`));
+                      `<a> <b> "invalid"^^<${xsd.decimal}>.\n`)
+    );
 
-    it('should serialize a double literal',
+    it(
+      'should serialize a double literal',
       shouldSerialize(['a', 'b', `"123.456E10"^^${xsd.double}`],
-                      '<a> <b> 123.456E10.\n'));
+                      '<a> <b> 123.456E10.\n')
+    );
 
-    it('should serialize a positive double literal',
+    it(
+      'should serialize a positive double literal',
       shouldSerialize(['a', 'b', `"+123.456E10"^^${xsd.double}`],
-                      '<a> <b> +123.456E10.\n'));
+                      '<a> <b> +123.456E10.\n')
+    );
 
-    it('should serialize a negative double literal',
+    it(
+      'should serialize a negative double literal',
       shouldSerialize(['a', 'b', `"-123.456E10"^^${xsd.double}`],
-                      '<a> <b> -123.456E10.\n'));
+                      '<a> <b> -123.456E10.\n')
+    );
 
-    it('should serialize an invalid double literal',
+    it(
+      'should serialize an invalid double literal',
       shouldSerialize(['a', 'b', `"invalid"^^${xsd.double}`],
-                      `<a> <b> "invalid"^^<${xsd.double}>.\n`));
+                      `<a> <b> "invalid"^^<${xsd.double}>.\n`)
+    );
 
-    it('should serialize blank nodes',
+    it(
+      'should serialize blank nodes',
       shouldSerialize(['_:a', 'b', { termType: 'BlankNode', value: 'c' }],
-                      '_:a <b> _:c.\n'));
+                      '_:a <b> _:c.\n')
+    );
 
-    it('should not leave leading whitespace if the prefix set is empty',
+    it(
+      'should not leave leading whitespace if the prefix set is empty',
       shouldSerialize({},
                       ['a', 'b', 'c'],
-                      '<a> <b> <c>.\n'));
+                      '<a> <b> <c>.\n')
+    );
 
-    it('should serialize prefixes',
+    it(
+      'should serialize prefixes',
       shouldSerialize({ prefixes: { a: 'http://a.org/', b: new NamedNode('http://a.org/b#'), c: 'http://a.org/c' } },
                       '@prefix a: <http://a.org/>.\n' +
                       '@prefix b: <http://a.org/b#>.\n' +
-                      '@prefix c: <http://a.org/c>.\n\n'));
+                      '@prefix c: <http://a.org/c>.\n\n')
+    );
 
-    it('should use prefixes when possible',
+    it(
+      'should use prefixes when possible',
       shouldSerialize({ prefixes: { a: 'http://a.org/', b: 'http://a.org/b#', c: 'http://a.org/b' } },
                       ['http://a.org/bc', 'http://a.org/b#ef', 'http://a.org/bhi'],
                       ['http://a.org/bc/de', 'http://a.org/b#e#f', 'http://a.org/b#x/t'],
@@ -207,24 +271,30 @@ describe('Writer', () => {
                       '@prefix c: <http://a.org/b>.\n\n' +
                       'a:bc b:ef a:bhi.\n' +
                       '<http://a.org/bc/de> <http://a.org/b#e#f> <http://a.org/b#x/t>.\n' +
-                      '<http://a.org/3a> <http://a.org/b#3a> b:a3.\n'));
+                      '<http://a.org/3a> <http://a.org/b#3a> b:a3.\n')
+    );
 
-    it('should expand prefixes when possible',
+    it(
+      'should expand prefixes when possible',
       shouldSerialize({ prefixes: { a: 'http://a.org/', b: 'http://a.org/b#' } },
                       ['a:bc', 'b:ef', 'c:bhi'],
                       '@prefix a: <http://a.org/>.\n' +
                       '@prefix b: <http://a.org/b#>.\n\n' +
-                      'a:bc b:ef <c:bhi>.\n'));
+                      'a:bc b:ef <c:bhi>.\n')
+    );
 
-    it('should not repeat the same subjects',
+    it(
+      'should not repeat the same subjects',
       shouldSerialize(['abc', 'def', 'ghi'],
                       ['abc', 'mno', 'pqr'],
                       ['stu', 'vwx', 'yz'],
                       '<abc> <def> <ghi>;\n' +
                       '    <mno> <pqr>.\n' +
-                      '<stu> <vwx> <yz>.\n'));
+                      '<stu> <vwx> <yz>.\n')
+    );
 
-    it('should not repeat the same predicates',
+    it(
+      'should not repeat the same predicates',
       shouldSerialize(['abc', 'def', 'ghi'],
                       ['abc', 'def', 'pqr'],
                       ['abc', 'bef', 'ghi'],
@@ -232,19 +302,25 @@ describe('Writer', () => {
                       ['stu', 'bef', 'yz'],
                       '<abc> <def> <ghi>, <pqr>;\n' +
                       '    <bef> <ghi>, <pqr>.\n' +
-                      '<stu> <bef> <yz>.\n'));
+                      '<stu> <bef> <yz>.\n')
+    );
 
-    it('should write rdf:type as "a"',
+    it(
+      'should write rdf:type as "a"',
       shouldSerialize(['abc', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'def'],
-                      '<abc> a <def>.\n'));
+                      '<abc> a <def>.\n')
+    );
 
-    it('should serialize a graph with 1 triple',
+    it(
+      'should serialize a graph with 1 triple',
       shouldSerialize(['abc', 'def', 'ghi', 'xyz'],
                       '<xyz> {\n' +
                       '<abc> <def> <ghi>\n' +
-                      '}\n'));
+                      '}\n')
+    );
 
-    it('should serialize a graph with 3 triples',
+    it(
+      'should serialize a graph with 3 triples',
       shouldSerialize(['abc', 'def', 'ghi', 'xyz'],
                       ['jkl', 'mno', 'pqr', 'xyz'],
                       ['stu', 'vwx', 'yz',  'xyz'],
@@ -252,23 +328,30 @@ describe('Writer', () => {
                       '<abc> <def> <ghi>.\n' +
                       '<jkl> <mno> <pqr>.\n' +
                       '<stu> <vwx> <yz>\n' +
-                      '}\n'));
+                      '}\n')
+    );
 
-    it('should serialize three graphs',
+    it(
+      'should serialize three graphs',
       shouldSerialize(['abc', 'def', 'ghi', 'xyz'],
                       ['jkl', 'mno', 'pqr', ''],
                       ['stu', 'vwx', 'yz',  'abc'],
                       '<xyz> {\n<abc> <def> <ghi>\n}\n' +
                       '<jkl> <mno> <pqr>.\n' +
-                      '<abc> {\n<stu> <vwx> <yz>\n}\n'));
+                      '<abc> {\n<stu> <vwx> <yz>\n}\n')
+    );
 
-    it('should output 8-bit unicode characters as escape sequences',
+    it(
+      'should output 8-bit unicode characters as escape sequences',
       shouldSerialize(['\ud835\udc00', '\ud835\udc00', '"\ud835\udc00"^^\ud835\udc00', '\ud835\udc00'],
-                      '<\\U0001d400> {\n<\\U0001d400> <\\U0001d400> "\\U0001d400"^^<\\U0001d400>\n}\n'));
+                      '<\\U0001d400> {\n<\\U0001d400> <\\U0001d400> "\\U0001d400"^^<\\U0001d400>\n}\n')
+    );
 
-    it('should not use escape sequences in blank nodes',
+    it(
+      'should not use escape sequences in blank nodes',
       shouldSerialize(['_:\ud835\udc00', '_:\ud835\udc00', '_:\ud835\udc00', '_:\ud835\udc00'],
-                      '_:\ud835\udc00 {\n_:\ud835\udc00 _:\ud835\udc00 _:\ud835\udc00\n}\n'));
+                      '_:\ud835\udc00 {\n_:\ud835\udc00 _:\ud835\udc00 _:\ud835\udc00\n}\n')
+    );
 
     it('calls the done callback when ending the outputstream errors', done => {
       const writer = new Writer({
@@ -283,54 +366,63 @@ describe('Writer', () => {
       let notCalled = true;
       writer.addQuad(new Quad(new NamedNode('a'), new NamedNode('b'), new NamedNode('c')), () => { notCalled = false; });
       writer.end((error, output) => {
-        output.should.equal('<a> <b> <c>.\n');
+        expect(output).toBe('<a> <b> <c>.\n');
         done(notCalled || error);
       });
     });
 
-    it('respects the prefixes argument when no stream argument is given', done => {
-      const writer = new Writer({ prefixes: { a: 'b#' } });
-      writer.addQuad(new Quad(new NamedNode('b#a'), new NamedNode('b#b'), new NamedNode('b#c')));
-      writer.end((error, output) => {
-        output.should.equal('@prefix a: <b#>.\n\na:a a:b a:c.\n');
-        done(error);
-      });
-    });
+    it(
+      'respects the prefixes argument when no stream argument is given',
+      done => {
+        const writer = new Writer({ prefixes: { a: 'b#' } });
+        writer.addQuad(new Quad(new NamedNode('b#a'), new NamedNode('b#b'), new NamedNode('b#c')));
+        writer.end((error, output) => {
+          expect(output).toBe('@prefix a: <b#>.\n\na:a a:b a:c.\n');
+          done(error);
+        });
+      }
+    );
 
     it('ignores an empty prefix list', done => {
       const writer = new Writer();
       writer.addPrefixes({});
       writer.addQuad(new Quad(new NamedNode('b#a'), new NamedNode('b#b'), new NamedNode('b#c')));
       writer.end((error, output) => {
-        output.should.equal('<b#a> <b#b> <b#c>.\n');
+        expect(output).toBe('<b#a> <b#b> <b#c>.\n');
         done(error);
       });
     });
 
-    it('should serialize triples of graph with prefix for local names that begin with underscore', done => {
-      const writer = new Writer();
-      writer.addPrefix('a', 'b#');
-      writer.addQuad(new Quad(new NamedNode('b#_a'), new NamedNode('b#b'), new NamedNode('b#c'), new NamedNode('b#g')));
-      writer.end((error, output) => {
-        output.should.equal('@prefix a: <b#>.\n\na:g {\na:_a a:b a:c\n}\n');
-        done(error);
-      });
-    });
+    it(
+      'should serialize triples of graph with prefix for local names that begin with underscore',
+      done => {
+        const writer = new Writer();
+        writer.addPrefix('a', 'b#');
+        writer.addQuad(new Quad(new NamedNode('b#_a'), new NamedNode('b#b'), new NamedNode('b#c'), new NamedNode('b#g')));
+        writer.end((error, output) => {
+          expect(output).toBe('@prefix a: <b#>.\n\na:g {\na:_a a:b a:c\n}\n');
+          done(error);
+        });
+      }
+    );
 
-    it('serializes triples of a graph with a prefix declaration in between', done => {
-      const writer = new Writer();
-      writer.addQuad(new Quad(new NamedNode('b#a'), new NamedNode('b#b'), new NamedNode('b#c')));
-      writer.addPrefix('a', 'b#');
-      writer.addQuad(new Quad(new NamedNode('b#a'), new NamedNode('b#b'), new NamedNode('b#c'), new NamedNode('b#g')));
-      writer.addPrefix('d', 'e#');
-      writer.addQuad({ subject: new NamedNode('b#a'), predicate: new NamedNode('b#b'), object: new NamedNode('b#d'), graph: new NamedNode('b#g') });
-      writer.end((error, output) => {
-        output.should.equal('<b#a> <b#b> <b#c>.\n' +
-                            '@prefix a: <b#>.\n\na:g {\na:a a:b a:c\n}\n' +
-                            '@prefix d: <e#>.\n\na:g {\na:a a:b a:d\n}\n');
-        done(error);
-      });
-    });
+    it(
+      'serializes triples of a graph with a prefix declaration in between',
+      done => {
+        const writer = new Writer();
+        writer.addQuad(new Quad(new NamedNode('b#a'), new NamedNode('b#b'), new NamedNode('b#c')));
+        writer.addPrefix('a', 'b#');
+        writer.addQuad(new Quad(new NamedNode('b#a'), new NamedNode('b#b'), new NamedNode('b#c'), new NamedNode('b#g')));
+        writer.addPrefix('d', 'e#');
+        writer.addQuad({ subject: new NamedNode('b#a'), predicate: new NamedNode('b#b'), object: new NamedNode('b#d'), graph: new NamedNode('b#g') });
+        writer.end((error, output) => {
+          expect(output).toBe('<b#a> <b#b> <b#c>.\n' +
+                              '@prefix a: <b#>.\n\na:g {\na:a a:b a:c\n}\n' +
+                              '@prefix d: <e#>.\n\na:g {\na:a a:b a:d\n}\n');
+          done(error);
+        });
+      }
+    );
 
     it('should not write prefixes in N-Triples mode', done => {
       const writer = new Writer({ format: 'N-Triples', prefixes: { a: 'b#' } });
@@ -341,8 +433,8 @@ describe('Writer', () => {
       writer.addQuad(new NamedNode('a'), new NamedNode('b'), new Literal(`"1"^^${xsd.integer}`));
       writer.addPrefix('e', 'f#', callback);
       writer.end((error, output) => {
-        called.should.be.true;
-        output.should.equal(`<a> <b> "c" .\n<a> <b> "1"^^<${xsd.integer}> .\n`);
+        expect(called).toBe(true);
+        expect(output).toBe(`<a> <b> "c" .\n<a> <b> "1"^^<${xsd.integer}> .\n`);
         done(error);
       });
     });
@@ -354,7 +446,7 @@ describe('Writer', () => {
         new NamedNode('http://example.org/foo/#b'),
         new NamedNode('http://example.org/foo/cdeFgh/ijk')));
       writer.end((error, output) => {
-        output.should.equal('<> <#b> <cdeFgh/ijk>.\n');
+        expect(output).toBe('<> <#b> <cdeFgh/ijk>.\n');
         done(error);
       });
     });
@@ -366,7 +458,9 @@ describe('Writer', () => {
         new NamedNode('http://www.w3.org/2002/07/owl#sameAs'),
         new NamedNode('https://pod.example/profile/card-1234.ttl')));
       writer.end((error, output) => {
-        output.should.equal('<#me> <http://www.w3.org/2002/07/owl#sameAs> <https://pod.example/profile/card-1234.ttl>.\n');
+        expect(output).toBe(
+          '<#me> <http://www.w3.org/2002/07/owl#sameAs> <https://pod.example/profile/card-1234.ttl>.\n'
+        );
         done(error);
       });
     });
@@ -376,7 +470,7 @@ describe('Writer', () => {
       writer.addQuad(new NamedNode('a'), new NamedNode('b'), new NamedNode('c'));
       writer.addQuad(new NamedNode('a'), new NamedNode('b'), new NamedNode('d'));
       writer.end((error, output) => {
-        output.should.equal('<a> <b> <c>, <d>.\n');
+        expect(output).toBe('<a> <b> <c>, <d>.\n');
         done(error);
       });
     });
@@ -386,7 +480,7 @@ describe('Writer', () => {
       writer.addQuad(new NamedNode('a'), new NamedNode('b'), new NamedNode('c'), new NamedNode('g'));
       writer.addQuad(new NamedNode('a'), new NamedNode('b'), new NamedNode('d'), new NamedNode('g'));
       writer.end((error, output) => {
-        output.should.equal('<g> {\n<a> <b> <c>, <d>\n}\n');
+        expect(output).toBe('<g> {\n<a> <b> <c>, <d>\n}\n');
         done(error);
       });
     });
@@ -396,7 +490,7 @@ describe('Writer', () => {
       writer.addQuad(new NamedNode('a1'), new NamedNode('b'), writer.blank());
       writer.addQuad(new NamedNode('a2'), new NamedNode('b'), writer.blank([]));
       writer.end((error, output) => {
-        output.should.equal('<a1> <b> [].\n' +
+        expect(output).toBe('<a1> <b> [].\n' +
                             '<a2> <b> [].\n');
         done(error);
       });
@@ -408,73 +502,85 @@ describe('Writer', () => {
       writer.addQuad(blank, new NamedNode('a'), new NamedNode('b'));
       writer.addQuad(blank, new NamedNode('c'), new NamedNode('d'));
       writer.end((error, output) => {
-        output.should.equal('[] <a> <b>;\n' +
+        expect(output).toBe('[] <a> <b>;\n' +
                             '    <c> <d>.\n');
         done(error);
       });
     });
 
-    it('should serialize triples with a one-triple blank node as object', done => {
-      const writer = new Writer();
-      writer.addQuad(new NamedNode('a1'), new NamedNode('b'), writer.blank(new NamedNode('d'), new NamedNode('e')));
-      writer.addQuad(new NamedNode('a2'), new NamedNode('b'), writer.blank({ predicate: new NamedNode('d'), object: new NamedNode('e') }));
-      writer.addQuad(new NamedNode('a3'), new NamedNode('b'), writer.blank([{ predicate: new NamedNode('d'), object: new NamedNode('e') }]));
-      writer.end((error, output) => {
-        output.should.equal('<a1> <b> [ <d> <e> ].\n' +
-                            '<a2> <b> [ <d> <e> ].\n' +
-                            '<a3> <b> [ <d> <e> ].\n');
-        done(error);
-      });
-    });
+    it(
+      'should serialize triples with a one-triple blank node as object',
+      done => {
+        const writer = new Writer();
+        writer.addQuad(new NamedNode('a1'), new NamedNode('b'), writer.blank(new NamedNode('d'), new NamedNode('e')));
+        writer.addQuad(new NamedNode('a2'), new NamedNode('b'), writer.blank({ predicate: new NamedNode('d'), object: new NamedNode('e') }));
+        writer.addQuad(new NamedNode('a3'), new NamedNode('b'), writer.blank([{ predicate: new NamedNode('d'), object: new NamedNode('e') }]));
+        writer.end((error, output) => {
+          expect(output).toBe('<a1> <b> [ <d> <e> ].\n' +
+                              '<a2> <b> [ <d> <e> ].\n' +
+                              '<a3> <b> [ <d> <e> ].\n');
+          done(error);
+        });
+      }
+    );
 
-    it('should serialize triples with a two-triple blank node as object', done => {
-      const writer = new Writer();
-      writer.addQuad(new NamedNode('a'), new NamedNode('b'), writer.blank([
+    it(
+      'should serialize triples with a two-triple blank node as object',
+      done => {
+        const writer = new Writer();
+        writer.addQuad(new NamedNode('a'), new NamedNode('b'), writer.blank([
+            { predicate: new NamedNode('d'), object: new NamedNode('e') },
+            { predicate: new NamedNode('f'), object: new Literal('"g"') },
+        ]));
+        writer.end((error, output) => {
+          expect(output).toBe('<a> <b> [\n' +
+                              '  <d> <e>;\n' +
+                              '  <f> "g"\n' +
+                              '].\n');
+          done(error);
+        });
+      }
+    );
+
+    it(
+      'should serialize triples with a three-triple blank node as object',
+      done => {
+        const writer = new Writer();
+        writer.addQuad(new NamedNode('a'), new NamedNode('b'), writer.blank([
           { predicate: new NamedNode('d'), object: new NamedNode('e') },
           { predicate: new NamedNode('f'), object: new Literal('"g"') },
-      ]));
-      writer.end((error, output) => {
-        output.should.equal('<a> <b> [\n' +
-                            '  <d> <e>;\n' +
-                            '  <f> "g"\n' +
-                            '].\n');
-        done(error);
-      });
-    });
+          { predicate: new NamedNode('h'), object: new NamedNode('i') },
+        ]));
+        writer.end((error, output) => {
+          expect(output).toBe('<a> <b> [\n' +
+                              '  <d> <e>;\n' +
+                              '  <f> "g";\n' +
+                              '  <h> <i>\n' +
+                              '].\n');
+          done(error);
+        });
+      }
+    );
 
-    it('should serialize triples with a three-triple blank node as object', done => {
-      const writer = new Writer();
-      writer.addQuad(new NamedNode('a'), new NamedNode('b'), writer.blank([
-        { predicate: new NamedNode('d'), object: new NamedNode('e') },
-        { predicate: new NamedNode('f'), object: new Literal('"g"') },
-        { predicate: new NamedNode('h'), object: new NamedNode('i') },
-      ]));
-      writer.end((error, output) => {
-        output.should.equal('<a> <b> [\n' +
-                            '  <d> <e>;\n' +
-                            '  <f> "g";\n' +
-                            '  <h> <i>\n' +
-                            '].\n');
-        done(error);
-      });
-    });
-
-    it('should serialize triples with predicate-sharing blank node triples as object', done => {
-      const writer = new Writer();
-      writer.addQuad(new NamedNode('a'), new NamedNode('b'), writer.blank([
-        { predicate: new NamedNode('d'), object: new NamedNode('e') },
-        { predicate: new NamedNode('d'), object: new NamedNode('f') },
-        { predicate: new NamedNode('g'), object: new NamedNode('h') },
-        { predicate: new NamedNode('g'), object: new NamedNode('i') },
-      ]));
-      writer.end((error, output) => {
-        output.should.equal('<a> <b> [\n' +
-          '  <d> <e>, <f>;\n' +
-          '  <g> <h>, <i>\n' +
-          '].\n');
-        done(error);
-      });
-    });
+    it(
+      'should serialize triples with predicate-sharing blank node triples as object',
+      done => {
+        const writer = new Writer();
+        writer.addQuad(new NamedNode('a'), new NamedNode('b'), writer.blank([
+          { predicate: new NamedNode('d'), object: new NamedNode('e') },
+          { predicate: new NamedNode('d'), object: new NamedNode('f') },
+          { predicate: new NamedNode('g'), object: new NamedNode('h') },
+          { predicate: new NamedNode('g'), object: new NamedNode('i') },
+        ]));
+        writer.end((error, output) => {
+          expect(output).toBe('<a> <b> [\n' +
+            '  <d> <e>, <f>;\n' +
+            '  <g> <h>, <i>\n' +
+            '].\n');
+          done(error);
+        });
+      }
+    );
 
     it('should serialize triples with nested blank nodes as object', done => {
       const writer = new Writer();
@@ -492,7 +598,7 @@ describe('Writer', () => {
         ]) },
       ]));
       writer.end((error, output) => {
-        output.should.equal('<a1> <b> [\n' +
+        expect(output).toBe('<a1> <b> [\n' +
           '  <d> []\n' +
           '].\n' +
           '<a2> <b> [\n' +
@@ -514,31 +620,34 @@ describe('Writer', () => {
       writer.addQuad(writer.blank(), new NamedNode('b'), new NamedNode('c'));
       writer.addQuad(writer.blank([]), new NamedNode('b'), new NamedNode('c'));
       writer.end((error, output) => {
-        output.should.equal('[] <b> <c>.\n' +
+        expect(output).toBe('[] <b> <c>.\n' +
                             '[] <b> <c>.\n');
         done(error);
       });
     });
 
-    it('should serialize triples with a one-triple blank node as subject', done => {
-      const writer = new Writer();
-      writer.addQuad(writer.blank(new NamedNode('a'), new NamedNode('b')), new NamedNode('c'), new NamedNode('d'));
-      writer.addQuad(writer.blank({ predicate: new NamedNode('a'), object: new NamedNode('b') }), new NamedNode('c'), new NamedNode('d'));
-      writer.addQuad(writer.blank([{ predicate: new NamedNode('a'), object: new NamedNode('b') }]), new NamedNode('c'), new NamedNode('d'));
-      writer.end((error, output) => {
-        output.should.equal('[ <a> <b> ] <c> <d>.\n' +
-                            '[ <a> <b> ] <c> <d>.\n' +
-                            '[ <a> <b> ] <c> <d>.\n');
-        done(error);
-      });
-    });
+    it(
+      'should serialize triples with a one-triple blank node as subject',
+      done => {
+        const writer = new Writer();
+        writer.addQuad(writer.blank(new NamedNode('a'), new NamedNode('b')), new NamedNode('c'), new NamedNode('d'));
+        writer.addQuad(writer.blank({ predicate: new NamedNode('a'), object: new NamedNode('b') }), new NamedNode('c'), new NamedNode('d'));
+        writer.addQuad(writer.blank([{ predicate: new NamedNode('a'), object: new NamedNode('b') }]), new NamedNode('c'), new NamedNode('d'));
+        writer.end((error, output) => {
+          expect(output).toBe('[ <a> <b> ] <c> <d>.\n' +
+                              '[ <a> <b> ] <c> <d>.\n' +
+                              '[ <a> <b> ] <c> <d>.\n');
+          done(error);
+        });
+      }
+    );
 
     it('should serialize triples with an empty blank node as graph', done => {
       const writer = new Writer();
       writer.addQuad(new NamedNode('a'), new NamedNode('b'), new NamedNode('c'), writer.blank());
       writer.addQuad(new NamedNode('a'), new NamedNode('b'), new NamedNode('c'), writer.blank([]));
       writer.end((error, output) => {
-        output.should.equal('[] {\n<a> <b> <c>\n}\n' +
+        expect(output).toBe('[] {\n<a> <b> <c>\n}\n' +
                             '[] {\n<a> <b> <c>\n}\n');
         done(error);
       });
@@ -549,7 +658,7 @@ describe('Writer', () => {
       writer.addQuad(new NamedNode('a1'), new NamedNode('b'), writer.list());
       writer.addQuad(new NamedNode('a2'), new NamedNode('b'), writer.list([]));
       writer.end((error, output) => {
-        output.should.equal('<a1> <b> ().\n' +
+        expect(output).toBe('<a1> <b> ().\n' +
                             '<a2> <b> ().\n');
         done(error);
       });
@@ -560,7 +669,7 @@ describe('Writer', () => {
       writer.addQuad(new NamedNode('a1'), new NamedNode('b'), writer.list([new NamedNode('c')]));
       writer.addQuad(new NamedNode('a2'), new NamedNode('b'), writer.list([new Literal('"c"')]));
       writer.end((error, output) => {
-        output.should.equal('<a1> <b> (<c>).\n' +
+        expect(output).toBe('<a1> <b> (<c>).\n' +
                             '<a2> <b> ("c").\n');
         done(error);
       });
@@ -571,7 +680,7 @@ describe('Writer', () => {
       writer.addQuad(new NamedNode('a1'), new NamedNode('b'), writer.list([new NamedNode('c'), new NamedNode('d'), new NamedNode('e')]));
       writer.addQuad(new NamedNode('a2'), new NamedNode('b'), writer.list([new Literal('"c"'), new Literal('"d"'), new Literal('"e"')]));
       writer.end((error, output) => {
-        output.should.equal('<a1> <b> (<c> <d> <e>).\n' +
+        expect(output).toBe('<a1> <b> (<c> <d> <e>).\n' +
                             '<a2> <b> ("c" "d" "e").\n');
         done(error);
       });
@@ -582,7 +691,7 @@ describe('Writer', () => {
       writer.addQuad(writer.list(),   new NamedNode('b1'), new NamedNode('c'));
       writer.addQuad(writer.list([]), new NamedNode('b2'), new NamedNode('c'));
       writer.end((error, output) => {
-        output.should.equal('() <b1> <c>.\n' +
+        expect(output).toBe('() <b1> <c>.\n' +
                             '() <b2> <c>.\n');
         done(error);
       });
@@ -593,7 +702,7 @@ describe('Writer', () => {
       writer.addQuad(writer.list([new NamedNode('a')]), new NamedNode('b1'), new NamedNode('c'));
       writer.addQuad(writer.list([new NamedNode('a')]), new NamedNode('b2'), new NamedNode('c'));
       writer.end((error, output) => {
-        output.should.equal('(<a>) <b1> <c>.\n' +
+        expect(output).toBe('(<a>) <b1> <c>.\n' +
                             '(<a>) <b2> <c>.\n');
         done(error);
       });
@@ -603,33 +712,36 @@ describe('Writer', () => {
       const writer = new Writer();
       writer.addQuad(writer.list([new NamedNode('a1'), new Literal('"b"'), new Literal('"c"')]), new NamedNode('d'), new NamedNode('e'));
       writer.end((error, output) => {
-        output.should.equal('(<a1> "b" "c") <d> <e>.\n');
+        expect(output).toBe('(<a1> "b" "c") <d> <e>.\n');
         done(error);
       });
     });
 
-    it('should serialize subject and object triples passed by options.listHeads', done => {
-      const lists = {
-        l1: [new NamedNode('c'), new NamedNode('d'), new NamedNode('e')],
-        l2: [new Literal('c'), new Literal('d'), new Literal('e')],
-      };
+    it(
+      'should serialize subject and object triples passed by options.listHeads',
+      done => {
+        const lists = {
+          l1: [new NamedNode('c'), new NamedNode('d'), new NamedNode('e')],
+          l2: [new Literal('c'), new Literal('d'), new Literal('e')],
+        };
 
-      const writer = new Writer({ lists });
-      writer.addQuad(new BlankNode('l1'), new NamedNode('b'), new BlankNode('l2'));
-      writer.addQuad(new NamedNode('a3'), new NamedNode('b'), new BlankNode('m3'));
-      writer.end((error, output) => {
-        output.should.equal('(<c> <d> <e>) <b> ("c" "d" "e").\n' +
-          '<a3> <b> _:m3.\n');
-        done(error);
-      });
-    });
+        const writer = new Writer({ lists });
+        writer.addQuad(new BlankNode('l1'), new NamedNode('b'), new BlankNode('l2'));
+        writer.addQuad(new NamedNode('a3'), new NamedNode('b'), new BlankNode('m3'));
+        writer.end((error, output) => {
+          expect(output).toBe('(<c> <d> <e>) <b> ("c" "d" "e").\n' +
+            '<a3> <b> _:m3.\n');
+          done(error);
+        });
+      }
+    );
 
     it('should accept triples in bulk', done => {
       const writer = new Writer();
       writer.addQuads([new Quad(new NamedNode('a'), new NamedNode('b'), new NamedNode('c')),
         new Quad(new NamedNode('a'), new NamedNode('b'), new NamedNode('d'))]);
       writer.end((error, output) => {
-        output.should.equal('<a> <b> <c>, <d>.\n');
+        expect(output).toBe('<a> <b> <c>, <d>.\n');
         done(error);
       });
     });
@@ -639,8 +751,8 @@ describe('Writer', () => {
       writer.addQuad(new Quad(new NamedNode('a'), new NamedNode('b'), new NamedNode('c')));
       writer.end();
       writer.addQuad(new Quad(new NamedNode('d'), new NamedNode('e'), new NamedNode('f')), error => {
-        error.should.be.an.instanceof(Error);
-        error.should.have.property('message', 'Cannot write because the writer has been closed.');
+        expect(error).toBeInstanceOf(Error);
+        expect(error).toHaveProperty('message', 'Cannot write because the writer has been closed.');
         done();
       });
     });
@@ -650,7 +762,7 @@ describe('Writer', () => {
       writer.addQuad(new NamedNode('a'), new NamedNode('b'), new NamedNode('c'));
       writer.addQuad(new NamedNode('a'), new NamedNode('b'), new NamedNode('d'));
       writer.end((error, output) => {
-        output.should.equal('<a> <b> <c> .\n<a> <b> <d> .\n');
+        expect(output).toBe('<a> <b> <c> .\n<a> <b> <d> .\n');
         done(error);
       });
     });
@@ -662,97 +774,133 @@ describe('Writer', () => {
       writer.addQuad(new NamedNode('a'), new NamedNode('b'), new NamedNode('c'), callback);
       writer.addQuad(new NamedNode('a'), new NamedNode('b'), new NamedNode('d'), new NamedNode('g'));
       writer.end((error, output) => {
-        called.should.be.true;
-        output.should.equal('<a> <b> <c> .\n<a> <b> <d> <g> .\n');
+        expect(called).toBe(true);
+        expect(output).toBe('<a> <b> <c> .\n<a> <b> <d> <g> .\n');
         done(error);
       });
     });
 
     it('should end when the end option is not set', done => {
       const outputStream = new QuickStream(), writer = new Writer(outputStream, {});
-      outputStream.should.have.property('ended', false);
+      expect(outputStream).toHaveProperty('ended', false);
       writer.end(() => {
-        outputStream.should.have.property('ended', true);
+        expect(outputStream).toHaveProperty('ended', true);
         done();
       });
     });
 
     it('should end when the end option is set to true', done => {
       const outputStream = new QuickStream(), writer = new Writer(outputStream, { end: true });
-      outputStream.should.have.property('ended', false);
+      expect(outputStream).toHaveProperty('ended', false);
       writer.end(() => {
-        outputStream.should.have.property('ended', true);
+        expect(outputStream).toHaveProperty('ended', true);
         done();
       });
     });
 
     it('should not end when the end option is set to false', done => {
       const outputStream = new QuickStream(), writer = new Writer(outputStream, { end: false });
-      outputStream.should.have.property('ended', false);
+      expect(outputStream).toHaveProperty('ended', false);
       writer.end(() => {
-        outputStream.should.have.property('ended', false);
+        expect(outputStream).toHaveProperty('ended', false);
         done();
       });
     });
 
-    it('should serialize a triple with a triple with mixed component types as subject', () => {
-      const writer = new Writer();
-      writer.quadToString(new Quad(new BlankNode('b1'), new NamedNode('b'), new Literal('l1')), new NamedNode('b'), new NamedNode('c')).should.equal('<<_:b1 <b> "l">> <b> <c> .\n');
-    });
+    it(
+      'should serialize a triple with a triple with mixed component types as subject',
+      () => {
+        const writer = new Writer();
+        expect(
+          writer.quadToString(new Quad(new BlankNode('b1'), new NamedNode('b'), new Literal('l1')), new NamedNode('b'), new NamedNode('c'))
+        ).toBe('<<_:b1 <b> "l">> <b> <c> .\n');
+      }
+    );
 
     it('should serialize a triple with a triple with iris as subject', () => {
       const writer = new Writer();
-      writer.quadToString(new Quad(new NamedNode('a'), new NamedNode('b'), new NamedNode('c')), new NamedNode('b'), new NamedNode('c')).should.equal('<<<a> <b> <c>>> <b> <c> .\n');
+      expect(
+        writer.quadToString(new Quad(new NamedNode('a'), new NamedNode('b'), new NamedNode('c')), new NamedNode('b'), new NamedNode('c'))
+      ).toBe('<<<a> <b> <c>>> <b> <c> .\n');
     });
 
-    it('should serialize a triple with a triple with blanknodes as subject', () => {
-      const writer = new Writer();
-      writer.quadToString(new Quad(new BlankNode('b1'), new BlankNode('b2'), new BlankNode('b3')), new NamedNode('b'), new NamedNode('c')).should.equal('<<_:b1 _:b2 _:b3>> <b> <c> .\n');
-    });
+    it(
+      'should serialize a triple with a triple with blanknodes as subject',
+      () => {
+        const writer = new Writer();
+        expect(
+          writer.quadToString(new Quad(new BlankNode('b1'), new BlankNode('b2'), new BlankNode('b3')), new NamedNode('b'), new NamedNode('c'))
+        ).toBe('<<_:b1 _:b2 _:b3>> <b> <c> .\n');
+      }
+    );
 
     it('should serialize a triple with a triple as object', () => {
       const writer = new Writer();
-      writer.quadToString(new NamedNode('a'), new NamedNode('b'), new Quad(new BlankNode('b1'), new NamedNode('b'), new Literal('l1'))).should.equal('<a> <b> <<_:b1 <b> "l">> .\n');
+      expect(
+        writer.quadToString(new NamedNode('a'), new NamedNode('b'), new Quad(new BlankNode('b1'), new NamedNode('b'), new Literal('l1')))
+      ).toBe('<a> <b> <<_:b1 <b> "l">> .\n');
     });
 
     it('should serialize a triple with a triple with iris as object', () => {
       const writer = new Writer();
-      writer.quadToString(new NamedNode('a'), new NamedNode('b'), new Quad(new NamedNode('a'), new NamedNode('b'), new NamedNode('c'))).should.equal('<a> <b> <<<a> <b> <c>>> .\n');
+      expect(
+        writer.quadToString(new NamedNode('a'), new NamedNode('b'), new Quad(new NamedNode('a'), new NamedNode('b'), new NamedNode('c')))
+      ).toBe('<a> <b> <<<a> <b> <c>>> .\n');
     });
 
-    it('should serialize a triple with a triple with blanknodes as object', () => {
-      const writer = new Writer();
-      writer.quadToString(new NamedNode('a'), new NamedNode('b'), new Quad(new BlankNode('b1'), new BlankNode('b2'), new BlankNode('b3'))).should.equal('<a> <b> <<_:b1 _:b2 _:b3>> .\n');
-    });
+    it(
+      'should serialize a triple with a triple with blanknodes as object',
+      () => {
+        const writer = new Writer();
+        expect(
+          writer.quadToString(new NamedNode('a'), new NamedNode('b'), new Quad(new BlankNode('b1'), new BlankNode('b2'), new BlankNode('b3')))
+        ).toBe('<a> <b> <<_:b1 _:b2 _:b3>> .\n');
+      }
+    );
 
-    it('should serialize a quad with a triple with mixed component types as subject', () => {
-      const writer = new Writer();
-      writer.quadToString(new Quad(new NamedNode('a'), new NamedNode('b'), new NamedNode('c')), new NamedNode('b'), new NamedNode('c'), new NamedNode('g')).should.equal('<<<a> <b> <c>>> <b> <c> <g> .\n');
-    });
+    it(
+      'should serialize a quad with a triple with mixed component types as subject',
+      () => {
+        const writer = new Writer();
+        expect(
+          writer.quadToString(new Quad(new NamedNode('a'), new NamedNode('b'), new NamedNode('c')), new NamedNode('b'), new NamedNode('c'), new NamedNode('g'))
+        ).toBe('<<<a> <b> <c>>> <b> <c> <g> .\n');
+      }
+    );
 
     it('should serialize a quad with a triple as object', () => {
       const writer = new Writer();
-      writer.quadToString(new NamedNode('a'), new NamedNode('b'), new Quad(new NamedNode('a'), new NamedNode('b'), new NamedNode('c')), new NamedNode('g')).should.equal('<a> <b> <<<a> <b> <c>>> <g> .\n');
+      expect(
+        writer.quadToString(new NamedNode('a'), new NamedNode('b'), new Quad(new NamedNode('a'), new NamedNode('b'), new NamedNode('c')), new NamedNode('g'))
+      ).toBe('<a> <b> <<<a> <b> <c>>> <g> .\n');
     });
 
     it('should serialize a quad with a quad as subject', () => {
       const writer = new Writer();
-      writer.quadToString(new Quad(new NamedNode('a'), new NamedNode('b'), new NamedNode('c'), new NamedNode('g')), new NamedNode('b'), new NamedNode('c'), new NamedNode('g')).should.equal('<<<a> <b> <c> <g>>> <b> <c> <g> .\n');
+      expect(
+        writer.quadToString(new Quad(new NamedNode('a'), new NamedNode('b'), new NamedNode('c'), new NamedNode('g')), new NamedNode('b'), new NamedNode('c'), new NamedNode('g'))
+      ).toBe('<<<a> <b> <c> <g>>> <b> <c> <g> .\n');
     });
 
     it('should serialize a quad with a quad as object', () => {
       const writer = new Writer();
-      writer.quadToString(new NamedNode('a'), new NamedNode('b'), new Quad(new NamedNode('a'), new NamedNode('b'), new NamedNode('c'), new NamedNode('g')), new NamedNode('g')).should.equal('<a> <b> <<<a> <b> <c> <g>>> <g> .\n');
+      expect(
+        writer.quadToString(new NamedNode('a'), new NamedNode('b'), new Quad(new NamedNode('a'), new NamedNode('b'), new NamedNode('c'), new NamedNode('g')), new NamedNode('g'))
+      ).toBe('<a> <b> <<<a> <b> <c> <g>>> <g> .\n');
     });
 
     it('should serialize a triple with a quad as subject', () => {
       const writer = new Writer();
-      writer.quadToString(new Quad(new NamedNode('a'), new NamedNode('b'), new NamedNode('c'), new NamedNode('g')), new NamedNode('b'), new NamedNode('c')).should.equal('<<<a> <b> <c> <g>>> <b> <c> .\n');
+      expect(
+        writer.quadToString(new Quad(new NamedNode('a'), new NamedNode('b'), new NamedNode('c'), new NamedNode('g')), new NamedNode('b'), new NamedNode('c'))
+      ).toBe('<<<a> <b> <c> <g>>> <b> <c> .\n');
     });
 
     it('should serialize a triple with a quad as object', () => {
       const writer = new Writer();
-      writer.quadToString(new NamedNode('a'), new NamedNode('b'), new Quad(new NamedNode('a'), new NamedNode('b'), new NamedNode('c'), new NamedNode('g'))).should.equal('<a> <b> <<<a> <b> <c> <g>>> .\n');
+      expect(
+        writer.quadToString(new NamedNode('a'), new NamedNode('b'), new Quad(new NamedNode('a'), new NamedNode('b'), new NamedNode('c'), new NamedNode('g')))
+      ).toBe('<a> <b> <<<a> <b> <c> <g>>> .\n');
     });
   });
 });
@@ -777,8 +925,8 @@ function shouldSerialize(/* prefixes?, tripleArrays..., expectedResult */) {
       else
         writer.end(error => {
           try {
-            outputStream.result.should.equal(expectedResult);
-            outputStream.should.have.property('ended', true);
+            expect(outputStream.result).toBe(expectedResult);
+            expect(outputStream).toHaveProperty('ended', true);
             done(error);
           }
           catch (e) {

--- a/test/NamedNode-test.js
+++ b/test/NamedNode-test.js
@@ -3,77 +3,83 @@ import { NamedNode, Term } from '../src/';
 describe('NamedNode', () => {
   describe('The NamedNode module', () => {
     it('should be a function', () => {
-      NamedNode.should.be.a('function');
+      expect(NamedNode).toBeInstanceOf(Function);
     });
 
     it('should be a NamedNode constructor', () => {
-      new NamedNode().should.be.an.instanceof(NamedNode);
+      expect(new NamedNode()).toBeInstanceOf(NamedNode);
     });
 
     it('should be a Term constructor', () => {
-      new NamedNode().should.be.an.instanceof(Term);
+      expect(new NamedNode()).toBeInstanceOf(Term);
     });
   });
 
   describe('A NamedNode instance created from an IRI', () => {
     let namedNode;
-    before(() => { namedNode = new NamedNode('http://example.org/foo#bar'); });
+    beforeAll(() => { namedNode = new NamedNode('http://example.org/foo#bar'); });
 
     it('should be a NamedNode', () => {
-      namedNode.should.be.an.instanceof(NamedNode);
+      expect(namedNode).toBeInstanceOf(NamedNode);
     });
 
     it('should be a Term', () => {
-      namedNode.should.be.an.instanceof(Term);
+      expect(namedNode).toBeInstanceOf(Term);
     });
 
     it('should have term type "NamedNode"', () => {
-      namedNode.termType.should.equal('NamedNode');
+      expect(namedNode.termType).toBe('NamedNode');
     });
 
     it('should have the IRI as value', () => {
-      namedNode.should.have.property('value', 'http://example.org/foo#bar');
+      expect(namedNode).toHaveProperty('value', 'http://example.org/foo#bar');
     });
 
     it('should have the IRI as id', () => {
-      namedNode.should.have.property('id', 'http://example.org/foo#bar');
+      expect(namedNode).toHaveProperty('id', 'http://example.org/foo#bar');
     });
 
     it('should equal a NamedNode instance with the same IRI', () => {
-      namedNode.equals(new NamedNode('http://example.org/foo#bar')).should.be.true;
+      expect(namedNode.equals(new NamedNode('http://example.org/foo#bar'))).toBe(true);
     });
 
     it('should equal an object with the same term type and value', () => {
-      namedNode.equals({
+      expect(namedNode.equals({
         termType: 'NamedNode',
         value: 'http://example.org/foo#bar',
-      }).should.be.true;
+      })).toBe(true);
     });
 
     it('should not equal a falsy object', () => {
-      namedNode.equals(null).should.be.false;
+      expect(namedNode.equals(null)).toBe(false);
     });
 
     it('should not equal a NamedNode instance with another IRI', () => {
-      namedNode.equals(new NamedNode('http://example.org/other')).should.be.false;
+      expect(namedNode.equals(new NamedNode('http://example.org/other'))).toBe(false);
     });
 
-    it('should not equal an object with the same term type but a different value', () => {
-      namedNode.equals({
-        termType: 'NamedNode',
-        value: 'http://example.org/other',
-      }).should.be.false;
-    });
+    it(
+      'should not equal an object with the same term type but a different value',
+      () => {
+        expect(namedNode.equals({
+          termType: 'NamedNode',
+          value: 'http://example.org/other',
+        })).toBe(false);
+      }
+    );
 
-    it('should not equal an object with a different term type but the same value', () => {
-      namedNode.equals({
-        termType: 'BlankNode',
-        value: 'http://example.org/foo#bar',
-      }).should.be.false;
-    });
+    it(
+      'should not equal an object with a different term type but the same value',
+      () => {
+        expect(namedNode.equals({
+          termType: 'BlankNode',
+          value: 'http://example.org/foo#bar',
+        })).toBe(false);
+      }
+    );
 
     it('should provide a JSON representation', () => {
-      namedNode.toJSON().should.deep.equal({
+      expect(namedNode.toJSON()).toEqual({
         termType: 'NamedNode',
         value: 'http://example.org/foo#bar',
       });

--- a/test/Quad-test.js
+++ b/test/Quad-test.js
@@ -3,21 +3,21 @@ import { Quad, Triple, DefaultGraph, termFromId, Term } from '../src/';
 describe('Quad', () => {
   describe('The Quad module', () => {
     it('should be a function', () => {
-      Quad.should.be.a('function');
+      expect(Quad).toBeInstanceOf(Function);
     });
 
     it('should be a Quad constructor', () => {
-      new Quad().should.be.an.instanceof(Quad);
+      expect(new Quad()).toBeInstanceOf(Quad);
     });
 
     it('should equal Triple', () => {
-      Quad.should.equal(Triple);
+      expect(Quad).toBe(Triple);
     });
   });
 
   describe('A Quad instance created with subject/predicate/object', () => {
     let quad, subject, predicate, object;
-    before(() => {
+    beforeAll(() => {
       quad = new Quad(
         subject   = termFromId('s'),
         predicate = termFromId('p'),
@@ -26,80 +26,80 @@ describe('Quad', () => {
     });
 
     it('should be a Quad', () => {
-      quad.should.be.an.instanceof(Quad);
+      expect(quad).toBeInstanceOf(Quad);
     });
 
     it('should be a Term', () => {
-      quad.should.be.an.instanceof(Term);
+      expect(quad).toBeInstanceOf(Term);
     });
 
     it('should have the correct termType', () => {
-      quad.termType.should.equal('Quad');
+      expect(quad.termType).toBe('Quad');
     });
 
     it('should have the correct subject', () => {
-      quad.subject.should.equal(subject);
+      expect(quad.subject).toBe(subject);
     });
 
     it('should have the correct predicate', () => {
-      quad.predicate.should.equal(predicate);
+      expect(quad.predicate).toBe(predicate);
     });
 
     it('should have the correct object', () => {
-      quad.object.should.equal(object);
+      expect(quad.object).toBe(object);
     });
 
     it('should have the default graph', () => {
-      quad.graph.should.equal(new DefaultGraph());
+      expect(quad.graph).toBe(new DefaultGraph());
     });
 
     it('should equal a quad with the same components', () => {
-      quad.equals({
+      expect(quad.equals({
         subject:   subject,
         predicate: predicate,
         object:    object,
         graph:     new DefaultGraph(),
-      }).should.be.true;
+      })).toBe(true);
     });
 
     it('should not equal a quad with a different subject', () => {
-      quad.equals({
+      expect(quad.equals({
         subject:   termFromId('x'),
         predicate: predicate,
         object:    object,
         graph:     new DefaultGraph(),
-      }).should.be.false;
+      })).toBe(false);
     });
 
     it('should not equal a quad with a different predicate', () => {
-      quad.equals({
+      expect(quad.equals({
         subject:   subject,
         predicate: termFromId('x'),
         object:    object,
         graph:     new DefaultGraph(),
-      }).should.be.false;
+      })).toBe(false);
     });
 
     it('should not equal a quad with a different object', () => {
-      quad.equals({
+      expect(quad.equals({
         subject:   subject,
         predicate: predicate,
         object:    termFromId('x'),
         graph:     new DefaultGraph(),
-      }).should.be.false;
+      })).toBe(false);
     });
 
     it('should not equal a quad with a different graph', () => {
-      quad.equals({
+      expect(quad.equals({
         subject:   subject,
         predicate: predicate,
         object:    object,
         graph:     termFromId('x'),
-      }).should.be.false;
+      })).toBe(false);
     });
 
     it('should provide a JSON representation', () => {
-      quad.toJSON().should.deep.equal({
+      expect(quad.toJSON()).toEqual({
         termType:  'Quad',
         subject:   { termType: 'NamedNode', value: 's' },
         predicate: { termType: 'NamedNode', value: 'p' },
@@ -111,7 +111,7 @@ describe('Quad', () => {
 
   describe('A Quad instance created with subject/predicate/object/graph', () => {
     let quad, subject, predicate, object, graph;
-    before(() => {
+    beforeAll(() => {
       quad = new Quad(
         subject   = termFromId('s'),
         predicate = termFromId('p'),
@@ -121,80 +121,80 @@ describe('Quad', () => {
     });
 
     it('should be a Quad', () => {
-      quad.should.be.an.instanceof(Quad);
+      expect(quad).toBeInstanceOf(Quad);
     });
 
     it('should be a Term', () => {
-      quad.should.be.an.instanceof(Term);
+      expect(quad).toBeInstanceOf(Term);
     });
 
     it('should have the correct termType', () => {
-      quad.termType.should.equal('Quad');
+      expect(quad.termType).toBe('Quad');
     });
 
     it('should have the correct subject', () => {
-      quad.subject.should.equal(subject);
+      expect(quad.subject).toBe(subject);
     });
 
     it('should have the correct predicate', () => {
-      quad.predicate.should.equal(predicate);
+      expect(quad.predicate).toBe(predicate);
     });
 
     it('should have the correct object', () => {
-      quad.object.should.equal(object);
+      expect(quad.object).toBe(object);
     });
 
     it('should have the default graph', () => {
-      quad.graph.should.equal(graph);
+      expect(quad.graph).toBe(graph);
     });
 
     it('should equal a quad with the same components', () => {
-      quad.equals({
+      expect(quad.equals({
         subject:   subject,
         predicate: predicate,
         object:    object,
         graph:     graph,
-      }).should.be.true;
+      })).toBe(true);
     });
 
     it('should not equal a quad with a different subject', () => {
-      quad.equals({
+      expect(quad.equals({
         subject:   termFromId('x'),
         predicate: predicate,
         object:    object,
         graph:     graph,
-      }).should.be.false;
+      })).toBe(false);
     });
 
     it('should not equal a quad with a different predicate', () => {
-      quad.equals({
+      expect(quad.equals({
         subject:   subject,
         predicate: termFromId('x'),
         object:    object,
         graph:     graph,
-      }).should.be.false;
+      })).toBe(false);
     });
 
     it('should not equal a quad with a different object', () => {
-      quad.equals({
+      expect(quad.equals({
         subject:   subject,
         predicate: predicate,
         object:    termFromId('x'),
         graph:     graph,
-      }).should.be.false;
+      })).toBe(false);
     });
 
     it('should not equal a quad with a different graph', () => {
-      quad.equals({
+      expect(quad.equals({
         subject:   subject,
         predicate: predicate,
         object:    object,
         graph:     termFromId('x'),
-      }).should.be.false;
+      })).toBe(false);
     });
 
     it('should provide a JSON representation', () => {
-      quad.toJSON().should.deep.equal({
+      expect(quad.toJSON()).toEqual({
         termType:  'Quad',
         subject:   { termType: 'NamedNode', value: 's' },
         predicate: { termType: 'NamedNode', value: 'p' },
@@ -206,7 +206,7 @@ describe('Quad', () => {
 
   describe('A Quad instance with nested quads', () => {
     let quad, subject, predicate, object;
-    before(() => {
+    beforeAll(() => {
       quad = new Quad(
         subject   = termFromId('<<_:n3-123 ?var-a ?var-b _:n3-000>>'),
         predicate = termFromId('p'),
@@ -215,88 +215,88 @@ describe('Quad', () => {
     });
 
     it('should be a Quad', () => {
-      quad.should.be.an.instanceof(Quad);
+      expect(quad).toBeInstanceOf(Quad);
     });
 
     it('should be a Term', () => {
-      quad.should.be.an.instanceof(Term);
+      expect(quad).toBeInstanceOf(Term);
     });
 
     it('should have the correct termType', () => {
-      quad.termType.should.equal('Quad');
+      expect(quad.termType).toBe('Quad');
     });
 
     it('should have the correct subject', () => {
-      quad.subject.should.equal(subject);
+      expect(quad.subject).toBe(subject);
     });
 
     it('should have the correct predicate', () => {
-      quad.predicate.should.equal(predicate);
+      expect(quad.predicate).toBe(predicate);
     });
 
     it('should have the correct object', () => {
-      quad.object.should.equal(object);
+      expect(quad.object).toBe(object);
     });
 
     it('should have the default graph', () => {
-      quad.graph.should.equal(new DefaultGraph());
+      expect(quad.graph).toBe(new DefaultGraph());
     });
 
     it('should equal a quad with the same components', () => {
-      quad.equals({
+      expect(quad.equals({
         subject:   subject,
         predicate: predicate,
         object:    object,
         graph:     new DefaultGraph(),
-      }).should.be.true;
+      })).toBe(true);
     });
 
     it('should not equal a quad with a different subject', () => {
-      quad.equals({
+      expect(quad.equals({
         termType: 'Quad',
         value: '',
         subject:   termFromId('x'),
         predicate: predicate,
         object:    object,
         graph:     new DefaultGraph(),
-      }).should.be.false;
+      })).toBe(false);
     });
 
     it('should not equal a quad with a different predicate', () => {
-      quad.equals({
+      expect(quad.equals({
         termType: 'Quad',
         value: '',
         subject:   subject,
         predicate: termFromId('x'),
         object:    object,
         graph:     new DefaultGraph(),
-      }).should.be.false;
+      })).toBe(false);
     });
 
     it('should not equal a quad with a different object', () => {
-      quad.equals({
+      expect(quad.equals({
         termType: 'Quad',
         value: '',
         subject:   subject,
         predicate: predicate,
         object:    termFromId('x'),
         graph:     new DefaultGraph(),
-      }).should.be.false;
+      })).toBe(false);
     });
 
     it('should not equal a quad with a different graph', () => {
-      quad.equals({
+      expect(quad.equals({
         termType: 'Quad',
         value: '',
         subject:   subject,
         predicate: predicate,
         object:    object,
         graph:     termFromId('x'),
-      }).should.be.false;
+      })).toBe(false);
     });
 
     it('should provide a JSON representation', () => {
-      quad.toJSON().should.deep.equal({
+      expect(quad.toJSON()).toEqual({
         termType:  'Quad',
         subject:   termFromId('<<_:n3-123 ?var-a ?var-b _:n3-000>>').toJSON(),
         predicate: { termType: 'NamedNode', value: 'p' },

--- a/test/Term-test.js
+++ b/test/Term-test.js
@@ -18,90 +18,105 @@ import {
 describe('Term', () => {
   describe('The Term module', () => {
     it('should be a function', () => {
-      Term.should.be.a('function');
+      expect(Term).toBeInstanceOf(Function);
     });
 
     it('should be a Term constructor', () => {
-      new Term().should.be.an.instanceof(Term);
+      expect(new Term()).toBeInstanceOf(Term);
     });
   });
 
   describe('A Term instance', () => {
     it('has an integer hashCode', () => {
-      new Term().hashCode().should.equal(0);
+      expect(new Term().hashCode()).toBe(0);
     });
   });
 
   describe('termFromId', () => {
     it('should create a DefaultGraph from a falsy value', () => {
-      termFromId(null).toJSON().should.deep.equal({
+      expect(termFromId(null).toJSON()).toEqual({
         termType: 'DefaultGraph',
         value: '',
       });
     });
 
     it('should create a DefaultGraph from the empty string', () => {
-      termFromId('').toJSON().should.deep.equal({
+      expect(termFromId('').toJSON()).toEqual({
         termType: 'DefaultGraph',
         value: '',
       });
     });
 
     it('should create a NamedNode from an IRI', () => {
-      termFromId('http://example.org/foo#bar').toJSON().should.deep.equal({
+      expect(termFromId('http://example.org/foo#bar').toJSON()).toEqual({
         termType: 'NamedNode',
         value: 'http://example.org/foo#bar',
       });
     });
 
-    it('should create a BlankNode from a string that starts with an underscore', () => {
-      termFromId('_:b1').toJSON().should.deep.equal({
-        termType: 'BlankNode',
-        value: 'b1',
-      });
-    });
+    it(
+      'should create a BlankNode from a string that starts with an underscore',
+      () => {
+        expect(termFromId('_:b1').toJSON()).toEqual({
+          termType: 'BlankNode',
+          value: 'b1',
+        });
+      }
+    );
 
-    it('should create a Variable from a string that starts with a question mark', () => {
-      termFromId('?v1').toJSON().should.deep.equal({
-        termType: 'Variable',
-        value: 'v1',
-      });
-    });
+    it(
+      'should create a Variable from a string that starts with a question mark',
+      () => {
+        expect(termFromId('?v1').toJSON()).toEqual({
+          termType: 'Variable',
+          value: 'v1',
+        });
+      }
+    );
 
-    it('should create a Literal from a string that starts with a quotation mark', () => {
-      termFromId('"abc"@en-us').toJSON().should.deep.equal({
-        termType: 'Literal',
-        value: 'abc',
-        language: 'en-us',
-        datatype: {
-          termType: 'NamedNode',
-          value: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#langString',
-        },
-      });
-    });
+    it(
+      'should create a Literal from a string that starts with a quotation mark',
+      () => {
+        expect(termFromId('"abc"@en-us').toJSON()).toEqual({
+          termType: 'Literal',
+          value: 'abc',
+          language: 'en-us',
+          datatype: {
+            termType: 'NamedNode',
+            value: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#langString',
+          },
+        });
+      }
+    );
 
-    it('should create a Quad with the default graph if the id doesnt specify the graph', () => {
-      termFromId('<<http://ex.org/a http://ex.org/b "abc"@en-us>>').should.deep.equal(new Quad(
-        new NamedNode('http://ex.org/a'),
-        new NamedNode('http://ex.org/b'),
-        new Literal('"abc"@en-us'),
-        new DefaultGraph()
-      ));
-    });
+    it(
+      'should create a Quad with the default graph if the id doesnt specify the graph',
+      () => {
+        expect(termFromId('<<http://ex.org/a http://ex.org/b "abc"@en-us>>')).toEqual(new Quad(
+          new NamedNode('http://ex.org/a'),
+          new NamedNode('http://ex.org/b'),
+          new Literal('"abc"@en-us'),
+          new DefaultGraph()
+        ));
+      }
+    );
 
-    it('should create a Quad with the correct graph if the id specifies a graph', () => {
-      const id = '<<http://ex.org/a http://ex.org/b "abc"@en-us http://ex.org/d>>';
-      termFromId(id).should.deep.equal(new Quad(
-        new NamedNode('http://ex.org/a'),
-        new NamedNode('http://ex.org/b'),
-        new Literal('"abc"@en-us'),
-        new NamedNode('http://ex.org/d')
-      ));
-    });
+    it(
+      'should create a Quad with the correct graph if the id specifies a graph',
+      () => {
+        const id = '<<http://ex.org/a http://ex.org/b "abc"@en-us http://ex.org/d>>';
+        expect(termFromId(id)).toEqual(new Quad(
+          new NamedNode('http://ex.org/a'),
+          new NamedNode('http://ex.org/b'),
+          new Literal('"abc"@en-us'),
+          new NamedNode('http://ex.org/d')
+        ));
+      }
+    );
 
     it('should create a Quad correctly', () => {
       const id = '<<http://ex.org/a http://ex.org/b http://ex.org/c>>';
-      termFromId(id).should.deep.equal(new Quad(
+      expect(termFromId(id)).toEqual(new Quad(
         new NamedNode('http://ex.org/a'),
         new NamedNode('http://ex.org/b'),
         new NamedNode('http://ex.org/c'),
@@ -111,7 +126,7 @@ describe('Term', () => {
 
     it('should create a Quad correctly', () => {
       const id = '<<_:n3-123 ?var-a ?var-b _:n3-000>>';
-      termFromId(id).should.deep.equal(new Quad(
+      expect(termFromId(id)).toEqual(new Quad(
         new BlankNode('n3-123'),
         new Variable('var-a'),
         new Variable('var-b'),
@@ -121,7 +136,7 @@ describe('Term', () => {
 
     it('should create a Quad correctly', () => {
       const id = '<<?var-a ?var-b "abc"@en-us ?var-d>>';
-      termFromId(id).should.deep.equal(new Quad(
+      expect(termFromId(id)).toEqual(new Quad(
         new Variable('var-a'),
         new Variable('var-b'),
         new Literal('"abc"@en-us'),
@@ -131,7 +146,7 @@ describe('Term', () => {
 
     it('should create a Quad correctly', () => {
       const id = '<<_:n3-000 ?var-b _:n3-123 http://ex.org/d>>';
-      termFromId(id).should.deep.equal(new Quad(
+      expect(termFromId(id)).toEqual(new Quad(
         new BlankNode('n3-000'),
         new Variable('var-b'),
         new BlankNode('n3-123'),
@@ -139,25 +154,31 @@ describe('Term', () => {
       ));
     });
 
-    it('should create a Quad correctly from literal containing escaped quotes', () => {
-      const id = '<<_:n3-000 ?var-b "Hello ""W""orl""d!"@en-us http://ex.org/d>>';
-      termFromId(id).should.deep.equal(new Quad(
-        new BlankNode('n3-000'),
-        new Variable('var-b'),
-        new Literal('"Hello "W"orl"d!"@en-us'),
-        new NamedNode('http://ex.org/d')
-      ));
-    });
+    it(
+      'should create a Quad correctly from literal containing escaped quotes',
+      () => {
+        const id = '<<_:n3-000 ?var-b "Hello ""W""orl""d!"@en-us http://ex.org/d>>';
+        expect(termFromId(id)).toEqual(new Quad(
+          new BlankNode('n3-000'),
+          new Variable('var-b'),
+          new Literal('"Hello "W"orl"d!"@en-us'),
+          new NamedNode('http://ex.org/d')
+        ));
+      }
+    );
 
-    it('should create a Quad correctly from literal containing escaped quotes', () => {
-      const id = '<<"Hello ""W""orl""d!"@en-us http://ex.org/b http://ex.org/c>>';
-      termFromId(id).should.deep.equal(new Quad(
-        new Literal('"Hello "W"orl"d!"@en-us'),
-        new NamedNode('http://ex.org/b'),
-        new NamedNode('http://ex.org/c'),
-        new DefaultGraph()
-      ));
-    });
+    it(
+      'should create a Quad correctly from literal containing escaped quotes',
+      () => {
+        const id = '<<"Hello ""W""orl""d!"@en-us http://ex.org/b http://ex.org/c>>';
+        expect(termFromId(id)).toEqual(new Quad(
+          new Literal('"Hello "W"orl"d!"@en-us'),
+          new NamedNode('http://ex.org/b'),
+          new NamedNode('http://ex.org/c'),
+          new DefaultGraph()
+        ));
+      }
+    );
 
     describe('with a custom factory', () => {
       const factory = {
@@ -169,229 +190,296 @@ describe('Term', () => {
       };
 
       it('should create a DefaultGraph from a falsy value', () => {
-        termFromId(null, factory).should.deep.equal(['d']);
+        expect(termFromId(null, factory)).toEqual(['d']);
       });
 
       it('should create a DefaultGraph from the empty string', () => {
-        termFromId('', factory).should.deep.equal(['d']);
+        expect(termFromId('', factory)).toEqual(['d']);
       });
 
       it('should create a NamedNode from an IRI', () => {
-        termFromId('http://example.org/foo#bar', factory).should.deep.equal(['n', 'http://example.org/foo#bar']);
+        expect(termFromId('http://example.org/foo#bar', factory)).toEqual(['n', 'http://example.org/foo#bar']);
       });
 
-      it('should create a BlankNode from a string that starts with an underscore', () => {
-        termFromId('_:b1', factory).should.deep.equal(['b', 'b1']);
-      });
+      it(
+        'should create a BlankNode from a string that starts with an underscore',
+        () => {
+          expect(termFromId('_:b1', factory)).toEqual(['b', 'b1']);
+        }
+      );
 
-      it('should create a Variable from a string that starts with a question mark', () => {
-        termFromId('?v1', factory).should.deep.equal(['v', 'v1']);
-      });
+      it(
+        'should create a Variable from a string that starts with a question mark',
+        () => {
+          expect(termFromId('?v1', factory)).toEqual(['v', 'v1']);
+        }
+      );
 
       it('should create a Literal without language or datatype', () => {
-        termFromId('"abc"', factory).should.deep.equal(['l', 'abc', undefined]);
+        expect(termFromId('"abc"', factory)).toEqual(['l', 'abc', undefined]);
       });
 
       it('should create a Literal with a language', () => {
-        termFromId('"abc"@en-us', factory).should.deep.equal(['l', 'abc', 'en-us']);
+        expect(termFromId('"abc"@en-us', factory)).toEqual(['l', 'abc', 'en-us']);
       });
 
       it('should create a Literal with a datatype', () => {
-        termFromId('"abc"^^https://ex.org/type', factory).should.deep.equal(['l', 'abc', ['n', 'https://ex.org/type']]);
+        expect(termFromId('"abc"^^https://ex.org/type', factory)).toEqual(['l', 'abc', ['n', 'https://ex.org/type']]);
       });
     });
   });
 
   describe('termToId', () => {
     it('should create the empty string a falsy value', () => {
-      termToId(null).should.equal('');
-      termToId(false).should.equal('');
-      termToId('').should.equal('');
+      expect(termToId(null)).toBe('');
+      expect(termToId(false)).toBe('');
+      expect(termToId('')).toBe('');
     });
 
     it('should create the empty string from the DefaultGraph', () => {
-      termToId(new DefaultGraph()).should.equal('');
-      termToId(new DefaultGraph().toJSON()).should.equal('');
+      expect(termToId(new DefaultGraph())).toBe('');
+      expect(termToId(new DefaultGraph().toJSON())).toBe('');
     });
 
-    it('should create an id that starts with a question mark from a Variable', () => {
-      termToId(new Variable('abc')).should.equal('?abc');
-      termToId(new Variable('abc').toJSON()).should.equal('?abc');
-    });
+    it(
+      'should create an id that starts with a question mark from a Variable',
+      () => {
+        expect(termToId(new Variable('abc'))).toBe('?abc');
+        expect(termToId(new Variable('abc').toJSON())).toBe('?abc');
+      }
+    );
 
-    it('should create an id that starts with a question mark from a Variable string', () => {
-      termToId('?abc').should.equal('?abc');
-    });
+    it(
+      'should create an id that starts with a question mark from a Variable string',
+      () => {
+        expect(termToId('?abc')).toBe('?abc');
+      }
+    );
 
-    it('should create an id that starts with a quotation mark from a Literal', () => {
-      termToId(new Literal('"abc"')).should.equal('"abc"');
-      termToId(new Literal('"abc"').toJSON()).should.equal('"abc"');
-    });
+    it(
+      'should create an id that starts with a quotation mark from a Literal',
+      () => {
+        expect(termToId(new Literal('"abc"'))).toBe('"abc"');
+        expect(termToId(new Literal('"abc"').toJSON())).toBe('"abc"');
+      }
+    );
 
-    it('should create an id that starts with a quotation mark from a Literal string', () => {
-      termToId('"abc"').should.equal('"abc"');
-    });
+    it(
+      'should create an id that starts with a quotation mark from a Literal string',
+      () => {
+        expect(termToId('"abc"')).toBe('"abc"');
+      }
+    );
 
-    it('should create an id that starts with a quotation mark and datatype from a Literal with a datatype', () => {
-      termToId(new Literal('"abc"^^http://example.org')).should.equal('"abc"^^http://example.org');
-      termToId(new Literal('"abc"^^http://example.org').toJSON()).should.equal('"abc"^^http://example.org');
-    });
+    it(
+      'should create an id that starts with a quotation mark and datatype from a Literal with a datatype',
+      () => {
+        expect(termToId(new Literal('"abc"^^http://example.org'))).toBe('"abc"^^http://example.org');
+        expect(termToId(new Literal('"abc"^^http://example.org').toJSON())).toBe('"abc"^^http://example.org');
+      }
+    );
 
-    it('should create an id that starts with a quotation mark and datatype from a Literal string with a datatype', () => {
-      termToId('"abc"^^http://example.org').should.equal('"abc"^^http://example.org');
-    });
+    it(
+      'should create an id that starts with a quotation mark and datatype from a Literal string with a datatype',
+      () => {
+        expect(termToId('"abc"^^http://example.org')).toBe('"abc"^^http://example.org');
+      }
+    );
 
-    it('should create an id that starts with a quotation mark and language tag from a Literal with a language', () => {
-      termToId(new Literal('"abc"@en-us')).should.equal('"abc"@en-us');
-      termToId(new Literal('"abc"@en-us').toJSON()).should.equal('"abc"@en-us');
-    });
+    it(
+      'should create an id that starts with a quotation mark and language tag from a Literal with a language',
+      () => {
+        expect(termToId(new Literal('"abc"@en-us'))).toBe('"abc"@en-us');
+        expect(termToId(new Literal('"abc"@en-us').toJSON())).toBe('"abc"@en-us');
+      }
+    );
 
-    it('should create an id that starts with a quotation mark and language tag from a Literal string with a language', () => {
-      termToId('"abc"@en-us').should.equal('"abc"@en-us');
-    });
+    it(
+      'should create an id that starts with a quotation mark and language tag from a Literal string with a language',
+      () => {
+        expect(termToId('"abc"@en-us')).toBe('"abc"@en-us');
+      }
+    );
 
-    it('should create an id that starts with a quotation mark, datatype and language tag from a Literal with a datatype and language', () => {
-      termToId(new Literal('"abc"^^http://example.org@en-us')).should.equal('"abc"^^http://example.org@en-us');
-      termToId(new Literal('"abc"^^http://example.org@en-us').toJSON()).should.equal('"abc"^^http://example.org@en-us');
-    });
+    it(
+      'should create an id that starts with a quotation mark, datatype and language tag from a Literal with a datatype and language',
+      () => {
+        expect(termToId(new Literal('"abc"^^http://example.org@en-us'))).toBe('"abc"^^http://example.org@en-us');
+        expect(termToId(new Literal('"abc"^^http://example.org@en-us').toJSON())).toBe('"abc"^^http://example.org@en-us');
+      }
+    );
 
-    it('should create an id that starts with a quotation mark, datatype and language tag from a Literal string with a datatype and language', () => {
-      termToId('"abc"^^http://example.org@en-us').should.equal('"abc"^^http://example.org@en-us');
-    });
+    it(
+      'should create an id that starts with a quotation mark, datatype and language tag from a Literal string with a datatype and language',
+      () => {
+        expect(termToId('"abc"^^http://example.org@en-us')).toBe('"abc"^^http://example.org@en-us');
+      }
+    );
 
-    it('should create an id that starts with an underscore from a BlankNode', () => {
-      termToId(new BlankNode('abc')).should.equal('_:abc');
-      termToId(new BlankNode('abc').toJSON()).should.equal('_:abc');
-    });
+    it(
+      'should create an id that starts with an underscore from a BlankNode',
+      () => {
+        expect(termToId(new BlankNode('abc'))).toBe('_:abc');
+        expect(termToId(new BlankNode('abc').toJSON())).toBe('_:abc');
+      }
+    );
 
-    it('should create an id that starts with an underscore from a BlankNode string', () => {
-      termToId('_:abc').should.equal('_:abc');
-    });
+    it(
+      'should create an id that starts with an underscore from a BlankNode string',
+      () => {
+        expect(termToId('_:abc')).toBe('_:abc');
+      }
+    );
 
     it('should create an IRI from a NamedNode', () => {
-      termToId(new NamedNode('http://example.org/')).should.equal('http://example.org/');
-      termToId(new NamedNode('http://example.org/').toJSON()).should.equal('http://example.org/');
+      expect(termToId(new NamedNode('http://example.org/'))).toBe('http://example.org/');
+      expect(termToId(new NamedNode('http://example.org/').toJSON())).toBe('http://example.org/');
     });
 
     it('should create an IRI from a NamedNode string', () => {
-      termToId('http://example.org/').should.equal('http://example.org/');
+      expect(termToId('http://example.org/')).toBe('http://example.org/');
     });
 
     it('should create an id without graph if default graph is used', () => {
-      termToId(new Quad(
+      expect(termToId(new Quad(
         new NamedNode('http://ex.org/a'),
         new NamedNode('http://ex.org/b'),
         new Literal('"abc"@en-us'),
         new DefaultGraph()
-      )).should.equal('<<http://ex.org/a http://ex.org/b "abc"@en-us>>');
+      ))).toBe('<<http://ex.org/a http://ex.org/b "abc"@en-us>>');
     });
 
     it('should create an id from a Quad', () => {
-      termToId(new Quad(
+      expect(termToId(new Quad(
         new NamedNode('http://ex.org/a'),
         new NamedNode('http://ex.org/b'),
         new Literal('"abc"@en-us'),
         new NamedNode('http://ex.org/d')
-      )).should.equal('<<http://ex.org/a http://ex.org/b "abc"@en-us http://ex.org/d>>');
+      ))).toBe('<<http://ex.org/a http://ex.org/b "abc"@en-us http://ex.org/d>>');
     });
 
     it('should create an id from a manually created Quad', () => {
-      termToId({
+      expect(termToId({
         subject: new NamedNode('http://ex.org/a'),
         predicate: new NamedNode('http://ex.org/b'),
         object: new Literal('"abc"@en-us'),
         graph: new NamedNode('http://ex.org/d'),
         termType: 'Quad',
         value: '',
-      }).should.equal('<<http://ex.org/a http://ex.org/b "abc"@en-us http://ex.org/d>>');
+      })).toBe('<<http://ex.org/a http://ex.org/b "abc"@en-us http://ex.org/d>>');
     });
 
     it('should create an id with escaped literals from a Quad', () => {
-      termToId(new Quad(
+      expect(termToId(new Quad(
         new BlankNode('n3-000'),
         new Variable('var-b'),
         new Literal('"Hello "W"orl"d!"@en-us'),
         new NamedNode('http://ex.org/d')
-      )).should.equal('<<_:n3-000 ?var-b "Hello ""W""orl""d!"@en-us http://ex.org/d>>');
+      ))).toBe('<<_:n3-000 ?var-b "Hello ""W""orl""d!"@en-us http://ex.org/d>>');
     });
 
-    it('should create an id without graph from a Quad with default graph and Quad as subject', () => {
-      termToId(new Quad(
-        new Quad(
-          new BlankNode('n3-000'),
-          new Variable('var-b'),
+    it(
+      'should create an id without graph from a Quad with default graph and Quad as subject',
+      () => {
+        expect(termToId(new Quad(
+          new Quad(
+            new BlankNode('n3-000'),
+            new Variable('var-b'),
+            new Literal('"abc"@en-us'),
+            new NamedNode('http://ex.org/d')
+          ),
+          new NamedNode('http://ex.org/b'),
           new Literal('"abc"@en-us'),
-          new NamedNode('http://ex.org/d')
-        ),
-        new NamedNode('http://ex.org/b'),
-        new Literal('"abc"@en-us'),
-        new DefaultGraph()
-      )).should.equal('<<<<_:n3-000 ?var-b "abc"@en-us http://ex.org/d>> http://ex.org/b "abc"@en-us>>');
-    });
+          new DefaultGraph()
+        ))).toBe(
+          '<<<<_:n3-000 ?var-b "abc"@en-us http://ex.org/d>> http://ex.org/b "abc"@en-us>>'
+        );
+      }
+    );
 
-    it('should create an id without graph from a Quad with default graph and Quad as object', () => {
-      termToId(new Quad(
-        new Literal('"abc"@en-us'),
-        new NamedNode('http://ex.org/b'),
-        new Quad(
-          new BlankNode('n3-000'),
-          new Variable('var-b'),
+    it(
+      'should create an id without graph from a Quad with default graph and Quad as object',
+      () => {
+        expect(termToId(new Quad(
           new Literal('"abc"@en-us'),
-          new NamedNode('http://ex.org/d')
-        ),
-        new DefaultGraph()
-      )).should.equal('<<"abc"@en-us http://ex.org/b <<_:n3-000 ?var-b "abc"@en-us http://ex.org/d>>>>');
-    });
+          new NamedNode('http://ex.org/b'),
+          new Quad(
+            new BlankNode('n3-000'),
+            new Variable('var-b'),
+            new Literal('"abc"@en-us'),
+            new NamedNode('http://ex.org/d')
+          ),
+          new DefaultGraph()
+        ))).toBe(
+          '<<"abc"@en-us http://ex.org/b <<_:n3-000 ?var-b "abc"@en-us http://ex.org/d>>>>'
+        );
+      }
+    );
 
-    it('should create an id without graph from a Quad with default graph and Quad as subject and object', () => {
-      termToId(new Quad(
-        new Quad(
-          new BlankNode('n3-000'),
-          new Variable('var-b'),
-          new Literal('"abc"@en-us'),
-          new NamedNode('http://ex.org/d')
-        ),
-        new NamedNode('http://ex.org/b'),
-        new Quad(
-          new BlankNode('n3-000'),
-          new Variable('var-b'),
-          new Literal('"abc"@en-us'),
-          new NamedNode('http://ex.org/d')
-        ),
-        new DefaultGraph()
-      )).should.equal('<<<<_:n3-000 ?var-b "abc"@en-us http://ex.org/d>> http://ex.org/b <<_:n3-000 ?var-b "abc"@en-us http://ex.org/d>>>>');
-    });
+    it(
+      'should create an id without graph from a Quad with default graph and Quad as subject and object',
+      () => {
+        expect(termToId(new Quad(
+          new Quad(
+            new BlankNode('n3-000'),
+            new Variable('var-b'),
+            new Literal('"abc"@en-us'),
+            new NamedNode('http://ex.org/d')
+          ),
+          new NamedNode('http://ex.org/b'),
+          new Quad(
+            new BlankNode('n3-000'),
+            new Variable('var-b'),
+            new Literal('"abc"@en-us'),
+            new NamedNode('http://ex.org/d')
+          ),
+          new DefaultGraph()
+        ))).toBe(
+          '<<<<_:n3-000 ?var-b "abc"@en-us http://ex.org/d>> http://ex.org/b <<_:n3-000 ?var-b "abc"@en-us http://ex.org/d>>>>'
+        );
+      }
+    );
 
-    it('should create an id without graph from a Quad with Quad as subject', () => {
-      termToId(new Quad(
-        new Quad(
-          new BlankNode('n3-000'),
-          new Variable('var-b'),
+    it(
+      'should create an id without graph from a Quad with Quad as subject',
+      () => {
+        expect(termToId(new Quad(
+          new Quad(
+            new BlankNode('n3-000'),
+            new Variable('var-b'),
+            new Literal('"abc"@en-us'),
+            new NamedNode('http://ex.org/d')
+          ),
+          new NamedNode('http://ex.org/b'),
           new Literal('"abc"@en-us'),
           new NamedNode('http://ex.org/d')
-        ),
-        new NamedNode('http://ex.org/b'),
-        new Literal('"abc"@en-us'),
-        new NamedNode('http://ex.org/d')
-      )).should.equal('<<<<_:n3-000 ?var-b "abc"@en-us http://ex.org/d>> http://ex.org/b "abc"@en-us http://ex.org/d>>');
-    });
+        ))).toBe(
+          '<<<<_:n3-000 ?var-b "abc"@en-us http://ex.org/d>> http://ex.org/b "abc"@en-us http://ex.org/d>>'
+        );
+      }
+    );
 
-    it('should create an id without graph from a Quad with Quad as object', () => {
-      termToId(new Quad(
-        new Literal('"abc"@en-us'),
-        new NamedNode('http://ex.org/b'),
-        new Quad(
-          new BlankNode('n3-000'),
-          new Variable('var-b'),
+    it(
+      'should create an id without graph from a Quad with Quad as object',
+      () => {
+        expect(termToId(new Quad(
           new Literal('"abc"@en-us'),
+          new NamedNode('http://ex.org/b'),
+          new Quad(
+            new BlankNode('n3-000'),
+            new Variable('var-b'),
+            new Literal('"abc"@en-us'),
+            new NamedNode('http://ex.org/d')
+          ),
           new NamedNode('http://ex.org/d')
-        ),
-        new NamedNode('http://ex.org/d')
-      )).should.equal('<<"abc"@en-us http://ex.org/b <<_:n3-000 ?var-b "abc"@en-us http://ex.org/d>> http://ex.org/d>>');
-    });
+        ))).toBe(
+          '<<"abc"@en-us http://ex.org/b <<_:n3-000 ?var-b "abc"@en-us http://ex.org/d>> http://ex.org/d>>'
+        );
+      }
+    );
 
     it('should create an id from a Quad with Quad as subject and object', () => {
-      termToId(new Quad(
+      expect(termToId(new Quad(
         new Quad(
           new BlankNode('n3-000'),
           new Variable('var-b'),
@@ -406,11 +494,13 @@ describe('Term', () => {
           new NamedNode('http://ex.org/d')
         ),
         new NamedNode('http://ex.org/d')
-      )).should.equal('<<<<_:n3-000 ?var-b "abc"@en-us http://ex.org/d>> http://ex.org/b <<_:n3-000 ?var-b "abc"@en-us http://ex.org/d>> http://ex.org/d>>');
+      ))).toBe(
+        '<<<<_:n3-000 ?var-b "abc"@en-us http://ex.org/d>> http://ex.org/b <<_:n3-000 ?var-b "abc"@en-us http://ex.org/d>> http://ex.org/d>>'
+      );
     });
 
     it('should escape literals in nested Quads', () => {
-      termToId(new Quad(
+      expect(termToId(new Quad(
         new Quad(
           new BlankNode('n3-000'),
           new Variable('var-b'),
@@ -425,11 +515,13 @@ describe('Term', () => {
           new NamedNode('http://ex.org/d')
         ),
         new DefaultGraph()
-      )).should.equal('<<<<_:n3-000 ?var-b "Hello ""W""orl""d!"@en-us http://ex.org/d>> http://ex.org/b <<_:n3-000 ?var-b "Hello ""W""orl""d!"@en-us http://ex.org/d>>>>');
+      ))).toBe(
+        '<<<<_:n3-000 ?var-b "Hello ""W""orl""d!"@en-us http://ex.org/d>> http://ex.org/b <<_:n3-000 ?var-b "Hello ""W""orl""d!"@en-us http://ex.org/d>>>>'
+      );
     });
 
     it('should correctly handle deeply nested quads', () => {
-      termToId(new Quad(
+      expect(termToId(new Quad(
         new Quad(
           new Quad(
             new Quad(
@@ -474,49 +566,50 @@ describe('Term', () => {
           new NamedNode('http://ex.org/d')
         ),
         new NamedNode('http://ex.org/d')
-      )).should.equal('<<<<<<<<_:n3-000 ?var-b "abc"@en-us http://ex.org/d>> ?var-b <<_:n3-000 ?var-b "abc"@en-us http://ex.org/d>> http://ex.org/d>> ?var-b <<_:n3-000 ?var-b "abc"@en-us http://ex.org/d>> http://ex.org/d>> http://ex.org/b <<<<_:n3-000 ?var-b "abc"@en-us http://ex.org/d>> ?var-b <<_:n3-000 ?var-b "abc"@en-us http://ex.org/d>> http://ex.org/d>> http://ex.org/d>>');
+      ))).toBe(
+        '<<<<<<<<_:n3-000 ?var-b "abc"@en-us http://ex.org/d>> ?var-b <<_:n3-000 ?var-b "abc"@en-us http://ex.org/d>> http://ex.org/d>> ?var-b <<_:n3-000 ?var-b "abc"@en-us http://ex.org/d>> http://ex.org/d>> http://ex.org/b <<<<_:n3-000 ?var-b "abc"@en-us http://ex.org/d>> ?var-b <<_:n3-000 ?var-b "abc"@en-us http://ex.org/d>> http://ex.org/d>> http://ex.org/d>>'
+      );
     });
 
     it('should throw on an unknown type', () => {
-      (function () { termToId({ termType: 'unknown' }); })
-        .should.throw('Unexpected termType: unknown');
+      expect((() => { termToId({ termType: 'unknown' }); })).toThrow('Unexpected termType: unknown');
     });
   });
 
   describe('escaping', () => {
     it('should unescape an escaped string correctly', () => {
       const id = '"Hello ""World"""@en-us';
-      unescapeQuotes(id).should.equal('"Hello "World""@en-us');
+      expect(unescapeQuotes(id)).toBe('"Hello "World""@en-us');
     });
 
     it('should escape an unescaped string correctly', () => {
       const id = '"Hello "World""@en-us';
-      escapeQuotes(id).should.equal('"Hello ""World"""@en-us');
+      expect(escapeQuotes(id)).toBe('"Hello ""World"""@en-us');
     });
 
     it('should not change an unescaped string', () => {
       const id = '"Hello "World""@en-us';
-      unescapeQuotes(id).should.equal(id);
+      expect(unescapeQuotes(id)).toBe(id);
     });
 
     it('should not change a string without quotes', () => {
       const id = '"Hello World"@en-us';
-      escapeQuotes(id).should.equal(id);
+      expect(escapeQuotes(id)).toBe(id);
     });
 
     it('should not change a blank node', () => {
       const id = '_:b1';
-      escapeQuotes(id).should.equal(id);
+      expect(escapeQuotes(id)).toBe(id);
     });
 
     it('should not change a variable', () => {
       const id = '?v1';
-      escapeQuotes(id).should.equal(id);
+      expect(escapeQuotes(id)).toBe(id);
     });
 
     it('should not change the empty string', () => {
       const id = '';
-      escapeQuotes(id).should.equal(id);
+      expect(escapeQuotes(id)).toBe(id);
     });
   });
 });

--- a/test/Variable-test.js
+++ b/test/Variable-test.js
@@ -3,77 +3,83 @@ import { Variable, Term } from '../src/';
 describe('Variable', () => {
   describe('The Variable module', () => {
     it('should be a function', () => {
-      Variable.should.be.a('function');
+      expect(Variable).toBeInstanceOf(Function);
     });
 
     it('should be a Variable constructor', () => {
-      new Variable().should.be.an.instanceof(Variable);
+      expect(new Variable()).toBeInstanceOf(Variable);
     });
 
     it('should be a Term constructor', () => {
-      new Variable().should.be.an.instanceof(Term);
+      expect(new Variable()).toBeInstanceOf(Term);
     });
   });
 
   describe('A Variable instance created from a name', () => {
     let variable;
-    before(() => { variable = new Variable('v1'); });
+    beforeAll(() => { variable = new Variable('v1'); });
 
     it('should be a Variable', () => {
-      variable.should.be.an.instanceof(Variable);
+      expect(variable).toBeInstanceOf(Variable);
     });
 
     it('should be a Term', () => {
-      variable.should.be.an.instanceof(Term);
+      expect(variable).toBeInstanceOf(Term);
     });
 
     it('should have term type "Variable"', () => {
-      variable.termType.should.equal('Variable');
+      expect(variable.termType).toBe('Variable');
     });
 
     it('should have the name as value', () => {
-      variable.should.have.property('value', 'v1');
+      expect(variable).toHaveProperty('value', 'v1');
     });
 
     it('should have "?name" as id value', () => {
-      variable.should.have.property('id', '?v1');
+      expect(variable).toHaveProperty('id', '?v1');
     });
 
     it('should equal a Variable instance with the same name', () => {
-      variable.equals(new Variable('v1')).should.be.true;
+      expect(variable.equals(new Variable('v1'))).toBe(true);
     });
 
     it('should equal an object with the same term type and value', () => {
-      variable.equals({
+      expect(variable.equals({
         termType: 'Variable',
         value: 'v1',
-      }).should.be.true;
+      })).toBe(true);
     });
 
     it('should not equal a falsy object', () => {
-      variable.equals(null).should.be.false;
+      expect(variable.equals(null)).toBe(false);
     });
 
     it('should not equal a Variable instance with another name', () => {
-      variable.equals(new Variable('v2')).should.be.false;
+      expect(variable.equals(new Variable('v2'))).toBe(false);
     });
 
-    it('should not equal an object with the same term type but a different value', () => {
-      variable.equals({
-        termType: 'Variable',
-        value: 'v2',
-      }).should.be.false;
-    });
+    it(
+      'should not equal an object with the same term type but a different value',
+      () => {
+        expect(variable.equals({
+          termType: 'Variable',
+          value: 'v2',
+        })).toBe(false);
+      }
+    );
 
-    it('should not equal an object with a different term type but the same value', () => {
-      variable.equals({
-        termType: 'NamedNode',
-        value: 'v1',
-      }).should.be.false;
-    });
+    it(
+      'should not equal an object with a different term type but the same value',
+      () => {
+        expect(variable.equals({
+          termType: 'NamedNode',
+          value: 'v1',
+        })).toBe(false);
+      }
+    );
 
     it('should provide a JSON representation', () => {
-      variable.toJSON().should.deep.equal({
+      expect(variable.toJSON()).toEqual({
         termType: 'Variable',
         value: 'v1',
       });


### PR DESCRIPTION
Largely automated transformation using [jest-codemods](https://jestjs.io/docs/migration-guide) - originally did this to get better test diffs using jest-rdf to analyze https://github.com/rdfjs/N3.js/pull/364 but it turns out the spec tests are driven differently.