### PR TITLE
feat: make return quads return a boolean indicating if all removed quads were in store

### DIFF
--- a/src/N3Store.js
+++ b/src/N3Store.js
@@ -446,9 +446,12 @@ export default class N3Store {
   }
 
   // ### `removeQuads` removes multiple quads from the store
+  // returns `true` if all quads were removed, `false` if some were not found
   removeQuads(quads) {
+    let removed = quads.length >= 0;
     for (let i = 0; i < quads.length; i++)
-      this.removeQuad(quads[i]);
+      removed = this.removeQuad(quads[i]) && removed;
+    return removed;
   }
 
   // ### `remove` removes a stream of quads from the store

--- a/test/N3Store-test.js
+++ b/test/N3Store-test.js
@@ -121,7 +121,7 @@ describe('Store', () => {
 
       expect(store.addQuad('_:b0', '_:b1', '_:b2')).toBe(true);
       expect(store.createBlankNode().value).toEqual('b3');
-      store.removeQuads(store.getQuads());
+      expect(store.removeQuads(store.getQuads())).toBe(true);
     });
 
     it('should be able to generate named blank nodes', () => {
@@ -135,7 +135,10 @@ describe('Store', () => {
         store.addQuad(store.createBlankNode('x'), new NamedNode('b'), new NamedNode('c')),
       ).toBe(true);
       shouldIncludeAll(store.getQuads(null, new NamedNode('b')), ['_:x', 'b', 'c'])();
-      store.removeQuads(store.getQuads());
+      const quads = [...store.getQuads()];
+      expect(store.removeQuads([quad(namedNode('p'), namedNode('q'), namedNode('r'))])).toBe(false);
+      expect(store.removeQuads(quads)).toBe(true);
+      expect(store.removeQuads(quads)).toBe(false);
     });
   });
 


### PR DESCRIPTION
Closes #479 

Technically a breaking change, may not be the right design choice. Lets discuss further in issue first.

