### PR TITLE
fix: fix implementation of #read when size=0

### DIFF
--- a/src/N3Store.js
+++ b/src/N3Store.js
@@ -430,7 +430,7 @@ export default class N3Store {
 
     const iterable = this.readQuads(subject, predicate, object, graph);
     stream._read = size => {
-      while (size-- > 0) {
+      while (--size >= 0) {
         const { done, value } = iterable.next();
         if (done) {
           stream.push(null);
@@ -1053,7 +1053,7 @@ class DatasetCoreAndReadableStream extends Readable {
     if (size > 0 && !this[ITERATOR])
       this[ITERATOR] = this[Symbol.iterator]();
     const iterable = this[ITERATOR];
-    while (size-- > 0) {
+    while (--size >= 0) {
       const { done, value } = iterable.next();
       if (done) {
         this.push(null);


### PR DESCRIPTION
No items should be pushed to the buffer when `size == 0`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Adjusted loop control structure to improve data processing in edge cases, potentially enhancing the handling of zero or small sizes.

- **Refactor**
	- Modified loop termination conditions for better iteration behavior when reading from an iterable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->