### PR TITLE
fix: align `some` with RDF/JS definition of `Dataset`

### DIFF
--- a/src/N3Store.js
+++ b/src/N3Store.js
@@ -601,7 +601,7 @@ export default class N3Store {
   // Setting any field to `undefined` or `null` indicates a wildcard.
   some(callback, subject, predicate, object, graph) {
     for (const quad of this.readQuads(subject, predicate, object, graph))
-      if (callback(quad))
+      if (callback(quad, this))
         return true;
     return false;
   }

--- a/test/N3Store-test.js
+++ b/test/N3Store-test.js
@@ -2444,6 +2444,18 @@ describe('Store', () => {
       it('should return false on the empty set', () => {
         expect(empty.some(quad => true)).toBe(false);
       });
+
+      it('should return true if any quad passes the test with a graph', () => {
+        expect(storeb.some(quad => quad.subject.value === 's1')).toBe(true);
+        expect(storeb.some(quad => quad.subject.value === 's2')).toBe(false);
+      });
+
+      it('should have the store as the second argument of the callback', () => {
+        expect(store1.some((_, store) => {
+          expect(store.equals(store1)).toBe(true);
+          return true;
+        })).toBe(true);
+      });
     });
 
     describe('#every', () => {


### PR DESCRIPTION
Passes `this` as the second argument to the `some` callback to align with the RDF/JS definition of `Dataset#some`.

cc @RubenVerborgh 