### PR TITLE
Add support for empty graphs in the subject and object positions

### DIFF
--- a/src/N3Parser.js
+++ b/src/N3Parser.js
@@ -663,8 +663,23 @@ export default class N3Parser {
     const graph = this._graph;
 
     // Store the last quad of the formula
-    if (this._subject !== null)
-      this._emit(this._subject, this._predicate, this._object, graph);
+
+    if (this._subject !== null) {
+      // Catch the empty graph being closed when parsing N3.
+      // In this case, we emit the empty graph as the value "true"^^xsd:boolean
+      if (!this._predicate && !this._object) {
+        const outerGraph = this._contextStack[this._contextStack.length - 1].graph;
+        this._emit(
+          graph,
+          this._namedNode('http://www.w3.org/1999/02/22-rdf-syntax-ns#value'),
+          this._literal('true', this._namedNode('http://www.w3.org/2001/XMLSchema#boolean')),
+          outerGraph
+        ); // Restore the parent context containing this formula
+      }
+      else {
+        this._emit(this._subject, this._predicate, this._object, graph);
+      }
+    }
 
     // Restore the parent context containing this formula
     this._restoreContext('formula', token);

--- a/test/N3Parser-test.js
+++ b/test/N3Parser-test.js
@@ -1763,7 +1763,7 @@ describe('Parser', () => {
       return isImpliedBy ? [to, 'http://www.w3.org/2000/10/swap/log#isImpliedBy', from] : [from, 'http://www.w3.org/2000/10/swap/log#implies', to];
     }
 
-    describe(`A Parser instance for the N3 format with rdfStar support disabled and with ${isImpliedBy ? 'enabled' : 'disabled'}`, () => {
+    describe(`A Parser instance for the N3 format with rdfStar support disabled and with isImpliedBy ${isImpliedBy ? 'enabled' : 'disabled'}`, () => {
       function parser() { return new Parser({ baseIRI: BASE_IRI, format: 'N3', rdfStar: false, isImpliedBy }); }
 
       describe('should parse a single triple',
@@ -2337,6 +2337,45 @@ describe('Parser', () => {
       it('should not parse RDF-star in the object position',
       shouldNotParse(parser, '<a> <b> <<<a> <b> <c>>>.',
         'Unexpected RDF-star syntax on line 1.'));
+
+      describe('should parse the empty graph as an rdf:value of "true"^^xsd:boolean in the object position',
+        shouldParse(parser, '<a> <b> {}.',
+            ['a', 'b', '_:b0'],
+            ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#value', '"true"^^http://www.w3.org/2001/XMLSchema#boolean']
+        ));
+
+      // describe('should parse the empty graph as an rdf:value of "true"^^xsd:boolean in the predicate position',
+      // shouldParse(parser, '<a> {} <c>.',
+      //     ['a', '_:b0', 'c'],
+      //     ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#value', '"true"^^http://www.w3.org/2001/XMLSchema#boolean']
+      // ));
+
+      describe('should parse the empty graph as an rdf:value of "true"^^xsd:boolean in the subject position',
+        shouldParse(parser, '{} <b> <c>.',
+            ['_:b0', 'b', 'c'],
+            ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#value', '"true"^^http://www.w3.org/2001/XMLSchema#boolean']
+        ));
+
+      describe('should parse the empty graph in the object position as an rdf:value of "true"^^xsd:boolean while retaining the encompassing graph',
+        shouldParse(parser, '<a> <b> { <x> <y> {} }.',
+          ['a', 'b', '_:b0'],
+          ['x', 'y', '_:b1', '_:b0'],
+          ['_:b1', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#value', '"true"^^http://www.w3.org/2001/XMLSchema#boolean', '_:b0']
+      ));
+
+      // describe('should parse the empty graph in the predicate position as an rdf:value of "true"^^xsd:boolean while retaining the encompassing graph',
+      //   shouldParse(parser, '<a> <b> { <x> {} <z> }.',
+      //     ['a', 'b', '_:b0'],
+      //     ['x', '_:b1', 'z', '_:b0'],
+      //     ['_:b1', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#value', '"true"^^http://www.w3.org/2001/XMLSchema#boolean', '_:b0']
+      // ));
+
+      describe('should parse the empty graph in the subject position as an rdf:value of "true"^^xsd:boolean while retaining the encompassing graph',
+        shouldParse(parser, '<a> <b> { {} <y> <z> }.',
+          ['a', 'b', '_:b0'],
+          ['_:b1', 'y', 'z', '_:b0'],
+          ['_:b1', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#value', '"true"^^http://www.w3.org/2001/XMLSchema#boolean', '_:b0']
+      ));
     });
   }
 

--- a/test/N3Parser-test.js
+++ b/test/N3Parser-test.js
@@ -2340,41 +2340,24 @@ describe('Parser', () => {
 
       describe('should parse the empty graph as an rdf:value of "true"^^xsd:boolean in the object position',
         shouldParse(parser, '<a> <b> {}.',
-            ['a', 'b', '_:b0'],
-            ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#value', '"true"^^http://www.w3.org/2001/XMLSchema#boolean']
+            ['a', 'b', '"true"^^http://www.w3.org/2001/XMLSchema#boolean']
         ));
-
-      // describe('should parse the empty graph as an rdf:value of "true"^^xsd:boolean in the predicate position',
-      // shouldParse(parser, '<a> {} <c>.',
-      //     ['a', '_:b0', 'c'],
-      //     ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#value', '"true"^^http://www.w3.org/2001/XMLSchema#boolean']
-      // ));
 
       describe('should parse the empty graph as an rdf:value of "true"^^xsd:boolean in the subject position',
         shouldParse(parser, '{} <b> <c>.',
-            ['_:b0', 'b', 'c'],
-            ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#value', '"true"^^http://www.w3.org/2001/XMLSchema#boolean']
+            ['"true"^^http://www.w3.org/2001/XMLSchema#boolean', 'b', 'c']
         ));
 
       describe('should parse the empty graph in the object position as an rdf:value of "true"^^xsd:boolean while retaining the encompassing graph',
         shouldParse(parser, '<a> <b> { <x> <y> {} }.',
           ['a', 'b', '_:b0'],
-          ['x', 'y', '_:b1', '_:b0'],
-          ['_:b1', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#value', '"true"^^http://www.w3.org/2001/XMLSchema#boolean', '_:b0']
+          ['x', 'y', '"true"^^http://www.w3.org/2001/XMLSchema#boolean', '_:b0']
       ));
-
-      // describe('should parse the empty graph in the predicate position as an rdf:value of "true"^^xsd:boolean while retaining the encompassing graph',
-      //   shouldParse(parser, '<a> <b> { <x> {} <z> }.',
-      //     ['a', 'b', '_:b0'],
-      //     ['x', '_:b1', 'z', '_:b0'],
-      //     ['_:b1', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#value', '"true"^^http://www.w3.org/2001/XMLSchema#boolean', '_:b0']
-      // ));
 
       describe('should parse the empty graph in the subject position as an rdf:value of "true"^^xsd:boolean while retaining the encompassing graph',
         shouldParse(parser, '<a> <b> { {} <y> <z> }.',
           ['a', 'b', '_:b0'],
-          ['_:b1', 'y', 'z', '_:b0'],
-          ['_:b1', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#value', '"true"^^http://www.w3.org/2001/XMLSchema#boolean', '_:b0']
+          ['"true"^^http://www.w3.org/2001/XMLSchema#boolean', 'y', 'z', '_:b0']
       ));
     });
   }


### PR DESCRIPTION
This PR contains a fix for parsing empty graphs in subject and object positions when parsing empty graphs.

I added some test cases that check for empty graphs in the subject and object position, both in the default graph, and contained in a subgraph.

Note that this does NOT work for empty graphs in the predicate position.
I have added tests for these as well, but they are commented out at the moment.