### PR TITLE
fix: allow import to be treated as `Promise<Store>` per the RDF/JS spec

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "buffer": "^6.0.3",
+        "events": "^3.3.0",
         "queue-microtask": "^1.1.2",
         "readable-stream": "^4.0.0"
       },
@@ -5526,6 +5527,7 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
       "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.8.x"
       }

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   ],
   "dependencies": {
     "buffer": "^6.0.3",
+    "events": "^3.3.0",
     "queue-microtask": "^1.1.2",
     "readable-stream": "^4.0.0"
   },

--- a/src/N3Store.js
+++ b/src/N3Store.js
@@ -411,8 +411,8 @@ export default class N3Store {
 
   /**
    * `import` adds a stream of quads to the store
-   * 
-   * @returns {EventEmitter & Promise<Store & EventEmitter>} A proxy object that acts as both an EventEmitter 
+   *
+   * @returns {EventEmitter & Promise<Store & EventEmitter>} A proxy object that acts as both an EventEmitter
    * (for backward compatibility) and a Promise that resolves to the store when the stream is complete.
    */
   import(stream) {

--- a/src/N3Store.js
+++ b/src/N3Store.js
@@ -1,4 +1,5 @@
 // **N3Store** objects store N3 quads by graph in memory.
+import EventEmitter from 'events';
 import { Readable } from 'readable-stream';
 import { default as N3DataFactory, termToId, termFromId } from './N3DataFactory';
 import namespaces from './IRIs';
@@ -410,8 +411,57 @@ export default class N3Store {
 
   // ### `import` adds a stream of quads to the store
   import(stream) {
+    // Add quads to the store as they arrive
     stream.on('data', quad => { this.addQuad(quad); });
-    return stream;
+
+    // Create a promise that resolves when the stream ends
+    const promise = new Promise((resolve, reject) => {
+      // Create proxy that combines N3Store with EventEmitter capabilities
+      const storeProxy = new Proxy(this, {
+        get(target, prop, receiver) {
+          if (prop in EventEmitter.prototype) {
+            return Reflect.get(stream, prop, receiver);
+          }
+          return Reflect.get(target, prop, receiver);
+        },
+      });
+
+      // Check if stream is already closed/ended
+      if (stream.readableEnded || stream.destroyed || stream.readable === false || stream.closed || stream.ended) {
+        // Resolve immediately if stream is already closed
+        resolve(storeProxy);
+      }
+      else {
+          // Otherwise, wait for end/error events
+          // eslint-disable-next-line func-style
+        const onEnd = () => {
+            // eslint-disable-next-line no-use-before-define
+          stream.removeListener('error', onError);
+          resolve(storeProxy);
+        };
+
+          // eslint-disable-next-line func-style
+        const onError = err => {
+          stream.removeListener('end', onEnd);
+          reject(err);
+        };
+
+        stream.once('end', onEnd);
+        stream.once('error', onError);
+      }
+    });
+
+    // Return a proxy that acts as both stream and promise without mutating the stream object
+    return new Proxy(stream, {
+      get(target, prop) {
+      // Forward Promise methods to the promise object
+        if (prop === 'then' || prop === 'catch' || prop === 'finally') {
+          return promise[prop].bind(promise);
+        }
+      // All other properties and methods are from the stream
+        return target[prop];
+      },
+    });
   }
 
   // ### `removeQuad` removes a quad from the store if it exists

--- a/src/N3Store.js
+++ b/src/N3Store.js
@@ -409,7 +409,12 @@ export default class N3Store {
     return !this.readQuads(subjectOrQuad, predicate, object, graph).next().done;
   }
 
-  // ### `import` adds a stream of quads to the store
+  /**
+   * `import` adds a stream of quads to the store
+   * 
+   * @returns {EventEmitter & Promise<Store & EventEmitter>} A proxy object that acts as both an EventEmitter 
+   * (for backward compatibility) and a Promise that resolves to the store when the stream is complete.
+   */
   import(stream) {
     // Add quads to the store as they arrive
     stream.on('data', quad => { this.addQuad(quad); });

--- a/src/N3Store.js
+++ b/src/N3Store.js
@@ -419,10 +419,7 @@ export default class N3Store {
       // Create proxy that combines N3Store with EventEmitter capabilities
       const storeProxy = new Proxy(this, {
         get(target, prop, receiver) {
-          if (prop in EventEmitter.prototype) {
-            return Reflect.get(stream, prop, receiver);
-          }
-          return Reflect.get(target, prop, receiver);
+          return Reflect.get(prop in EventEmitter.prototype ? stream : target, prop, receiver);
         },
       });
 


### PR DESCRIPTION
Uses a `Proxy` so that the return of `import` has the type `EventEmitter & Promise<Store & EventEmitter>` making it compatible both with the:
 - Existing return type of `import` (`EventEmitter`)
 - RDF/JS return type of `import` (`Promise<Store>`)
 
 cc @RubenVerborgh 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new dependency for enhanced event handling.
	- Improved the asynchronous data import process with robust event handling and promise resolution.
- **Tests**
	- Expanded test coverage to validate seamless stream processing, proper event handling, and reliable error management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->