### PR TITLE
Update reasoning snippet in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,7 +402,7 @@ const dataset = new Store(/* Dataset */)
 
 // Applies the rules to the store; mutating it
 const reasoner = new Reasoner(store);
-reasoner.reason(rules);
+reasoner.reason(rulesDataset);
 ```
 
 **Note**: N3.js currently only supports rules with [Basic Graph Patterns](https://www.w3.org/TR/sparql11-query/#BasicGraphPattern) in the premise and conclusion. Built-ins and backward-chaining are *not* supported. For an RDF/JS reasoner that supports all Notation3 reasoning features, see [eye-js](https://github.com/eyereasoner/eye-js/).


### PR DESCRIPTION
```ts
 reason(rules: Rule[] | RDF.DatasetCore<RDF.Quad>): void;
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Updated README examples to reflect the new rules input format, showing how to parse rules into a dataset before running reasoning.
  - Clarified usage steps to help users adapt to the updated workflow.
  - Improved guidance to reduce confusion when migrating from string-based rules input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->