### PR TITLE
feat: Implement RDF/JS dataset specification

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,7 +305,7 @@ for (const quad of store.match(namedNode('http://ex.org/Mickey'), null, null))
 ```
 
 ### [`Dataset` Interface](https://rdf.js.org/dataset-spec/#dataset-interface)
-This store adheres to the `Datase` interface which exposes the following properties
+This store adheres to the `Dataset` interface which exposes the following properties
 
 Attributes:
  - `size` — A non-negative integer that specifies the number of quads in the set.

--- a/README.md
+++ b/README.md
@@ -304,8 +304,8 @@ for (const quad of store.match(namedNode('http://ex.org/Mickey'), null, null))
   console.log(quad);
 ```
 
-### [`DatasetCore` Interface](https://rdf.js.org/dataset-spec/#datasetcore-interface)
-This store adheres to the `DatasetCore` interface which exposes the following properties
+### [`Dataset` Interface](https://rdf.js.org/dataset-spec/#dataset-interface)
+This store adheres to the `Datase` interface which exposes the following properties
 
 Attributes:
  - `size` — A non-negative integer that specifies the number of quads in the set.
@@ -318,7 +318,7 @@ Methods:
  - `[Symbol.iterator]` — Implements the iterator protocol to allow iteration over all `quads` in the dataset as in the example above.
 
 ### Addition and deletion of quads
-The store provides the following manipulation methods in addition to implementing the standard [`DatasetCore` Interface](https://rdf.js.org/dataset-spec/#datasetcore-interface)
+The store provides the following manipulation methods in addition to implementing the standard [`Dataset` Interface](https://rdf.js.org/dataset-spec/#dataset-interface)
 ([documentation](http://rdfjs.github.io/N3.js/docs/N3Store.html)):
 - `addQuad` to insert one quad
 - `addQuads` to insert an array of quads

--- a/README.md
+++ b/README.md
@@ -318,7 +318,7 @@ Methods:
  - `[Symbol.iterator]` — Implements the iterator protocol to allow iteration over all `quads` in the dataset as in the example above.
 
 ### Addition and deletion of quads
-The store provides the following manipulation methods in addition to implementing the standard [`Dataset` Interface](https://rdf.js.org/dataset-spec/#dataset-interface)
+The store implements the following manipulation methods in addition to the standard [`Dataset` Interface](https://rdf.js.org/dataset-spec/#dataset-interface)
 ([documentation](http://rdfjs.github.io/N3.js/docs/N3Store.html)):
 - `addQuad` to insert one quad
 - `addQuads` to insert an array of quads

--- a/src/N3Store.js
+++ b/src/N3Store.js
@@ -871,13 +871,10 @@ export default class N3Store {
    * This method is aligned with `Array.prototype.reduce()` in ECMAScript-262.
    */
   reduce(callback, initialValue) {
-    let accumulator = initialValue;
-    for (const quad of this) {
-      if (accumulator === undefined)
-        accumulator = quad;
-      else
-        accumulator = callback(accumulator, quad, this);
-    }
+    const iter = this.readQuads();
+    let accumulator = initialValue === undefined ? iter.next().value : initialValue;
+    for (const quad of iter)
+      accumulator = callback(accumulator, quad, this);
     return accumulator;
   }
 

--- a/src/N3Store.js
+++ b/src/N3Store.js
@@ -3,6 +3,7 @@ import { Readable } from 'readable-stream';
 import { default as N3DataFactory, termToId, termFromId } from './N3DataFactory';
 import namespaces from './IRIs';
 import { isDefaultGraph } from './N3Util';
+import N3Writer from './N3Writer';
 
 // ## Constructor
 export default class N3Store {
@@ -799,7 +800,11 @@ export default class N3Store {
    * Blank Nodes will be normalized.
    */
   contains(other) {
-    return other.every(quad => this.has(quad));
+    console.log('containes called on')
+    return other.every(quad => {
+      console.log('every called on', quad);
+      return this.has(quad)
+    });
   }
 
   /**
@@ -924,7 +929,7 @@ export default class N3Store {
     * implementation.
     */
   toString() {
-    throw new Error('not implemented');
+    return (new N3Writer).quadsToString(this);
   }
 
    /**

--- a/src/N3Store.js
+++ b/src/N3Store.js
@@ -799,7 +799,7 @@ export default class N3Store {
   }
 
   /**
-   * This method removes the quads in the current instance that match the given arguments.
+   * This method removes the quads in the current dataset that match the given arguments.
    *
    * The logic described in {@link https://rdf.js.org/dataset-spec/#quad-matching|Quad Matching} is applied for each
    * quad in this dataset to select the quads which will be deleted.

--- a/src/N3Store.js
+++ b/src/N3Store.js
@@ -772,8 +772,8 @@ export default class N3Store {
   }
 
   /**
-   * Returns `true` if the current instance is a superset of the given dataset; differently put: if the given dataset
-   * is a subset of, is contained in the current dataset.
+   * Returns `true` if the current dataset is a superset of the given dataset; in other words, returns `true` if
+   * the given dataset is a subset of, i.e., is contained within, the current dataset.
    *
    * Blank Nodes will be normalized.
    */

--- a/src/N3Store.js
+++ b/src/N3Store.js
@@ -476,7 +476,7 @@ export default class N3Store {
   // Setting any field to `undefined` or `null` indicates a wildcard.
   forEach(callback, subject, predicate, object, graph) {
     this.some(quad => {
-      callback(quad);
+      callback(quad, this);
       return false;
     }, subject, predicate, object, graph);
   }
@@ -488,7 +488,7 @@ export default class N3Store {
     let some = false;
     const every = !this.some(quad => {
       some = true;
-      return !callback(quad);
+      return !callback(quad, this);
     }, subject, predicate, object, graph);
     return some && every;
   }
@@ -773,6 +773,168 @@ export default class N3Store {
     if (remove)
       this.removeQuads(toRemove);
     return lists;
+  }
+
+  /**
+   * Returns `true` if the current instance is a superset of the given dataset; differently put: if the given dataset
+   * is a subset of, is contained in the current dataset.
+   *
+   * Blank Nodes will be normalized.
+   */
+  addAll(quads) {
+    if (Array.isArray(quads))
+      this.addQuads(quads);
+    else {
+      for (const quad of quads)
+        this.add(quad);
+    }
+    return this;
+  }
+
+
+  /**
+   * Returns `true` if the current instance is a superset of the given dataset; differently put: if the given dataset
+   * is a subset of, is contained in the current dataset.
+   *
+   * Blank Nodes will be normalized.
+   */
+  contains(other) {
+    return other.every(quad => this.has(quad));
+  }
+
+  /**
+   * This method removes the quads in the current instance that match the given arguments.
+   *
+   * The logic described in {@link https://rdf.js.org/dataset-spec/#quad-matching|Quad Matching} is applied for each
+   * quad in this dataset to select the quads which will be deleted.
+   *
+   * @param subject   The optional exact subject to match.
+   * @param predicate The optional exact predicate to match.
+   * @param object    The optional exact object to match.
+   * @param graph     The optional exact graph to match.
+   */
+  deleteMatches(subject, predicate, object, graph) {
+    this.removeMatches(subject, predicate, object, graph);
+    return this;
+  }
+
+  /**
+   * Returns a new dataset that contains all quads from the current dataset, not included in the given dataset.
+   */
+  difference(other) {
+    const store = new N3Store();
+    for (const quad of this)
+      if (!other.has(quad))
+        store.add(quad);
+    return store;
+  }
+
+  /**
+   * Returns true if the current instance contains the same graph structure as the given dataset.
+   *
+   * Blank Nodes will be normalized.
+   */
+  equals(other) {
+    return this.size === other.size && this.contains(other);
+  }
+
+  /**
+   * Creates a new dataset with all the quads that pass the test implemented by the provided `iteratee`.
+   *
+   * This method is aligned with Array.prototype.filter() in ECMAScript-262.
+   */
+  filter(iteratee) {
+    const store = new N3Store();
+    for (const quad of this)
+      if (iteratee(quad, this))
+        store.add(quad);
+    return store;
+  }
+
+  /**
+   * Returns a new dataset containing alls quads from the current dataset that are also included in the given dataset.
+   */
+  intersection(other) {
+    const store = new N3Store();
+    for (const quad of this)
+      if (other.has(quad))
+        store.add(quad);
+    return store;
+  }
+
+   /**
+    * Returns a new dataset containing all quads returned by applying `iteratee` to each quad in the current dataset.
+    */
+  map(iteratee) {
+    const store = new N3Store();
+    for (const quad of this)
+      store.add(iteratee(quad, this));
+    return store;
+  }
+
+   /**
+    * This method calls the `iteratee` on each `quad` of the `Dataset`. The first time the `iteratee` is called, the
+    * `accumulator` value is the `initialValue` or, if not given, equals to the first quad of the `Dataset`. The return
+    * value of the `iteratee` is used as `accumulator` value for the next calls.
+    *
+    * This method returns the return value of the last `iteratee` call.
+    *
+    * This method is aligned with `Array.prototype.reduce()` in ECMAScript-262.
+    */
+  reduce(callback, initialValue) {
+    let accumulator = initialValue;
+    for (const quad of this) {
+      if (accumulator === undefined)
+        accumulator = quad;
+      else
+        accumulator = callback(accumulator, quad, this);
+    }
+    return accumulator;
+  }
+
+   /**
+    * Returns the set of quads within the dataset as a host language native sequence, for example an `Array` in
+    * ECMAScript-262.
+    *
+    * Since a `Dataset` is an unordered set, the order of the quads within the returned sequence is arbitrary.
+    */
+  toArray() {
+    return this.getQuads();
+  }
+
+   /**
+    * Returns an N-Quads string representation of the dataset, preprocessed with
+    * {@link https://json-ld.github.io/normalization/spec/|RDF Dataset Normalization} algorithm.
+    */
+  toCanonical() {
+    throw new Error('not implemented');
+  }
+
+   /**
+    * Returns a stream that contains all quads of the dataset.
+    */
+  toStream() {
+    return this.match();
+  }
+
+   /**
+    * Returns an N-Quads string representation of the dataset.
+    *
+    * No prior normalization is required, therefore the results for the same quads may vary depending on the `Dataset`
+    * implementation.
+    */
+  toString() {
+    throw new Error('not implemented');
+  }
+
+   /**
+    * Returns a new `Dataset` that is a concatenation of this dataset and the quads given as an argument.
+    */
+  union(quads) {
+    const store = new N3Store();
+    store.addAll(this);
+    store.addAll(quads);
+    return store;
   }
 
   // ### Store is an iterable.

--- a/src/N3Store.js
+++ b/src/N3Store.js
@@ -789,8 +789,8 @@ export default class N3Store {
 
 
   /**
-   * Returns `true` if the current instance is a superset of the given dataset; differently put: if the given dataset
-   * is a subset of, is contained in the current dataset.
+   * Returns `true` if the current dataset is a superset of the given dataset; in other words, returns `true` if
+   * the given dataset is a subset of, i.e., is contained within, the current dataset.
    *
    * Blank Nodes will be normalized.
    */
@@ -802,7 +802,7 @@ export default class N3Store {
    * This method removes the quads in the current dataset that match the given arguments.
    *
    * The logic described in {@link https://rdf.js.org/dataset-spec/#quad-matching|Quad Matching} is applied for each
-   * quad in this dataset to select the quads which will be deleted.
+   * quad in this dataset, to select the quads which will be deleted.
    *
    * @param subject   The optional exact subject to match.
    * @param predicate The optional exact predicate to match.
@@ -816,14 +816,14 @@ export default class N3Store {
   }
 
   /**
-   * Returns a new dataset that contains all quads from the current dataset, not included in the given dataset.
+   * Returns a new dataset that contains all quads from the current dataset that are not included in the given dataset.
    */
   difference(other) {
     return this.filter(quad => !other.has(quad));
   }
 
   /**
-   * Returns true if the current instance contains the same graph structure as the given dataset.
+   * Returns true if the current dataset contains the same graph structure as the given dataset.
    *
    * Blank Nodes will be normalized.
    */
@@ -845,7 +845,7 @@ export default class N3Store {
   }
 
   /**
-   * Returns a new dataset containing alls quads from the current dataset that are also included in the given dataset.
+   * Returns a new dataset containing all quads from the current dataset that are also included in the given dataset.
    */
   intersection(other) {
     return this.filter(quad => other.has(quad));
@@ -862,9 +862,9 @@ export default class N3Store {
   }
 
   /**
-   * This method calls the `iteratee` on each `quad` of the `Dataset`. The first time the `iteratee` is called, the
-   * `accumulator` value is the `initialValue` or, if not given, equals to the first quad of the `Dataset`. The return
-   * value of the `iteratee` is used as `accumulator` value for the next calls.
+   * This method calls the `iteratee` method on each `quad` of the `Dataset`. The first time the `iteratee` method
+   * is called, the `accumulator` value is the `initialValue`, or, if not given, equals the first quad of the `Dataset`.
+   * The return value of each call to the `iteratee` method is used as the `accumulator` value for the next call.
    *
    * This method returns the return value of the last `iteratee` call.
    *
@@ -879,7 +879,7 @@ export default class N3Store {
   }
 
   /**
-   * Returns the set of quads within the dataset as a host language native sequence, for example an `Array` in
+   * Returns the set of quads within the dataset as a host-language-native sequence, for example an `Array` in
    * ECMAScript-262.
    *
    * Since a `Dataset` is an unordered set, the order of the quads within the returned sequence is arbitrary.
@@ -889,7 +889,7 @@ export default class N3Store {
   }
 
   /**
-   * Returns an N-Quads string representation of the dataset, preprocessed with
+   * Returns an N-Quads string representation of the dataset, preprocessed with the
    * {@link https://json-ld.github.io/normalization/spec/|RDF Dataset Normalization} algorithm.
    */
   toCanonical() {

--- a/src/N3Writer.js
+++ b/src/N3Writer.js
@@ -15,7 +15,7 @@ const escape    = /["\\\t\n\r\b\f\u0000-\u0019\ud800-\udbff]/,
       '\n': '\\n', '\r': '\\r', '\b': '\\b', '\f': '\\f',
     };
 
-// ## Placeholder class to represent already pretty-printed terms
+// ## Placeholder class to represent already pretty-pnew Error('not implemented')rinted terms
 class SerializedTerm extends Term {
   // Pretty-printed nodes are not equal to any other node
   // (e.g., [] does not equal [])

--- a/src/N3Writer.js
+++ b/src/N3Writer.js
@@ -15,7 +15,7 @@ const escape    = /["\\\t\n\r\b\f\u0000-\u0019\ud800-\udbff]/,
       '\n': '\\n', '\r': '\\r', '\b': '\\b', '\f': '\\f',
     };
 
-// ## Placeholder class to represent already pretty-pnew Error('not implemented')rinted terms
+// ## Placeholder class to represent already pretty-printed terms
 class SerializedTerm extends Term {
   // Pretty-printed nodes are not equal to any other node
   // (e.g., [] does not equal [])

--- a/src/N3Writer.js
+++ b/src/N3Writer.js
@@ -130,9 +130,10 @@ export default class N3Writer {
 
   // ### `quadsToString` serializes an array of quads as a string
   quadsToString(quads) {
-    return quads.map(t => {
-      return this.quadToString(t.subject, t.predicate, t.object, t.graph);
-    }).join('');
+    let quadsString = '';
+    for (const quad of quads)
+      quadsString += this.quadToString(quad.subject, quad.predicate, quad.object, quad.graph);
+    return quadsString;
   }
 
   // ### `_encodeSubject` represents a subject

--- a/test/N3Store-test.js
+++ b/test/N3Store-test.js
@@ -2012,7 +2012,7 @@ describe('Store', () => {
     );
   });
 
-  describe.each([true, false])('RDF/JS Dataset Methods [DatasetCoreAndReadableStream: %s]', match => {
+  describe.each([true, false, 'instantiated'])('RDF/JS Dataset Methods [DatasetCoreAndReadableStream: %s]', match => {
     let q1, q2, q3, store, store1, store2, empty;
 
     beforeEach(() => {
@@ -2029,6 +2029,13 @@ describe('Store', () => {
         store = store2.match(new NamedNode('s1'));
         store1 = store1.match();
         store2 = store2.match();
+      }
+
+      if (match === 'instantiated') {
+        empty.size;
+        store.size;
+        store1.size;
+        store2.size;
       }
     });
 
@@ -2135,15 +2142,11 @@ describe('Store', () => {
     });
 
     describe('#toStream', () => {
-      it('should convert to a stream', done => {
-        const stream = store1.toStream();
-        stream.once('data', quad => {
-          expect(quad).toEqual(q1);
-          stream.once('data', quad => {
-            expect(quad).toEqual(q2);
-            done();
-          });
-        });
+      it('should convert to a stream', () => {
+        expect(arrayifyStream(store2.toStream())).resolves.toEqual([q1, q3]);
+        expect(arrayifyStream(store1.toStream())).resolves.toEqual([q1, q2]);
+        expect(arrayifyStream(store.toStream())).resolves.toEqual([q1]);
+        expect(arrayifyStream(empty.toStream())).resolves.toEqual([]);
       });
     });
 

--- a/test/N3Store-test.js
+++ b/test/N3Store-test.js
@@ -2118,8 +2118,10 @@ describe('Store', () => {
 
     describe('#reduce', () => {
       it('should reduce over quads', () => {
-        expect(store1.reduce((acc, quad) => acc + 1, 0)).toEqual(2);
+        expect(store1.reduce((acc, _) => acc + 1, 0)).toEqual(2);
         expect(store1.reduce((acc, quad) => acc + quad.subject.value.length, 0)).toEqual(4);
+        expect(store1.reduce((acc, _) => acc, 0)).toEqual(0);
+        expect(store.reduce((acc, _) => acc)).toEqual(q1);
       });
     });
 
@@ -2217,6 +2219,21 @@ describe('Store', () => {
         expect(store.equals(new Store([q2]))).toBe(false);
         expect(store1.equals(new Store([q1]))).toBe(false);
         expect(store2.equals(new Store([q1]))).toBe(false);
+      });
+    });
+
+    describe('#some', () => {
+      it('should return true if any quad passes the test', () => {
+        expect(store1.some(quad => quad.subject.value === 's1')).toBe(true);
+        expect(store1.some(quad => quad.subject.value === 's2')).toBe(false);
+      });
+
+      it('should return false if no quad passes the test', () => {
+        expect(store1.some(quad => quad.subject.value === 's2')).toBe(false);
+      });
+
+      it('should return false on the empty set', () => {
+        expect(empty.some(quad => true)).toBe(false);
       });
     });
   });

--- a/test/N3Store-test.js
+++ b/test/N3Store-test.js
@@ -2011,6 +2011,59 @@ describe('Store', () => {
       }
     );
   });
+
+  describe('RDF/JS Dataset Methods', () => {
+    let q1, q2, q3, store, store1, store2;
+
+    beforeEach(() => {
+      q1 = new Quad(new NamedNode('s1'), new NamedNode('p1'), new NamedNode('o1'));
+      q2 = new Quad(new NamedNode('s1'), new NamedNode('p1'), new NamedNode('o2'));
+      q3 = new Quad(new NamedNode('s2'), new NamedNode('p2'), new NamedNode('03'));
+      store = new Store(q1);
+      store1 = new Store([ q1, q2 ]);
+      store2 = new Store([ q2, q3]);
+    });
+
+    describe('#contains', () => {
+      it('store is contained in store1 and store2', () => {
+        expect(store.contains(store)).toBe(true);
+        // expect(store1.contains(store)).toBe(true);
+        // expect(store2.contains(store)).toBe(true);
+      });
+  
+      // it('should return false for a non-existing quad', () => {
+      //   expect(store.contains(store1)).toBe(false);
+      //   expect(store.contains(store2)).toBe(false);
+      // });
+    });
+  
+    describe('#union', () => {
+      it('should return a new store with the union of the quads', () => {
+        const store = store1.union(store2);
+        expect(store1.size).toEqual(2);
+        expect(store2.size).toEqual(2);
+        expect(store.size).toEqual(3);
+      });
+    });
+  
+    describe('#difference', () => {
+      it('should return a new store with the difference of the quads', () => {
+        const store = store1.difference(store2);
+        expect(store1.size).toEqual(2);
+        expect(store2.size).toEqual(2);
+        expect(store.size).toEqual(1);
+      });
+    });
+  
+    describe('#intersection', () => {
+      it('should return a new store with the intersection of the quads', () => {
+        const store = store1.intersection(store2);
+        expect(store1.size).toEqual(2);
+        expect(store2.size).toEqual(2);
+        expect(store.size).toEqual(1);
+      });
+    });
+  });
 });
 
 function alwaysTrue()  { return true;  }


### PR DESCRIPTION
Draft PR to add full functionality of https://github.com/rdfjs/types/blob/master/dataset.d.ts. Observe that we alter the behavior of `#empty` on the empty set to now return `true` instead of `false`, as described in https://github.com/rdfjs/N3.js/issues/391 - so it may be that this needs to be an mver bump.

Supercedes https://github.com/rdfjs/N3.js/pull/288, pushing to a branch on the N3.js repo so CI will run.

Closes #390
Closes #391 