### PR TITLE
fix: allow datasets to be inputs to stores to align with RDF/JS `DatasetFactory` interface

### DIFF
--- a/src/N3Store.js
+++ b/src/N3Store.js
@@ -174,9 +174,8 @@ export default class N3Store {
     this._termToNewNumericId = this._entityIndex._termToNewNumericId.bind(this._entityIndex);
 
     // Add quads if passed
-    if (quads) {
+    if (quads)
       this.addAll(quads);
-    }
   }
 
   // ## Public properties

--- a/src/N3Store.js
+++ b/src/N3Store.js
@@ -163,7 +163,7 @@ export default class N3Store {
     this._graphs = Object.create(null);
 
     // Shift parameters if `quads` is not given
-    if (!options && quads && !quads[0])
+    if (!options && quads && !quads[0] && !(typeof quads.match === 'function'))
       options = quads, quads = null;
     options = options || {};
     this._factory = options.factory || N3DataFactory;
@@ -174,8 +174,16 @@ export default class N3Store {
     this._termToNewNumericId = this._entityIndex._termToNewNumericId.bind(this._entityIndex);
 
     // Add quads if passed
-    if (quads)
-      this.addQuads(quads);
+    if (quads) {
+      if (Array.isArray(quads)) {
+        this.addQuads(quads);
+      }
+      else {
+        for (const quad of quads) {
+          this.addQuad(quad);
+        }
+      }
+    }
   }
 
   // ## Public properties

--- a/src/N3Store.js
+++ b/src/N3Store.js
@@ -175,14 +175,7 @@ export default class N3Store {
 
     // Add quads if passed
     if (quads) {
-      if (Array.isArray(quads)) {
-        this.addQuads(quads);
-      }
-      else {
-        for (const quad of quads) {
-          this.addQuad(quad);
-        }
-      }
+      this.addAll(quads);
     }
   }
 

--- a/test/N3Store-test.js
+++ b/test/N3Store-test.js
@@ -2463,6 +2463,16 @@ describe('Store', () => {
       });
     });
   });
+
+  it('should initialize the store correctly with a another store', () => {
+    const quads = new Store([
+      new Quad(new NamedNode('s1'), new NamedNode('p1'), new NamedNode('o1')),
+      new Quad(new NamedNode('s1'), new NamedNode('p1'), new NamedNode('o2')),
+    ]);
+    const store = new Store(quads);
+    expect(store.size).toEqual(2);
+    expect(store.getQuads()).toHaveLength(2);
+  });
 });
 
 describe('EntityIndex', () => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Enhanced the store’s initialization process to better handle the `quads` parameter and renamed the method for adding quads to improve clarity.
- **Tests**
  - Added a new test to confirm that the store initializes correctly when provided with multiple data entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->