### PR TITLE
Fix #377: Implemented support for adding the tokens to parsed nodes.

### DIFF
--- a/src/N3DataFactory.js
+++ b/src/N3DataFactory.js
@@ -5,6 +5,8 @@ import namespaces from './IRIs';
 
 const { rdf, xsd } = namespaces;
 
+const DEFAULT_CONTEXT = { token: null };
+
 // eslint-disable-next-line prefer-const
 let DEFAULTGRAPH;
 let _blankNodeCounter = 0;
@@ -26,8 +28,9 @@ export default DataFactory;
 
 // ## Term constructor
 export class Term {
-  constructor(id) {
+  constructor(id, context = DEFAULT_CONTEXT) {
     this.id = id;
+    this.context = context;
   }
 
   // ### The value of this term
@@ -64,12 +67,6 @@ export class Term {
 
 // ## NamedNode constructor
 export class NamedNode extends Term {
-  constructor(id, token) {
-    super(id);
-
-    this.token = token;
-  }
-
   // ### The term type of this term
   get termType() {
     return 'NamedNode';
@@ -78,12 +75,6 @@ export class NamedNode extends Term {
 
 // ## Literal constructor
 export class Literal extends Term {
-  constructor(id, token) {
-    super(id);
-
-    this.token = token;
-  }
-
   // ### The term type of this term
   get termType() {
     return 'Literal';
@@ -105,7 +96,7 @@ export class Literal extends Term {
 
   // ### The datatype IRI of this literal
   get datatype() {
-    return new NamedNode(this.datatypeString, this.token);
+    return new NamedNode(this.datatypeString);
   }
 
   // ### The datatype string of this literal
@@ -145,10 +136,8 @@ export class Literal extends Term {
 
 // ## BlankNode constructor
 export class BlankNode extends Term {
-  constructor(name, token) {
-    super(`_:${name}`);
-
-    this.token = token;
+  constructor(name, context = DEFAULT_CONTEXT) {
+    super(`_:${name}`, context);
   }
 
   // ### The term type of this term
@@ -163,10 +152,8 @@ export class BlankNode extends Term {
 }
 
 export class Variable extends Term {
-  constructor(name, token) {
-    super(`?${name}`);
-
-    this.token = token;
+  constructor(name, context = DEFAULT_CONTEXT) {
+    super(`?${name}`, context);
   }
 
   // ### The term type of this term
@@ -183,7 +170,7 @@ export class Variable extends Term {
 // ## DefaultGraph constructor
 export class DefaultGraph extends Term {
   constructor() {
-    super('');
+    super('', DEFAULT_CONTEXT);
 
     return DEFAULTGRAPH || this;
   }
@@ -291,7 +278,7 @@ export function termToId(term, nested) {
 // ## Quad constructor
 export class Quad extends Term {
   constructor(subject, predicate, object, graph) {
-    super(undefined);
+    super('', DEFAULT_CONTEXT);
 
     this._subject   = subject;
     this._predicate = predicate;
@@ -352,20 +339,20 @@ export function unescapeQuotes(id) {
 }
 
 // ### Creates an IRI
-export function namedNode(iri, token) {
-  return new NamedNode(iri, token);
+export function namedNode(iri, context = DEFAULT_CONTEXT) {
+  return new NamedNode(iri, context);
 }
 
 // ### Creates a blank node
-export function blankNode(name, token) {
-  return new BlankNode(name || `n3-${_blankNodeCounter++}`, token);
+export function blankNode(name, context = DEFAULT_CONTEXT) {
+  return new BlankNode(name || `n3-${_blankNodeCounter++}`, context);
 }
 
 // ### Creates a literal
-export function literal(value, languageOrDataType, token) {
+export function literal(value, languageOrDataType, context = DEFAULT_CONTEXT) {
   // Create a language-tagged string
   if (typeof languageOrDataType === 'string')
-    return new Literal(`"${value}"@${languageOrDataType.toLowerCase()}`, token);
+    return new Literal(`"${value}"@${languageOrDataType.toLowerCase()}`, context);
 
   // Automatically determine datatype for booleans and numbers
   let datatype = languageOrDataType ? languageOrDataType.value : '';
@@ -387,13 +374,13 @@ export function literal(value, languageOrDataType, token) {
 
   // Create a datatyped literal
   return (datatype === '' || datatype === xsd.string) ?
-    new Literal(`"${value}"`, token) :
-    new Literal(`"${value}"^^${datatype}`, token);
+    new Literal(`"${value}"`, context) :
+    new Literal(`"${value}"^^${datatype}`, context);
 }
 
 // ### Creates a variable
-export function variable(name, token) {
-  return new Variable(name, token);
+export function variable(name, context = DEFAULT_CONTEXT) {
+  return new Variable(name, context);
 }
 
 // ### Returns the default graph

--- a/src/N3Parser.js
+++ b/src/N3Parser.js
@@ -159,7 +159,7 @@ export default class N3Parser {
       const iri = this._resolveIRI(token.value);
       if (iri === null)
         return this._error('Invalid IRI', token);
-      value = this._namedNode(iri);
+      value = this._namedNode(iri, token);
       break;
     // Read a prefixed name
     case 'type':
@@ -167,11 +167,11 @@ export default class N3Parser {
       const prefix = this._prefixes[token.prefix];
       if (prefix === undefined)
         return this._error(`Undefined prefix "${token.prefix}:"`, token);
-      value = this._namedNode(prefix + token.value);
+      value = this._namedNode(prefix + token.value, token);
       break;
     // Read a blank node
     case 'blank':
-      value = this._blankNode(this._prefixes[token.prefix] + token.value);
+      value = this._blankNode(this._prefixes[token.prefix] + token.value, token);
       break;
     // Read a variable
     case 'var':
@@ -194,7 +194,7 @@ export default class N3Parser {
     case '[':
       // Start a new quad with a new blank node as subject
       this._saveContext('blank', this._graph,
-                        this._subject = this._blankNode(), null, null);
+                        this._subject = this._blankNode(undefined, token), null, null);
       return this._readBlankNodeHead;
     case '(':
       // Start a new list
@@ -206,7 +206,7 @@ export default class N3Parser {
       if (!this._n3Mode)
         return this._error('Unexpected graph', token);
       this._saveContext('formula', this._graph,
-                        this._graph = this._blankNode(), null, null);
+                        this._graph = this._blankNode(undefined, token), null, null);
       return this._readSubject;
     case '}':
        // No subject; the graph in which we are reading is closed instead
@@ -234,7 +234,7 @@ export default class N3Parser {
         return this._completeSubjectLiteral;
       }
       else
-        this._subject = this._literal(token.value, this._namedNode(token.prefix));
+        this._subject = this._literal(token.value, this._namedNode(token.prefix, token), token);
 
       break;
     case '<<':
@@ -282,7 +282,7 @@ export default class N3Parser {
       if (this._n3Mode) {
         // Start a new quad with a new blank node as subject
         this._saveContext('blank', this._graph, this._subject,
-                          this._subject = this._blankNode(), null);
+                          this._subject = this._blankNode(undefined, token), null);
         return this._readBlankNodeHead;
       }
     case 'blank':
@@ -307,12 +307,12 @@ export default class N3Parser {
       }
       // Pre-datatyped string literal (prefix stores the datatype)
       else
-        this._object = this._literal(token.value, this._namedNode(token.prefix));
+        this._object = this._literal(token.value, this._namedNode(token.prefix, token), token);
       break;
     case '[':
       // Start a new quad with a new blank node as subject
       this._saveContext('blank', this._graph, this._subject, this._predicate,
-                        this._subject = this._blankNode());
+                        this._subject = this._blankNode(undefined, token));
       return this._readBlankNodeHead;
     case '(':
       // Start a new list
@@ -324,7 +324,7 @@ export default class N3Parser {
       if (!this._n3Mode)
         return this._error('Unexpected graph', token);
       this._saveContext('formula', this._graph, this._subject, this._predicate,
-                        this._graph = this._blankNode());
+                        this._graph = this._blankNode(undefined, token));
       return this._readSubject;
     case '<<':
       if (!this._supportsRDFStar)
@@ -419,14 +419,14 @@ export default class N3Parser {
     case '[':
       // Stack the current list quad and start a new quad with a blank node as subject
       this._saveContext('blank', this._graph,
-                        list = this._blankNode(), this.RDF_FIRST,
-                        this._subject = item = this._blankNode());
+                        list = this._blankNode(undefined, token), this.RDF_FIRST,
+                        this._subject = item = this._blankNode(undefined, token));
       next = this._readBlankNodeHead;
       break;
     case '(':
       // Stack the current list quad and start a new list
       this._saveContext('list', this._graph,
-                        list = this._blankNode(), this.RDF_FIRST, this.RDF_NIL);
+                        list = this._blankNode(undefined, token), this.RDF_FIRST, this.RDF_NIL);
       this._subject = null;
       break;
     case ')':
@@ -462,7 +462,7 @@ export default class N3Parser {
       }
       // Pre-datatyped string literal (prefix stores the datatype)
       else {
-        item = this._literal(token.value, this._namedNode(token.prefix));
+        item = this._literal(token.value, this._namedNode(token.prefix, token), token);
         next = this._getContextEndReader();
       }
       break;
@@ -471,7 +471,7 @@ export default class N3Parser {
       if (!this._n3Mode)
         return this._error('Unexpected graph', token);
       this._saveContext('formula', this._graph, this._subject, this._predicate,
-                        this._graph = this._blankNode());
+                        this._graph = this._blankNode(undefined, token));
       return this._readSubject;
     default:
       if ((item = this._readEntity(token)) === undefined)
@@ -480,7 +480,7 @@ export default class N3Parser {
 
      // Create a new blank node if no item head was assigned yet
     if (list === null)
-      this._subject = list = this._blankNode();
+      this._subject = list = this._blankNode(undefined, token);
 
     // Is this the first element of the list?
     if (previousList === null) {
@@ -524,7 +524,7 @@ export default class N3Parser {
   // ### `_completeLiteral` completes a literal with an optional datatype or language
   _completeLiteral(token) {
     // Create a simple string literal by default
-    let literal = this._literal(this._literalValue);
+    let literal = this._literal(this._literalValue, undefined, token);
 
     switch (token.type) {
     // Create a datatyped literal
@@ -532,12 +532,12 @@ export default class N3Parser {
     case 'typeIRI':
       const datatype = this._readEntity(token);
       if (datatype === undefined) return; // No datatype means an error occurred
-      literal = this._literal(this._literalValue, datatype);
+      literal = this._literal(this._literalValue, datatype, token);
       token = null;
       break;
     // Create a language-tagged string
     case 'langcode':
-      literal = this._literal(this._literalValue, token.value);
+      literal = this._literal(this._literalValue, token.value, token);
       token = null;
       break;
     }
@@ -721,7 +721,7 @@ export default class N3Parser {
   _readNamedGraphBlankLabel(token) {
     if (token.type !== ']')
       return this._error('Invalid graph label', token);
-    this._subject = this._blankNode();
+    this._subject = this._blankNode(undefined, token);
     return this._readGraph;
   }
 
@@ -751,17 +751,17 @@ export default class N3Parser {
     }
     // Without explicit quantifiers, map entities to a quantified entity
     if (!this._explicitQuantifiers)
-      this._quantified[entity.id] = this._quantifier(this._blankNode().value);
+      this._quantified[entity.id] = this._quantifier(this._blankNode(undefined, token).value);
     // With explicit quantifiers, output the reified quantifier
     else {
       // If this is the first item, start a new quantifier list
       if (this._subject === null)
         this._emit(this._graph || this.DEFAULTGRAPH, this._predicate,
-                   this._subject = this._blankNode(), this.QUANTIFIERS_GRAPH);
+                   this._subject = this._blankNode(undefined, token), this.QUANTIFIERS_GRAPH);
       // Otherwise, continue the previous list
       else
         this._emit(this._subject, this.RDF_REST,
-                   this._subject = this._blankNode(), this.QUANTIFIERS_GRAPH);
+                   this._subject = this._blankNode(undefined, token), this.QUANTIFIERS_GRAPH);
       // Output the list item
       this._emit(this._subject, this.RDF_FIRST, entity, this.QUANTIFIERS_GRAPH);
     }
@@ -818,7 +818,7 @@ export default class N3Parser {
   // ### `_readForwardPath` reads a '!' path
   _readForwardPath(token) {
     let subject, predicate;
-    const object = this._blankNode();
+    const object = this._blankNode(undefined, token);
     // The next token is the predicate
     if ((predicate = this._readEntity(token)) === undefined)
       return;
@@ -835,7 +835,7 @@ export default class N3Parser {
 
   // ### `_readBackwardPath` reads a '^' path
   _readBackwardPath(token) {
-    const subject = this._blankNode();
+    const subject = this._blankNode(undefined, token);
     let predicate, object;
     // The next token is the predicate
     if ((predicate = this._readEntity(token)) === undefined)

--- a/src/N3Parser.js
+++ b/src/N3Parser.js
@@ -159,7 +159,7 @@ export default class N3Parser {
       const iri = this._resolveIRI(token.value);
       if (iri === null)
         return this._error('Invalid IRI', token);
-      value = this._namedNode(iri, token);
+      value = this._namedNode(iri, { token });
       break;
     // Read a prefixed name
     case 'type':
@@ -167,15 +167,15 @@ export default class N3Parser {
       const prefix = this._prefixes[token.prefix];
       if (prefix === undefined)
         return this._error(`Undefined prefix "${token.prefix}:"`, token);
-      value = this._namedNode(prefix + token.value, token);
+      value = this._namedNode(prefix + token.value, { token });
       break;
     // Read a blank node
     case 'blank':
-      value = this._blankNode(this._prefixes[token.prefix] + token.value, token);
+      value = this._blankNode(this._prefixes[token.prefix] + token.value, { token });
       break;
     // Read a variable
     case 'var':
-      value = this._variable(token.value.substr(1));
+      value = this._variable(token.value.substr(1), { token });
       break;
     // Everything else is not an entity
     default:
@@ -194,7 +194,7 @@ export default class N3Parser {
     case '[':
       // Start a new quad with a new blank node as subject
       this._saveContext('blank', this._graph,
-                        this._subject = this._blankNode(undefined, token), null, null);
+                        this._subject = this._blankNode(undefined, { token }), null, null);
       return this._readBlankNodeHead;
     case '(':
       // Start a new list
@@ -206,7 +206,7 @@ export default class N3Parser {
       if (!this._n3Mode)
         return this._error('Unexpected graph', token);
       this._saveContext('formula', this._graph,
-                        this._graph = this._blankNode(undefined, token), null, null);
+                        this._graph = this._blankNode(undefined, { token }), null, null);
       return this._readSubject;
     case '}':
        // No subject; the graph in which we are reading is closed instead
@@ -234,7 +234,7 @@ export default class N3Parser {
         return this._completeSubjectLiteral;
       }
       else
-        this._subject = this._literal(token.value, this._namedNode(token.prefix, token), token);
+        this._subject = this._literal(token.value, this._namedNode(token.prefix, { token }), { token });
 
       break;
     case '<<':
@@ -282,7 +282,7 @@ export default class N3Parser {
       if (this._n3Mode) {
         // Start a new quad with a new blank node as subject
         this._saveContext('blank', this._graph, this._subject,
-                          this._subject = this._blankNode(undefined, token), null);
+                          this._subject = this._blankNode(undefined, { token }), null);
         return this._readBlankNodeHead;
       }
     case 'blank':
@@ -307,12 +307,12 @@ export default class N3Parser {
       }
       // Pre-datatyped string literal (prefix stores the datatype)
       else
-        this._object = this._literal(token.value, this._namedNode(token.prefix, token), token);
+        this._object = this._literal(token.value, this._namedNode(token.prefix, { token }), { token });
       break;
     case '[':
       // Start a new quad with a new blank node as subject
       this._saveContext('blank', this._graph, this._subject, this._predicate,
-                        this._subject = this._blankNode(undefined, token));
+                        this._subject = this._blankNode(undefined, { token }));
       return this._readBlankNodeHead;
     case '(':
       // Start a new list
@@ -324,7 +324,7 @@ export default class N3Parser {
       if (!this._n3Mode)
         return this._error('Unexpected graph', token);
       this._saveContext('formula', this._graph, this._subject, this._predicate,
-                        this._graph = this._blankNode(undefined, token));
+                        this._graph = this._blankNode(undefined, { token }));
       return this._readSubject;
     case '<<':
       if (!this._supportsRDFStar)
@@ -420,13 +420,13 @@ export default class N3Parser {
       // Stack the current list quad and start a new quad with a blank node as subject
       this._saveContext('blank', this._graph,
                         list = this._blankNode(undefined, token), this.RDF_FIRST,
-                        this._subject = item = this._blankNode(undefined, token));
+                        this._subject = item = this._blankNode(undefined, { token }));
       next = this._readBlankNodeHead;
       break;
     case '(':
       // Stack the current list quad and start a new list
       this._saveContext('list', this._graph,
-                        list = this._blankNode(undefined, token), this.RDF_FIRST, this.RDF_NIL);
+                        list = this._blankNode(undefined, { token }), this.RDF_FIRST, this.RDF_NIL);
       this._subject = null;
       break;
     case ')':
@@ -462,7 +462,7 @@ export default class N3Parser {
       }
       // Pre-datatyped string literal (prefix stores the datatype)
       else {
-        item = this._literal(token.value, this._namedNode(token.prefix, token), token);
+        item = this._literal(token.value, this._namedNode(token.prefix, { token }), { token });
         next = this._getContextEndReader();
       }
       break;
@@ -471,7 +471,7 @@ export default class N3Parser {
       if (!this._n3Mode)
         return this._error('Unexpected graph', token);
       this._saveContext('formula', this._graph, this._subject, this._predicate,
-                        this._graph = this._blankNode(undefined, token));
+                        this._graph = this._blankNode(undefined, { token }));
       return this._readSubject;
     default:
       if ((item = this._readEntity(token)) === undefined)
@@ -480,7 +480,7 @@ export default class N3Parser {
 
      // Create a new blank node if no item head was assigned yet
     if (list === null)
-      this._subject = list = this._blankNode(undefined, token);
+      this._subject = list = this._blankNode(undefined, { token });
 
     // Is this the first element of the list?
     if (previousList === null) {
@@ -524,7 +524,7 @@ export default class N3Parser {
   // ### `_completeLiteral` completes a literal with an optional datatype or language
   _completeLiteral(token) {
     // Create a simple string literal by default
-    let literal = this._literal(this._literalValue, undefined, token);
+    let literal = this._literal(this._literalValue, undefined, { token });
 
     switch (token.type) {
     // Create a datatyped literal
@@ -532,12 +532,12 @@ export default class N3Parser {
     case 'typeIRI':
       const datatype = this._readEntity(token);
       if (datatype === undefined) return; // No datatype means an error occurred
-      literal = this._literal(this._literalValue, datatype, token);
+      literal = this._literal(this._literalValue, datatype, { token });
       token = null;
       break;
     // Create a language-tagged string
     case 'langcode':
-      literal = this._literal(this._literalValue, token.value, token);
+      literal = this._literal(this._literalValue, token.value, { token });
       token = null;
       break;
     }
@@ -721,7 +721,7 @@ export default class N3Parser {
   _readNamedGraphBlankLabel(token) {
     if (token.type !== ']')
       return this._error('Invalid graph label', token);
-    this._subject = this._blankNode(undefined, token);
+    this._subject = this._blankNode(undefined, { token });
     return this._readGraph;
   }
 
@@ -751,17 +751,17 @@ export default class N3Parser {
     }
     // Without explicit quantifiers, map entities to a quantified entity
     if (!this._explicitQuantifiers)
-      this._quantified[entity.id] = this._quantifier(this._blankNode(undefined, token).value);
+      this._quantified[entity.id] = this._quantifier(this._blankNode(undefined, { token }).value);
     // With explicit quantifiers, output the reified quantifier
     else {
       // If this is the first item, start a new quantifier list
       if (this._subject === null)
         this._emit(this._graph || this.DEFAULTGRAPH, this._predicate,
-                   this._subject = this._blankNode(undefined, token), this.QUANTIFIERS_GRAPH);
+                   this._subject = this._blankNode(undefined, { token }), this.QUANTIFIERS_GRAPH);
       // Otherwise, continue the previous list
       else
         this._emit(this._subject, this.RDF_REST,
-                   this._subject = this._blankNode(undefined, token), this.QUANTIFIERS_GRAPH);
+                   this._subject = this._blankNode(undefined, { token }), this.QUANTIFIERS_GRAPH);
       // Output the list item
       this._emit(this._subject, this.RDF_FIRST, entity, this.QUANTIFIERS_GRAPH);
     }
@@ -818,7 +818,7 @@ export default class N3Parser {
   // ### `_readForwardPath` reads a '!' path
   _readForwardPath(token) {
     let subject, predicate;
-    const object = this._blankNode(undefined, token);
+    const object = this._blankNode(undefined, { token });
     // The next token is the predicate
     if ((predicate = this._readEntity(token)) === undefined)
       return;
@@ -835,7 +835,7 @@ export default class N3Parser {
 
   // ### `_readBackwardPath` reads a '^' path
   _readBackwardPath(token) {
-    const subject = this._blankNode(undefined, token);
+    const subject = this._blankNode(undefined, { token });
     let predicate, object;
     // The next token is the predicate
     if ((predicate = this._readEntity(token)) === undefined)

--- a/src/index.js
+++ b/src/index.js
@@ -20,6 +20,10 @@ import {
 
   termFromId,
   termToId,
+  namedNode,
+  blankNode,
+  literal,
+  variable,
 } from './N3DataFactory';
 
 // Named exports
@@ -31,9 +35,7 @@ export {
   StreamParser,
   StreamWriter,
   Util,
-
   DataFactory,
-
   Term,
   NamedNode,
   Literal,
@@ -45,6 +47,10 @@ export {
 
   termFromId,
   termToId,
+  namedNode,
+  blankNode,
+  literal,
+  variable,
 };
 
 // Export all named exports as a default object for backward compatibility
@@ -56,9 +62,7 @@ export default {
   StreamParser,
   StreamWriter,
   Util,
-
   DataFactory,
-
   Term,
   NamedNode,
   Literal,
@@ -70,4 +74,8 @@ export default {
 
   termFromId,
   termToId,
+  namedNode,
+  blankNode,
+  literal,
+  variable,
 };

--- a/test/N3Parser-test.js
+++ b/test/N3Parser-test.js
@@ -2522,9 +2522,12 @@ describe('Parser', () => {
       });
 
       for (const quad of parser.parse('<a> <b> 1, _:d.')) {
-        expect(quad.subject.token).toBeDefined();
-        expect(quad.predicate.token).toBeDefined();
-        expect(quad.object.token).toBeDefined();
+        expect(quad.subject.context).toBeDefined();
+        expect(quad.subject.context.token).toBeDefined();
+        expect(quad.predicate.context).toBeDefined();
+        expect(quad.predicate.context.token).toBeDefined();
+        expect(quad.object.context).toBeDefined();
+        expect(quad.object.context.token).toBeDefined();
       }
     });
   });

--- a/test/N3Parser-test.js
+++ b/test/N3Parser-test.js
@@ -1,4 +1,4 @@
-import { Parser, NamedNode, BlankNode, Quad, termFromId, DataFactory as DF } from '../src';
+import { Parser, NamedNode, BlankNode, Quad, termFromId, DataFactory as DF, literal, variable, namedNode, blankNode, DataFactory } from '../src';
 import rdfDataModel from '@rdfjs/data-model';
 import { isomorphic } from 'rdf-isomorphic';
 
@@ -2508,6 +2508,24 @@ describe('Parser', () => {
         { s: 'n-http://example.org/a', p: 'v-b', o: 'l-1',    g: 'defaultGraph' },
         { s: 'n-http://example.org/a', p: 'v-b', o: 'b-b0_d', g: 'defaultGraph' },
       ]);
+    });
+
+    it('should provide tokens using a custom factory', () => {
+      parser = new Parser({
+        factory: {
+          ...DataFactory,
+          namedNode: namedNode,
+          blankNode: blankNode,
+          literal: literal,
+          variable: variable,
+        },
+      });
+
+      for (const quad of parser.parse('<a> <b> 1, _:d.')) {
+        expect(quad.subject.token).toBeDefined();
+        expect(quad.predicate.token).toBeDefined();
+        expect(quad.object.token).toBeDefined();
+      }
     });
   });
 


### PR DESCRIPTION
I extended the factory methods `namedNode`, `blankNode`, `literalNode `and `variable `to also accept an optional token as additional parameter and pass it to the created Term instance.

Then I changed the Parser to provide the tokens as an additional argument when parsing a file.

The default exported `DataFactory `does, however, not pass the token to the factory methods and thus creates nodes without additional added tokens as a default behaviour. This means that the current behaviour is not changed and all existing tests pass.

Using the exported factory methods for one can create a custom DataFactory which can be passed to the parser as an argument using the existing API. This way the exported tokens can either be a) passed as they are or b) modified and stored with the nodes as neded.