### PR TITLE
perf: perform matching over indices

### DIFF
--- a/src/N3Store.js
+++ b/src/N3Store.js
@@ -1027,7 +1027,12 @@ export default class N3Store {
 }
 
 /**
- * Performs matching over the store indexes
+ * Returns a subset of the `index` with that part of the index
+ * matching the `ids` array. `ids` contains 3 elements that are
+ * either numerical ids; or `null`.
+ *
+ * `false` is returned when there are no matching indices; this should
+ * *not* be set as the value for an index.
  */
 function indexMatch(index, ids, depth = 0) {
   const ind = ids[depth];

--- a/test/N3Store-test.js
+++ b/test/N3Store-test.js
@@ -2,6 +2,7 @@ import {
   Store,
   termFromId, termToId,
   EntityIndex,
+  DataFactory,
 } from '../src';
 import {
   NamedNode,
@@ -12,6 +13,8 @@ import {
 import namespaces from '../src/IRIs';
 import { Readable } from 'readable-stream';
 import { arrayifyStream } from 'arrayify-stream';
+
+const { namedNode } = DataFactory;
 
 describe('Store', () => {
   describe('The Store export', () => {
@@ -695,6 +698,9 @@ describe('Store', () => {
 
           expect(nextDataset.has(new Quad('s2', 'p1', 'o1'))).toBe(true);
           expect(nextDataset.has(new Quad('s2', 'p2', 'o2'))).toBe(true);
+          expect(nextDataset.match(namedNode('s2'), null, null).has(new Quad('s2', 'p2', 'o2'))).toBe(true);
+          expect(nextDataset.match(null, namedNode('p2'), null).has(new Quad('s2', 'p2', 'o2'))).toBe(true);
+          expect(nextDataset.match(null, null, namedNode('o2')).has(new Quad('s2', 'p2', 'o2'))).toBe(true);
 
           nextDataset.delete(new Quad('s2', 'p1', 'o1'));
           nextDataset.delete(new Quad('s2', 'p2', 'o2'));

--- a/test/N3Store-test.js
+++ b/test/N3Store-test.js
@@ -701,6 +701,11 @@ describe('Store', () => {
           expect(nextDataset.match(namedNode('s2'), null, null).has(new Quad('s2', 'p2', 'o2'))).toBe(true);
           expect(nextDataset.match(null, namedNode('p2'), null).has(new Quad('s2', 'p2', 'o2'))).toBe(true);
           expect(nextDataset.match(null, null, namedNode('o2')).has(new Quad('s2', 'p2', 'o2'))).toBe(true);
+          expect(nextDataset.size).toBe(2);
+          nextDataset.add(new Quad('s2', 'p1', 'onew'));
+          expect(nextDataset.size).toBe(3);
+          nextDataset.add(new Quad('s2', 'p1', 'onew'));
+          expect(nextDataset.size).toBe(3);
 
           nextDataset.delete(new Quad('s2', 'p1', 'o1'));
           nextDataset.delete(new Quad('s2', 'p2', 'o2'));


### PR DESCRIPTION
When creating a new dataset with `#match` do this over the indices rather than requiring the RDF/JS layer

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced a new function for advanced recursive matching in the dataset processing, enhancing the ability to match identifiers within store indexes.

- **Bug Fixes**
	- Improved error handling when translating IRIs into internal IDs, ensuring more reliable dataset processing.

- **Tests**
	- Expanded test suite to include precise matching checks for dataset quads, increasing the robustness and reliability of the tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->