### PR TITLE
Feature: callback and event for comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ the callback is invoked one last time with `null` for `quad`
 and a hash of prefixes as third argument.
 <br>
 
-Alternatively, an object may be supplied, where `onQuad`, `onPrefix` and `onComment` may be used to listen for `quads`, `prefixes` and `comments` as follows:
+Alternatively, an object can be supplied, where `onQuad`, `onPrefix` and `onComment` are used to listen for `quads`, `prefixes` and `comments` as follows:
 ```JavaScript
 const parser = new N3.Parser();
 
@@ -113,14 +113,14 @@ parser.parse(tomAndJerry, {
   // onQuad (required) accepts a listener of type (quad: RDF.Quad) => void
   onQuad: (err, quad) => { console.log(quad); },
   // onPrefix (optional) accepts a listener of type (prefix: string, iri: NamedNode) => void
-  onPrefix: (prefix, iri) => { console.log(prefix, 'expands to', iri); },
+  onPrefix: (prefix, iri) => { console.log(prefix, 'expands to', iri.value); },
   // onComment (optional) accepts a listener of type (comment: string) => void
   onComment: (comment) => { console.log('#', comment); },
 });
 ```
 
 <br>
-If no callbacks are provided, parsing happens synchronously returning an array of parsed quads.
+If no callbacks are provided, parsing happens synchronously returning an array of quads.
 
 ```JavaScript
 const parser = new N3.Parser();
@@ -193,7 +193,7 @@ function SlowConsumer() {
 
 A dedicated `prefix` event signals every prefix with `prefix` and `term` arguments.
 
-A dedicated `comment` event may be enabled by setting `comments: true` in the N3.StreamParser constructor.
+A dedicated `comment` event can be enabled by setting `comments: true` in the N3.StreamParser constructor.
 
 ## Writing
 

--- a/README.md
+++ b/README.md
@@ -89,19 +89,22 @@ parser.parse(
    c:Tom a c:Cat.
    c:Jerry a c:Mouse;
            c:smarterThan c:Tom.`,
-  (error, quad, prefixes) => {
+  (error, quad) => {
     if (quad)
       console.log(quad);
     else
-      console.log("# That's all, folks!", prefixes);
+      console.log("# That's all, folks!");
   });
 ```
 The callback's first argument is an optional error value, the second is a quad.
 If there are no more quads,
-the callback is invoked one last time with `null` for `quad`
-and a hash of prefixes as third argument.
+the callback is invoked one last time with `null` for `quad`.
 <br>
-Pass a second callback to `parse` to retrieve prefixes as they are read.
+In case you would also like to process prefixes, you can instead pass an object containing multiple callbacks.
+The callback to retrieve the quads is called `onQuad`.
+The callback to also retrieve prefixes as they are read is called `onPrefix`.
+The first argument is the prefix, the second is the IRI.
+There is also a third callback called `onComment` taking only one `comment` argument.
 <br>
 If no callbacks are provided, parsing happens synchronously.
 
@@ -168,6 +171,8 @@ function SlowConsumer() {
 ```
 
 A dedicated `prefix` event signals every prefix with `prefix` and `term` arguments.
+
+Also a `comment` event can be enabled through the options object of the N3.StreamParser constructor using: `comments: true`.
 
 ## Writing
 

--- a/README.md
+++ b/README.md
@@ -89,16 +89,17 @@ parser.parse(
    c:Tom a c:Cat.
    c:Jerry a c:Mouse;
            c:smarterThan c:Tom.`,
-  (error, quad) => {
+  (error, quad, prefixes) => {
     if (quad)
       console.log(quad);
     else
-      console.log("# That's all, folks!");
+      console.log("# That's all, folks!", prefixes);
   });
 ```
 The callback's first argument is an optional error value, the second is a quad.
 If there are no more quads,
-the callback is invoked one last time with `null` for `quad`.
+the callback is invoked one last time with `null` for `quad`
+and a hash of prefixes as third argument.
 <br>
 In case you would also like to process prefixes, you can instead pass an object containing multiple callbacks.
 The callback to retrieve the quads is called `onQuad`.

--- a/README.md
+++ b/README.md
@@ -83,12 +83,15 @@ we assume that a quad is simply a triple in a named or default graph.
 
 `N3.Parser` transforms Turtle, TriG, N-Triples, or N-Quads document into quads through a callback:
 ```JavaScript
+const tomAndJerry = `PREFIX c: <http://example.org/cartoons#>
+  # Tom is a cat
+  c:Tom a c:Cat.
+  c:Jerry a c:Mouse;
+    c:smarterThan c:Tom.`
+
 const parser = new N3.Parser();
-parser.parse(
-  `PREFIX c: <http://example.org/cartoons#>
-   c:Tom a c:Cat.
-   c:Jerry a c:Mouse;
-           c:smarterThan c:Tom.`,
+
+parser.parse(tomAndJerry,
   (error, quad, prefixes) => {
     if (quad)
       console.log(quad);
@@ -101,13 +104,30 @@ If there are no more quads,
 the callback is invoked one last time with `null` for `quad`
 and a hash of prefixes as third argument.
 <br>
-In case you would also like to process prefixes, you can instead pass an object containing multiple callbacks.
-The callback to retrieve the quads is called `onQuad`.
-The callback to also retrieve prefixes as they are read is called `onPrefix`.
-The first argument is the prefix, the second is the IRI.
-There is also a third callback called `onComment` taking only one `comment` argument.
+
+Alternatively, an object may be supplied, where `onQuad`, `onPrefix` and `onComment` may be used to listen for `quads`, `prefixes` and `comments` as follows:
+```JavaScript
+const parser = new N3.Parser();
+
+parser.parse(tomAndJerry, {
+  // onQuad (required) accepts a listener of type (quad: RDF.Quad) => void
+  onQuad: (err, quad) => { console.log(quad); },
+  // onPrefix (optional) accepts a listener of type (prefix: string, iri: NamedNode) => void
+  onPrefix: (prefix, iri) => { console.log(prefix, 'expands to', iri); },
+  // onComment (optional) accepts a listener of type (comment: string) => void
+  onComment: (comment) => { console.log('#', comment); },
+});
+```
+
 <br>
-If no callbacks are provided, parsing happens synchronously.
+If no callbacks are provided, parsing happens synchronously returning an array of parsed quads.
+
+```JavaScript
+const parser = new N3.Parser();
+
+// An array of resultant Quads
+const quadArray = parser.parse(tomAndJerry);
+```
 
 By default, `N3.Parser` parses a permissive superset of Turtle, TriG, N-Triples, and N-Quads.
 <br>
@@ -173,7 +193,7 @@ function SlowConsumer() {
 
 A dedicated `prefix` event signals every prefix with `prefix` and `term` arguments.
 
-Also a `comment` event can be enabled through the options object of the N3.StreamParser constructor using: `comments: true`.
+A dedicated `comment` event may be enabled by setting `comments: true` in the N3.StreamParser constructor.
 
 ## Writing
 

--- a/src/N3Lexer.js
+++ b/src/N3Lexer.js
@@ -68,7 +68,7 @@ export default class N3Lexer {
       this._n3Mode = options.n3 !== false;
     }
     // Don't output comment tokens by default
-    this._comments = !!options.comments;
+    this.comments = !!options.comments;
     // Cache the last tested closing position of long literals
     this._literalClosingPos = 0;
   }
@@ -85,7 +85,7 @@ export default class N3Lexer {
       let whiteSpaceMatch, comment;
       while (whiteSpaceMatch = this._newline.exec(input)) {
         // Try to find a comment
-        if (this._comments && (comment = this._comment.exec(whiteSpaceMatch[0])))
+        if (this.comments && (comment = this._comment.exec(whiteSpaceMatch[0])))
           emitToken('comment', comment[1], '', this._line, whiteSpaceMatch[0].length);
         // Advance the input
         input = input.substr(whiteSpaceMatch[0].length, input.length);
@@ -101,7 +101,7 @@ export default class N3Lexer {
         // If the input is finished, emit EOF
         if (inputFinished) {
           // Try to find a final comment
-          if (this._comments && (comment = this._comment.exec(input)))
+          if (this.comments && (comment = this._comment.exec(input)))
             emitToken('comment', comment[1], '', this._line, input.length);
           input = null;
           emitToken('eof', '', '', this._line, 0);
@@ -462,11 +462,6 @@ export default class N3Lexer {
   }
 
   // ## Public methods
-
-  // ### `setComments` enables or disables creating a token per comment using a boolean.
-  setComments(enable) {
-    this._comments = enable;
-  }
 
   // ### `tokenize` starts the transformation of an N3 document into an array of tokens.
   // The input can be a string or a stream.

--- a/src/N3Lexer.js
+++ b/src/N3Lexer.js
@@ -463,6 +463,11 @@ export default class N3Lexer {
 
   // ## Public methods
 
+  // ### `setComments` enables or disables creating a token per comment using a boolean.
+  setComments(enable) {
+    this._comments = enable;
+  }
+
   // ### `tokenize` starts the transformation of an N3 document into an array of tokens.
   // The input can be a string or a stream.
   tokenize(input, callback) {

--- a/src/N3Parser.js
+++ b/src/N3Parser.js
@@ -1050,9 +1050,8 @@ export default class N3Parser {
     let processNextToken = (error, token) => {
       if (error !== null)
         this._callback(error), this._callback = noop;
-      else if (this._readCallback) {
+      else if (this._readCallback)
         this._readCallback = this._readCallback(token);
-      }
     };
 
     // Enable checking for comments on every token when a commentCallback has been set
@@ -1064,12 +1063,10 @@ export default class N3Parser {
         if (error !== null)
           this._callback(error), this._callback = noop;
         else if (this._readCallback) {
-          if (token.type === 'comment') {
+          if (token.type === 'comment')
             onComment(token.value);
-          }
-          else {
+          else
             this._readCallback = this._readCallback(token);
-          }
         }
       };
     }

--- a/src/N3Parser.js
+++ b/src/N3Parser.js
@@ -1023,8 +1023,8 @@ export default class N3Parser {
     this._inversePredicate = false;
     this._quantified = Object.create(null);
 
-    // If the parser is requested to provide comments through a callback, override the current lexer’s configuration parameter to emit comments
-    if (commentCallback) this._lexer._comments = true;
+    // If the parser is requested to provide comments through a callback, ask the lexer to return comments as tokens as well (disabled by default)
+    if (commentCallback) this._lexer.setComments(true);
 
     // Parse synchronously if no quad callback is given
     if (!quadCallback) {

--- a/src/N3Parser.js
+++ b/src/N3Parser.js
@@ -1057,7 +1057,7 @@ export default class N3Parser {
     // Enable checking for comments on every token when a commentCallback has been set
     if (onComment) {
       // Enable the lexer to return comments as tokens first (disabled by default)
-      this._lexer.setComments(true);
+      this._lexer.comments = true;
       // Patch the processNextToken function
       processNextToken = (error, token) => {
         if (error !== null)

--- a/src/N3StreamParser.js
+++ b/src/N3StreamParser.js
@@ -23,6 +23,7 @@ export default class N3StreamParser extends Transform {
       (error, quad) => { error && this.emit('error', error) || quad && this.push(quad); },
       // Emit prefixes through the `prefix` event
       (prefix, uri) => { this.emit('prefix', prefix, uri); },
+      comment => { this.emit('comment', comment); },
     );
 
     // Implement Transform methods through parser callbacks

--- a/src/N3StreamParser.js
+++ b/src/N3StreamParser.js
@@ -11,6 +11,17 @@ export default class N3StreamParser extends Transform {
     // Set up parser with dummy stream to obtain `data` and `end` callbacks
     const parser = new N3Parser(options);
     let onData, onEnd;
+
+    const callbacks = {
+        // Handle quads by pushing them down the pipeline
+      onQuad: (error, quad) => { error && this.emit('error', error) || quad && this.push(quad); },
+        // Emit prefixes through the `prefix` event
+      onPrefix: (prefix, uri) => { this.emit('prefix', prefix, uri); },
+    };
+
+    if (options && options.comments)
+      callbacks.onComment = comment => { this.emit('comment', comment); };
+
     parser.parse({
       on: (event, callback) => {
         switch (event) {
@@ -18,13 +29,7 @@ export default class N3StreamParser extends Transform {
         case 'end':   onEnd = callback; break;
         }
       },
-    }, {
-      // Handle quads by pushing them down the pipeline
-      onQuad: (error, quad) => { error && this.emit('error', error) || quad && this.push(quad); },
-      // Emit prefixes through the `prefix` event
-      onPrefix: (prefix, uri) => { this.emit('prefix', prefix, uri); },
-      onComment: comment => { this.emit('comment', comment); },
-    });
+    }, callbacks);
 
     // Implement Transform methods through parser callbacks
     this._transform = (chunk, encoding, done) => { onData(chunk); done(); };

--- a/src/N3StreamParser.js
+++ b/src/N3StreamParser.js
@@ -18,13 +18,13 @@ export default class N3StreamParser extends Transform {
         case 'end':   onEnd = callback; break;
         }
       },
-    },
+    }, {
       // Handle quads by pushing them down the pipeline
-      (error, quad) => { error && this.emit('error', error) || quad && this.push(quad); },
+      onQuad: (error, quad) => { error && this.emit('error', error) || quad && this.push(quad); },
       // Emit prefixes through the `prefix` event
-      (prefix, uri) => { this.emit('prefix', prefix, uri); },
-      comment => { this.emit('comment', comment); },
-    );
+      onPrefix: (prefix, uri) => { this.emit('prefix', prefix, uri); },
+      onComment: comment => { this.emit('comment', comment); },
+    });
 
     // Implement Transform methods through parser callbacks
     this._transform = (chunk, encoding, done) => { onData(chunk); done(); };

--- a/test/N3Parser-test.js
+++ b/test/N3Parser-test.js
@@ -1646,6 +1646,12 @@ describe('Parser', () => {
       shouldNotParse(parser, '<<_:a <http://ex.org/b> _:b <http://ex.org/b>>> <http://ex.org/b> "c" .',
         'Expected >> to follow "_:b0_b" on line 1.'),
     );
+
+    it(
+      'should not parse nested quads with comments',
+      shouldNotParseWithComments(parser, '#comment1\n<<_:a <http://ex.org/b> _:b <http://ex.org/b>>> <http://ex.org/b> "c" .',
+        'Expected >> to follow "_:b0_b" on line 2.'),
+    );
   });
 
   describe('A Parser instance for the TriG format', () => {
@@ -3115,6 +3121,30 @@ function shouldNotParse(parser, input, expectedError, expectedContext) {
       else if (!triple)
         done(new Error(`Expected error ${expectedError}`));
     });
+  };
+}
+
+function shouldNotParseWithComments(parser, input, expectedError, expectedContext) {
+  // Shift parameters if necessary
+  if (!parser.call)
+    expectedContext = expectedError, expectedError = input, input = parser, parser = Parser;
+
+  return function (done) {
+    new parser({ baseIRI: BASE_IRI }).parse(input, (error, triple) => {
+      if (error) {
+        expect(triple).toBeFalsy();
+        expect(error).toBeInstanceOf(Error);
+        expect(error.message).toEqual(expectedError);
+        if (expectedContext) expect(error.context).toEqual(expectedContext);
+        done();
+      }
+      else if (!triple)
+        done(new Error(`Expected error ${expectedError}`));
+    },
+    null,
+    // Enables comment mode
+    () => {},
+    );
   };
 }
 

--- a/test/N3Parser-test.js
+++ b/test/N3Parser-test.js
@@ -41,6 +41,20 @@ describe('Parser', () => {
                   ['g', 'h', 'i']),
     );
 
+    it(
+      'should parse three triples with comments if no comment callback is set',
+      shouldParse('<a> <b> #comment2\n <c> . \n<d> <e> <f>.\n<g> <h> <i>.',
+                  ['a', 'b', 'c'],
+                  ['d', 'e', 'f'],
+                  ['g', 'h', 'i']),
+    );
+
+    it(
+      'should callback comments when a comment allback is set',
+      shouldCallbackComments('#comment1\n<a> <b> #comment2\n <c> . \n<d> <e> <f>.\n<g> <h> <i>.',
+                  'comment1', 'comment2'),
+    );
+
     it('should parse a triple with a literal', shouldParse('<a> <b> "string".',
                 ['a', 'b', '"string"']));
 
@@ -3035,6 +3049,28 @@ function shouldParse(parser, input) {
       else
         expect(toSortedJSON(results)).toBe(toSortedJSON(items)), done();
     });
+  };
+}
+
+
+function shouldCallbackComments(parser, input) {
+  const expected = Array.prototype.slice.call(arguments, 1);
+  // Shift parameters as necessary
+  if (parser.call)
+    expected.shift();
+  else
+    input = parser, parser = Parser;
+
+  return function (done) {
+    const items = expected;
+    const comments = [];
+    new parser({ baseIRI: BASE_IRI }).parse(input, (error, triple) => {
+      if (!triple) {
+        // Marks the end
+        expect(JSON.stringify(comments)).toBe(JSON.stringify(items));
+        done();
+      }
+    }, null, comment => { comments.push(comment); });
   };
 }
 

--- a/test/N3Parser-test.js
+++ b/test/N3Parser-test.js
@@ -50,7 +50,7 @@ describe('Parser', () => {
     );
 
     it(
-      'should callback comments when a comment allback is set',
+      'should callback comments when a comment callback is set',
       shouldCallbackComments('#comment1\n<a> <b> #comment2\n <c> . \n<d> <e> <f>.\n<g> <h> <i>.',
                   'comment1', 'comment2'),
     );

--- a/test/N3StreamParser-test.js
+++ b/test/N3StreamParser-test.js
@@ -64,6 +64,16 @@ describe('StreamParser', () => {
                          { a: new NamedNode('http://a.org/#'), b: new NamedNode('http://b.org/#') }),
     );
 
+    it(
+      'parses two triples with comments',
+      shouldParse(['#comment1\n<a> <b> #comment2\n#comment3\n <c>. <d> <e> <f>.'], 2),
+    );
+
+    it(
+      'emits "comment" events',
+      shouldEmitComments(['#comment1\n<a> <b> #comment2\n#comment3\n <c>. <d> <e> <f>.'], ['comment1', 'comment2', 'comment3']),
+    );
+
     it('passes an error', () => {
       const input = new Readable(), parser = new StreamParser();
       let error = null;
@@ -121,6 +131,22 @@ function shouldEmitPrefixes(chunks, expectedPrefixes) {
     parser.on('error', done);
     parser.on('end', error => {
       expect(prefixes).toEqual(expectedPrefixes);
+      done(error);
+    });
+  };
+}
+
+function shouldEmitComments(chunks, expectedComments) {
+  return function (done) {
+    const comments = [],
+        parser = new StreamParser(),
+        inputStream = new ArrayReader(chunks);
+    inputStream.pipe(parser);
+    parser.on('data', () => {});
+    parser.on('comment', comment => { comments.push(comment); });
+    parser.on('error', done);
+    parser.on('end', error => {
+      expect(comments).toEqual(expectedComments);
       done(error);
     });
   };

--- a/test/N3StreamParser-test.js
+++ b/test/N3StreamParser-test.js
@@ -74,6 +74,11 @@ describe('StreamParser', () => {
       shouldEmitComments(['#comment1\n<a> <b> #comment2\n#comment3\n <c>. <d> <e> <f>.'], ['comment1', 'comment2', 'comment3']),
     );
 
+    it(
+      'emits "comment" events',
+      shouldNotEmitCommentsWhenNotEnabled(['#comment1\n<a> <b> #comment2\n#comment3\n <c>. <d> <e> <f>.'], ['comment1', 'comment2', 'comment3']),
+    );
+
     it('passes an error', () => {
       const input = new Readable(), parser = new StreamParser();
       let error = null;
@@ -139,7 +144,7 @@ function shouldEmitPrefixes(chunks, expectedPrefixes) {
 function shouldEmitComments(chunks, expectedComments) {
   return function (done) {
     const comments = [],
-        parser = new StreamParser(),
+        parser = new StreamParser({ comments: true }),
         inputStream = new ArrayReader(chunks);
     inputStream.pipe(parser);
     parser.on('data', () => {});
@@ -148,6 +153,20 @@ function shouldEmitComments(chunks, expectedComments) {
     parser.on('end', error => {
       expect(comments).toEqual(expectedComments);
       done(error);
+    });
+  };
+}
+
+function shouldNotEmitCommentsWhenNotEnabled(chunks, expectedComments) {
+  return function (done) {
+    const parser = new StreamParser(),
+        inputStream = new ArrayReader(chunks);
+    inputStream.pipe(parser);
+    parser.on('data', () => {});
+    parser.on('comment', comment => { done(new Error('Should not emit comments but it did')); });
+    parser.on('error', done);
+    parser.on('end', error => {
+      done();
     });
   };
 }


### PR DESCRIPTION
For my project I need access to the comments in a turtle (etc.) file.

This pull request:
 1. extends the N3Parser.parse function with an optional commentCallback. If set, the lexer’s configuration will be overridden to also provide comment tokens.
 2. extends the N3StreamParser with a "comment" event in a separate commit
