### PR TITLE
RDF Messages support added

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,9 +98,11 @@ parser.parse(tomAndJerry,
   });
 ```
 The callback's first argument is an optional error value, the second is a quad.
+The fourth argument is an optional `messageCounter`, which is only defined when parsing in RDF message mode.
 If there are no more quads,
 the callback is invoked one last time with `null` for `quad`
 and a hash of prefixes as third argument.
+When parsing in RDF message mode, that final callback also receives the current `messageCounter`.
 <br>
 
 Alternatively, an object can be supplied, where `onQuad`, `onPrefix` and `onComment` are used to listen for `quads`, `prefixes` and `comments` as follows:
@@ -108,8 +110,9 @@ Alternatively, an object can be supplied, where `onQuad`, `onPrefix` and `onComm
 const parser = new N3.Parser();
 
 parser.parse(tomAndJerry, {
-  // onQuad (required) accepts a listener of type (quad: RDF.Quad) => void
-  onQuad: (err, quad) => { console.log(quad); },
+  // onQuad (required) accepts a listener of type
+  // (err: Error | null, quad: RDF.Quad | null, prefixes?: Record<string, string>, messageCounter?: number) => void
+  onQuad: (err, quad, prefixes, messageCounter) => { console.log(quad, prefixes, messageCounter); },
   // onPrefix (optional) accepts a listener of type (prefix: string, iri: NamedNode) => void
   onPrefix: (prefix, iri) => { console.log(prefix, 'expands to', iri.value); },
   // onComment (optional) accepts a listener of type (comment: string) => void
@@ -202,7 +205,11 @@ A dedicated `comment` event can be enabled by setting `comments: true` in the N3
 
 N3.js can parse and write [RDF Message Logs](https://w3c-cg.github.io/rsp/spec/messages) for Turtle, TriG, N-Triples, and N-Quads.
 Enable message parsing with `messages: true`, or use a `-messages` version label such as `VERSION "1.2-messages"`.
-The parser still emits every quad through `onQuad`, and additionally calls `onMessage` with the quads of each completed message.
+The parser emits every quad through `onQuad`, and in message mode each callback also receives a `messageCounter`.
+At EOF, `onQuad` is called once with `quad = null`, `prefixes`, and the final `messageCounter`, so empty trailing messages can be detected.
+
+`onMessage` is a convenience callback for consumers that can buffer quads in memory.
+Internally it listens to `onQuad` and groups quads by `messageCounter`.
 
 ```JavaScript
 const messageLog = `VERSION "1.2-messages"
@@ -213,8 +220,15 @@ ex:message2 ex:text "Goodbye" .`;
 
 const parser = new N3.Parser();
 parser.parse(messageLog, {
-  onQuad: (error, quad) => { if (quad) console.log('quad', quad); },
-  onMessage: quads => { console.log('message with', quads.length, 'quads'); },
+  onQuad: (error, quad, prefixes, messageCounter) => {
+    if (quad)
+      console.log('quad', messageCounter, quad);
+    else
+      console.log('end', messageCounter, prefixes);
+  },
+  onMessage: (quads, messageCounter) => {
+    console.log('message', messageCounter, 'with', quads.length, 'quads');
+  },
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -198,6 +198,47 @@ function SlowConsumer() {
 A dedicated `prefix` event signals every prefix with `prefix` and `term` arguments.
 A dedicated `comment` event can be enabled by setting `comments: true` in the N3.StreamParser constructor.
 
+### RDF Messages
+
+N3.js can parse and write [RDF Message Logs](https://w3c-cg.github.io/rsp/spec/messages) for Turtle, TriG, N-Triples, and N-Quads.
+Enable message parsing with `messages: true`, or use a `-messages` version label such as `VERSION "1.2-messages"`.
+The parser still emits every quad through `onQuad`, and additionally calls `onMessage` with the quads of each completed message.
+
+```JavaScript
+const messageLog = `VERSION "1.2-messages"
+PREFIX ex: <http://example.org/>
+ex:message1 ex:text "Hello" .
+@message .
+ex:message2 ex:text "Goodbye" .`;
+
+const parser = new N3.Parser();
+parser.parse(messageLog, {
+  onQuad: (error, quad) => { if (quad) console.log('quad', quad); },
+  onMessage: quads => { console.log('message with', quads.length, 'quads'); },
+});
+```
+
+`N3.StreamParser` emits a `message` event for the same purpose:
+
+```JavaScript
+const streamParser = new N3.StreamParser({ messages: true });
+streamParser.on('message', quads => { console.log('message', quads); });
+```
+
+To serialize messages, call `addMessage` with the quads of one message.
+For Turtle and TriG, N3.js writes the old-style `@message .` delimiter; for N-Triples and N-Quads, it writes `MESSAGE`.
+
+```JavaScript
+const writer = new N3.Writer({ prefixes: { ex: 'http://example.org/' } });
+writer.addMessage([
+  quad(namedNode('http://example.org/radio1'), namedNode('http://example.org/plays'), literal('Never Gonna Give You Up')),
+]);
+writer.addMessage([
+  quad(namedNode('http://example.org/radio1'), namedNode('http://example.org/plays'), literal('My Way')),
+]);
+writer.end((error, result) => { console.log(result); });
+```
+
 ## Writing
 
 ### From quads to a string

--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ streamParser.on('message', quads => { console.log('message', quads); });
 ```
 
 To serialize messages, call `addMessage` with the quads of one message.
-For Turtle and TriG, N3.js writes the old-style `@message .` delimiter; for N-Triples and N-Quads, it writes `MESSAGE`.
+N3.js always writes the Turtle-style `@message .` delimiter for message boundaries.
 
 ```JavaScript
 const writer = new N3.Writer({ prefixes: { ex: 'http://example.org/' } });

--- a/src/N3Lexer.js
+++ b/src/N3Lexer.js
@@ -26,6 +26,7 @@ const lineModeRegExps = {
   _comment: true,
   _whitespace: true,
   _endOfFile: true,
+  _keyword: true,
 };
 const invalidRegExp = /$0^/;
 
@@ -47,7 +48,7 @@ export default class N3Lexer {
     this._number = /^[\-+]?(?:(\d+\.\d*|\.?\d+)[eE][\-+]?|\d*(\.)?)\d+(?=\.?[,;:\s#()\[\]\{\}"'<>])/;
     this._boolean = /^(?:true|false)(?=[.,;\s#()\[\]\{\}"'<>])/;
     this._atKeyword = /^@[a-z]+(?=[\s#<:])/i;
-    this._keyword = /^(?:PREFIX|BASE|VERSION|GRAPH)(?=[\s#<])/i;
+    this._keyword = /^(?:PREFIX|BASE|VERSION|GRAPH|MESSAGE)(?=$|[\s#<])/i;
     this._shortPredicates = /^a(?=[\s#()\[\]\{\}"'<>])/;
     this._newline = /^[ \t]*(?:#[^\n\r]*)?(?:\r\n|\n|\r)[ \t]*/;
     this._comment = /#([^\n\r]*)/;
@@ -277,6 +278,8 @@ export default class N3Lexer {
       case 'g':
       case 'V':
       case 'v':
+      case 'M':
+      case 'm':
         // Try to find a SPARQL-style keyword
         if (match = this._keyword.exec(input))
           type = match[0].toUpperCase();

--- a/src/N3Parser.js
+++ b/src/N3Parser.js
@@ -819,8 +819,10 @@ export default class N3Parser {
     if ((token.end - token.start) !== token.value.length + 2)
       return this._error('Version declarations must use single quotes', token);
     this._versionCallback(token.value);
-    if (/-messages$/.test(token.value))
+    if (/-messages$/.test(token.value) && !this._messageMode) {
       this._messageMode = true;
+      this._resetMessageBlankNodePrefix();
+    }
     if (!this._isValidVersion(token.value))
       return this._error(`Detected unsupported version: "${token.value}"`, token);
     return this._readDeclarationPunctuation;
@@ -1123,7 +1125,13 @@ export default class N3Parser {
       this._messageOpen = false;
     }
     if (this._messageMode)
-      this._prefixes._ = `b${blankNodePrefix++}_`;
+      this._resetMessageBlankNodePrefix();
+  }
+
+  // ### `_resetMessageBlankNodePrefix` scopes blank node labels to the current RDF message
+  _resetMessageBlankNodePrefix() {
+    const prefix = this._blankNodePrefix ? this._blankNodePrefix.substr(2) : 'b';
+    this._prefixes._ = `${prefix}${blankNodePrefix++}_`;
   }
 
   // ### `_error` emits an error message through the callback
@@ -1254,8 +1262,11 @@ export default class N3Parser {
     this._readCallback = this._readBeforeTopContext;
     this._sparqlStyle = false;
     this._prefixes = Object.create(null);
-    this._prefixes._ = this._blankNodePrefix ? this._blankNodePrefix.substr(2)
-                                             : `b${blankNodePrefix++}_`;
+    if (this._messageMode)
+      this._resetMessageBlankNodePrefix();
+    else
+      this._prefixes._ = this._blankNodePrefix ? this._blankNodePrefix.substr(2)
+                                               : `b${blankNodePrefix++}_`;
     this._prefixCallback = onPrefix || noop;
     this._versionCallback = onVersion || noop;
     this._messageCallback = onMessage || noop;

--- a/src/N3Parser.js
+++ b/src/N3Parser.js
@@ -35,7 +35,8 @@ export default class N3Parser {
     this._blankNodePrefix = typeof options.blankNodePrefix !== 'string' ? '' :
                               options.blankNodePrefix.replace(/^(?!_:)/, '_:');
     this._lexer = options.lexer || new N3Lexer({ lineMode: isLineMode, n3: isN3, isImpliedBy: this._isImpliedBy });
-    this._messageMode = !!options.messages || /-messages$/.test(options.version || '');
+    this._defaultMessageMode = !!options.messages || /-messages$/.test(options.version || '');
+    this._messageMode = this._defaultMessageMode;
     // Disable explicit quantifiers by default
     this._explicitQuantifiers = !!options.explicitQuantifiers;
     // Disable parsing of unsupported versions by default
@@ -1241,6 +1242,7 @@ export default class N3Parser {
 
   // ### `parse` parses the N3 input and emits each parsed quad through the onQuad callback.
   parse(input, quadCallback, prefixCallback, versionCallback) {
+    this._messageMode = this._defaultMessageMode;
     // The second parameter accepts an object { onQuad: ..., onPrefix: ..., onComment: ..., onMessage: ...}
     // As a second and third parameter it still accepts a separate quadCallback and prefixCallback for backward compatibility as well
     let onQuad, onPrefix, onComment, onVersion, onMessage;

--- a/src/N3Parser.js
+++ b/src/N3Parser.js
@@ -35,6 +35,7 @@ export default class N3Parser {
     this._blankNodePrefix = typeof options.blankNodePrefix !== 'string' ? '' :
                               options.blankNodePrefix.replace(/^(?!_:)/, '_:');
     this._lexer = options.lexer || new N3Lexer({ lineMode: isLineMode, n3: isN3, isImpliedBy: this._isImpliedBy });
+    this._messageMode = !!options.messages || /-messages$/.test(options.version || '');
     // Disable explicit quantifiers by default
     this._explicitQuantifiers = !!options.explicitQuantifiers;
     // Disable parsing of unsupported versions by default
@@ -121,6 +122,8 @@ export default class N3Parser {
   _readBeforeTopContext(token) {
     if (this._version && !this._isValidVersion(this._version))
       return this._error(`Detected unsupported version as media type parameter: "${this._version}"`, token);
+    if (this._version && /-messages$/.test(this._version))
+      this._messageMode = true;
     return this._readInTopContext(token);
   }
 
@@ -131,6 +134,7 @@ export default class N3Parser {
     case 'eof':
       if (this._graph !== null)
         return this._error('Unclosed graph', token);
+      this._endMessage();
       delete this._prefixes._;
       return this._callback(null, null, this._prefixes);
     // It could be a prefix declaration
@@ -148,6 +152,11 @@ export default class N3Parser {
       this._sparqlStyle = true;
     case '@version':
       return this._readVersion;
+    // It could be an RDF message delimiter
+    case 'MESSAGE':
+      return this._readMessage(token);
+    case '@message':
+      return this._readMessagePunctuation;
     // It could be a graph
     case '{':
       if (this._supportsNamedGraphs) {
@@ -810,9 +819,29 @@ export default class N3Parser {
     if ((token.end - token.start) !== token.value.length + 2)
       return this._error('Version declarations must use single quotes', token);
     this._versionCallback(token.value);
+    if (/-messages$/.test(token.value))
+      this._messageMode = true;
     if (!this._isValidVersion(token.value))
       return this._error(`Detected unsupported version: "${token.value}"`, token);
     return this._readDeclarationPunctuation;
+  }
+
+  // ### `_readMessage` reads a SPARQL-style RDF message delimiter
+  _readMessage(token) {
+    if (!this._messageMode)
+      return this._error('Unexpected MESSAGE', token);
+    this._endMessage(true);
+    return this._readInTopContext;
+  }
+
+  // ### `_readMessagePunctuation` reads the dot after an old-style RDF message delimiter
+  _readMessagePunctuation(token) {
+    if (!this._messageMode)
+      return this._error('Unexpected @message', token);
+    if (token.type !== '.')
+      return this._error('Expected dot to follow @message', token);
+    this._endMessage(true);
+    return this._readInTopContext;
   }
 
   // ### `_readNamedGraphLabel` reads the label of a named graph
@@ -1078,7 +1107,23 @@ export default class N3Parser {
 
   // ### `_emit` sends a quad through the callback
   _emit(subject, predicate, object, graph) {
-    this._callback(null, this._factory.quad(subject, predicate, object, graph || this.DEFAULTGRAPH));
+    const quad = this._factory.quad(subject, predicate, object, graph || this.DEFAULTGRAPH);
+    if (this._messageMode) {
+      this._messageOpen = true;
+      this._messageQuads.push(quad);
+    }
+    this._callback(null, quad);
+  }
+
+  // ### `_endMessage` sends the current RDF message through the message callback
+  _endMessage(force) {
+    if (this._messageMode && (force || this._messageOpen)) {
+      this._messageCallback(this._messageQuads);
+      this._messageQuads = [];
+      this._messageOpen = false;
+    }
+    if (this._messageMode && !this._blankNodePrefix)
+      this._prefixes._ = `b${blankNodePrefix++}_`;
   }
 
   // ### `_error` emits an error message through the callback
@@ -1188,14 +1233,16 @@ export default class N3Parser {
 
   // ### `parse` parses the N3 input and emits each parsed quad through the onQuad callback.
   parse(input, quadCallback, prefixCallback, versionCallback) {
-    // The second parameter accepts an object { onQuad: ..., onPrefix: ..., onComment: ...}
+    // The second parameter accepts an object { onQuad: ..., onPrefix: ..., onComment: ..., onMessage: ...}
     // As a second and third parameter it still accepts a separate quadCallback and prefixCallback for backward compatibility as well
-    let onQuad, onPrefix, onComment, onVersion;
-    if (quadCallback && (quadCallback.onQuad || quadCallback.onPrefix || quadCallback.onComment || quadCallback.onVersion)) {
+    let onQuad, onPrefix, onComment, onVersion, onMessage;
+    if (quadCallback && (quadCallback.onQuad || quadCallback.onPrefix || quadCallback.onComment ||
+                         quadCallback.onVersion || quadCallback.onMessage)) {
       onQuad = quadCallback.onQuad;
       onPrefix = quadCallback.onPrefix;
       onComment = quadCallback.onComment;
       onVersion = quadCallback.onVersion;
+      onMessage = quadCallback.onMessage;
     }
     else {
       onQuad = quadCallback;
@@ -1211,6 +1258,9 @@ export default class N3Parser {
                                              : `b${blankNodePrefix++}_`;
     this._prefixCallback = onPrefix || noop;
     this._versionCallback = onVersion || noop;
+    this._messageCallback = onMessage || noop;
+    this._messageQuads = [];
+    this._messageOpen = false;
     this._inversePredicate = false;
     this._quantified = Object.create(null);
 
@@ -1282,7 +1332,10 @@ function initDataFactory(parser, factory) {
 }
 N3Parser.SUPPORTED_VERSIONS = [
   '1.2',
+  '1.2-messages',
   '1.2-basic',
+  '1.2-basic-messages',
   '1.1',
+  '1.1-messages',
 ];
 initDataFactory(N3Parser.prototype, N3DataFactory);

--- a/src/N3Parser.js
+++ b/src/N3Parser.js
@@ -135,9 +135,8 @@ export default class N3Parser {
     case 'eof':
       if (this._graph !== null)
         return this._error('Unclosed graph', token);
-      this._endMessage();
       delete this._prefixes._;
-      return this._callback(null, null, this._prefixes);
+      return this._callback(null, null, this._prefixes, this._messageCounter);
     // It could be a prefix declaration
     case 'PREFIX':
       this._sparqlStyle = true;
@@ -822,6 +821,7 @@ export default class N3Parser {
     this._versionCallback(token.value);
     if (/-messages$/.test(token.value) && !this._messageMode) {
       this._messageMode = true;
+      this._messageCounter = 0;
       this._resetMessageBlankNodePrefix();
     }
     if (!this._isValidVersion(token.value))
@@ -833,7 +833,7 @@ export default class N3Parser {
   _readMessage(token) {
     if (!this._messageMode)
       return this._error('Unexpected MESSAGE', token);
-    this._endMessage(true);
+    this._advanceMessageCounter();
     return this._readInTopContext;
   }
 
@@ -843,7 +843,7 @@ export default class N3Parser {
       return this._error('Unexpected @message', token);
     if (token.type !== '.')
       return this._error('Expected dot to follow @message', token);
-    this._endMessage(true);
+    this._advanceMessageCounter();
     return this._readInTopContext;
   }
 
@@ -1111,22 +1111,13 @@ export default class N3Parser {
   // ### `_emit` sends a quad through the callback
   _emit(subject, predicate, object, graph) {
     const quad = this._factory.quad(subject, predicate, object, graph || this.DEFAULTGRAPH);
-    if (this._messageMode) {
-      this._messageOpen = true;
-      this._messageQuads.push(quad);
-    }
-    this._callback(null, quad);
+    this._callback(null, quad, null, this._messageCounter);
   }
 
-  // ### `_endMessage` sends the current RDF message through the message callback
-  _endMessage(force) {
-    if (this._messageMode && (force || this._messageOpen)) {
-      this._messageCallback(this._messageQuads);
-      this._messageQuads = [];
-      this._messageOpen = false;
-    }
-    if (this._messageMode)
-      this._resetMessageBlankNodePrefix();
+  // ### `_advanceMessageCounter` starts a new RDF message scope
+  _advanceMessageCounter() {
+    this._messageCounter++;
+    this._resetMessageBlankNodePrefix();
   }
 
   // ### `_resetMessageBlankNodePrefix` scopes blank node labels to the current RDF message
@@ -1271,9 +1262,7 @@ export default class N3Parser {
                                                : `b${blankNodePrefix++}_`;
     this._prefixCallback = onPrefix || noop;
     this._versionCallback = onVersion || noop;
-    this._messageCallback = onMessage || noop;
-    this._messageQuads = [];
-    this._messageOpen = false;
+    this._messageCounter = this._messageMode ? 0 : undefined;
     this._inversePredicate = false;
     this._quantified = Object.create(null);
 
@@ -1287,6 +1276,29 @@ export default class N3Parser {
       });
       if (error) throw error;
       return quads;
+    }
+
+    // `onMessage` is a convenience callback that groups `onQuad` data in memory.
+    if (onMessage) {
+      let currentMessageCounter;
+      let messageQuads = [];
+      const onQuadStream = onQuad;
+      onQuad = (error, quad, prefixes, messageCounter) => {
+        if (messageCounter !== undefined && currentMessageCounter === undefined)
+          currentMessageCounter = 0;
+        if (currentMessageCounter !== undefined) {
+          while (currentMessageCounter < messageCounter) {
+            onMessage(messageQuads, currentMessageCounter);
+            messageQuads = [];
+            currentMessageCounter++;
+          }
+          if (quad)
+            messageQuads.push(quad);
+          else
+            onMessage(messageQuads, currentMessageCounter);
+        }
+        onQuadStream(error, quad, prefixes, messageCounter);
+      };
     }
 
     let processNextToken = (error, token) => {

--- a/src/N3Parser.js
+++ b/src/N3Parser.js
@@ -1122,7 +1122,7 @@ export default class N3Parser {
       this._messageQuads = [];
       this._messageOpen = false;
     }
-    if (this._messageMode && !this._blankNodePrefix)
+    if (this._messageMode)
       this._prefixes._ = `b${blankNodePrefix++}_`;
   }
 

--- a/src/N3StreamParser.js
+++ b/src/N3StreamParser.js
@@ -18,7 +18,7 @@ export default class N3StreamParser extends Transform {
         // Emit prefixes through the `prefix` event
       onPrefix: (prefix, uri) => { this.emit('prefix', prefix, uri); },
         // Emit RDF messages through the `message` event
-      onMessage: quads => { this.emit('message', quads); },
+      onMessage: (quads, messageCounter) => { this.emit('message', quads, messageCounter); },
     };
 
     if (options && options.comments)

--- a/src/N3StreamParser.js
+++ b/src/N3StreamParser.js
@@ -17,6 +17,8 @@ export default class N3StreamParser extends Transform {
       onQuad: (error, quad) => { error && this.emit('error', error) || quad && this.push(quad); },
         // Emit prefixes through the `prefix` event
       onPrefix: (prefix, uri) => { this.emit('prefix', prefix, uri); },
+        // Emit RDF messages through the `message` event
+      onMessage: quads => { this.emit('message', quads); },
     };
 
     if (options && options.comments)

--- a/src/N3Writer.js
+++ b/src/N3Writer.js
@@ -278,7 +278,7 @@ export default class N3Writer {
       this._write(this._inDefaultGraph ? '.\n' : '\n}\n');
       this._subject = null;
     }
-    this._write(this._lineMode ? 'MESSAGE\n' : '@message .\n');
+    this._write('@message .\n');
   }
 
   // ### `addPrefix` adds the prefix to the output stream

--- a/src/N3Writer.js
+++ b/src/N3Writer.js
@@ -264,21 +264,36 @@ export default class N3Writer {
 
   // ### `addMessage` adds the quads of an RDF message to the output stream
   addMessage(quads, done) {
+    quads = quads || [];
+    let index = 0;
+    const writeNextQuad = error => {
+      if (error || index === quads.length)
+        return done && done(error);
+      this.addQuad(quads[index++], writeNextQuad);
+    };
     if (this._messageStarted)
-      this._writeMessageDelimiter();
-    else
+      this._writeMessageDelimiter(writeNextQuad);
+    else {
       this._messageStarted = true;
-    this.addQuads(quads || []);
-    done && done();
+      writeNextQuad();
+    }
   }
 
   // ### `_writeMessageDelimiter` starts the next RDF message
-  _writeMessageDelimiter() {
+  _writeMessageDelimiter(done) {
+    const writeDelimiter = error => {
+      if (error)
+        return done && done(error);
+      this._write('@message .\n', done);
+    };
     if (this._subject !== null) {
-      this._write(this._inDefaultGraph ? '.\n' : '\n}\n');
+      const closeGraph = this._inDefaultGraph ? '.\n' : '\n}\n';
       this._subject = null;
+      this._graph = null;
+      this._write(closeGraph, writeDelimiter);
     }
-    this._write('@message .\n');
+    else
+      writeDelimiter();
   }
 
   // ### `addPrefix` adds the prefix to the output stream

--- a/src/N3Writer.js
+++ b/src/N3Writer.js
@@ -54,6 +54,7 @@ export default class N3Writer {
 
     // Initialize writer, depending on the format
     this._subject = null;
+    this._messageStarted = false;
     if (!(/triple|quad/i).test(options.format)) {
       this._lineMode = false;
       this._graph = DEFAULTGRAPH;
@@ -259,6 +260,25 @@ export default class N3Writer {
   addQuads(quads) {
     for (let i = 0; i < quads.length; i++)
       this.addQuad(quads[i]);
+  }
+
+  // ### `addMessage` adds the quads of an RDF message to the output stream
+  addMessage(quads, done) {
+    if (this._messageStarted)
+      this._writeMessageDelimiter();
+    else
+      this._messageStarted = true;
+    this.addQuads(quads || []);
+    done && done();
+  }
+
+  // ### `_writeMessageDelimiter` starts the next RDF message
+  _writeMessageDelimiter() {
+    if (this._subject !== null) {
+      this._write(this._inDefaultGraph ? '.\n' : '\n}\n');
+      this._subject = null;
+    }
+    this._write(this._lineMode ? 'MESSAGE\n' : '@message .\n');
   }
 
   // ### `addPrefix` adds the prefix to the output stream

--- a/test/N3Parser-test.js
+++ b/test/N3Parser-test.js
@@ -996,12 +996,21 @@ describe('Parser', () => {
 
     it('should callback RDF messages at delimiters and EOF', done => {
       const messages = [];
+      const messageCounters = [];
+      const quadCounters = [];
       new Parser({ messages: true, baseIRI: BASE_IRI }).parse(
         '@message .\n<a> <b> <c>.\n@message .\n@message .\n<d> <e> <f>.',
         {
-          onQuad: (error, quad) => {
+          onQuad: (error, quad, prefixes, messageCounter) => {
             expect(error).toBeFalsy();
-            if (quad) return;
+            if (quad) {
+              quadCounters.push(messageCounter);
+              return;
+            }
+            expect(prefixes).toBeDefined();
+            expect(messageCounter).toEqual(3);
+            expect(quadCounters).toEqual([1, 3]);
+            expect(messageCounters).toEqual([0, 1, 2, 3]);
             expect(messages.map(message => toSortedJSON(message))).toEqual([
               toSortedJSON([]),
               toSortedJSON([mapToQuad(['a', 'b', 'c'])]),
@@ -1010,52 +1019,81 @@ describe('Parser', () => {
             ]);
             done();
           },
-          onMessage: message => { messages.push(message); },
+          onMessage: (message, messageCounter) => {
+            messages.push(message);
+            messageCounters.push(messageCounter);
+          },
         },
       );
     });
 
     it('should infer RDF message mode from a version declaration', done => {
       const messages = [];
+      const messageCounters = [];
+      const quadCounters = [];
       new Parser({ baseIRI: BASE_IRI }).parse(
         'VERSION "1.2-messages"\n<a> <b> <c>.\nMESSAGE\n<d> <e> <f>.',
         {
-          onQuad: (error, quad) => {
+          onQuad: (error, quad, prefixes, messageCounter) => {
             expect(error).toBeFalsy();
-            if (quad) return;
+            if (quad) {
+              quadCounters.push(messageCounter);
+              return;
+            }
+            expect(prefixes).toBeDefined();
+            expect(messageCounter).toEqual(1);
+            expect(quadCounters).toEqual([0, 1]);
+            expect(messageCounters).toEqual([0, 1]);
             expect(messages.map(message => toSortedJSON(message))).toEqual([
               toSortedJSON([mapToQuad(['a', 'b', 'c'])]),
               toSortedJSON([mapToQuad(['d', 'e', 'f'])]),
             ]);
             done();
           },
-          onMessage: message => { messages.push(message); },
+          onMessage: (message, messageCounter) => {
+            messages.push(message);
+            messageCounters.push(messageCounter);
+          },
         },
       );
     });
 
     it('should parse N-Quads RDF message delimiters', done => {
       const messages = [];
+      const messageCounters = [];
+      const quadCounters = [];
       new Parser({ format: 'N-Quads', version: '1.2-messages' }).parse(
         '<http://a> <http://b> <http://c> <http://g> .\nMESSAGE\n' +
         '<http://d> <http://e> <http://f> <http://h> .',
         {
-          onQuad: (error, quad) => {
+          onQuad: (error, quad, prefixes, messageCounter) => {
             expect(error).toBeFalsy();
-            if (quad) return;
+            if (quad) {
+              quadCounters.push(messageCounter);
+              return;
+            }
+            expect(prefixes).toBeDefined();
+            expect(messageCounter).toEqual(1);
+            expect(quadCounters).toEqual([0, 1]);
+            expect(messageCounters).toEqual([0, 1]);
             expect(messages.map(message => toSortedJSON(message))).toEqual([
               toSortedJSON([mapToQuad(['http://a', 'http://b', 'http://c', 'http://g'])]),
               toSortedJSON([mapToQuad(['http://d', 'http://e', 'http://f', 'http://h'])]),
             ]);
             done();
           },
-          onMessage: message => { messages.push(message); },
+          onMessage: (message, messageCounter) => {
+            messages.push(message);
+            messageCounters.push(messageCounter);
+          },
         },
       );
     });
 
     it('should parse RDF messages with default graph and named graph quads', done => {
       const messages = [];
+      const messageCounters = [];
+      const quadCounters = [];
       new Parser({ messages: true, baseIRI: BASE_IRI }).parse(
         'PREFIX ex: <http://example.org/>\n' +
         'ex:s1 ex:p ex:o1.\n' +
@@ -1063,9 +1101,16 @@ describe('Parser', () => {
         '@message .\n' +
         'ex:s4 ex:p ex:o4.',
         {
-          onQuad: (error, quad) => {
+          onQuad: (error, quad, prefixes, messageCounter) => {
             expect(error).toBeFalsy();
-            if (quad) return;
+            if (quad) {
+              quadCounters.push(messageCounter);
+              return;
+            }
+            expect(prefixes).toBeDefined();
+            expect(messageCounter).toEqual(1);
+            expect(quadCounters).toEqual([0, 0, 0, 1]);
+            expect(messageCounters).toEqual([0, 1]);
             expect(messages.map(message => toSortedJSON(message))).toEqual([
               toSortedJSON([
                 mapToQuad(['s1', 'p', 'o1']),
@@ -1076,19 +1121,29 @@ describe('Parser', () => {
             ]);
             done();
           },
-          onMessage: message => { messages.push(message); },
+          onMessage: (message, messageCounter) => {
+            messages.push(message);
+            messageCounters.push(messageCounter);
+          },
         },
       );
     });
 
     it('should scope blank node labels to RDF messages', done => {
       const messages = [];
+      const quadCounters = [];
       new Parser({ messages: true }).parse(
         '_:x <b> <c>.\nMESSAGE\n_:x <b> <d>.',
         {
-          onQuad: (error, quad) => {
+          onQuad: (error, quad, prefixes, messageCounter) => {
             expect(error).toBeFalsy();
-            if (quad) return;
+            if (quad) {
+              quadCounters.push(messageCounter);
+              return;
+            }
+            expect(prefixes).toBeDefined();
+            expect(messageCounter).toEqual(1);
+            expect(quadCounters).toEqual([0, 1]);
             expect(messages[0][0].subject.equals(messages[1][0].subject)).toBe(false);
             done();
           },
@@ -1099,14 +1154,21 @@ describe('Parser', () => {
 
     it('should scope the same blank node label in one string to different RDF messages', done => {
       const messages = [];
+      const quadCounters = [];
       new Parser({ messages: true }).parse(
         '_:b0 <http://example.org/p> <http://example.org/o1>.\n' +
         '@message .\n' +
         '_:b0 <http://example.org/p> <http://example.org/o2>.',
         {
-          onQuad: (error, quad) => {
+          onQuad: (error, quad, prefixes, messageCounter) => {
             expect(error).toBeFalsy();
-            if (quad) return;
+            if (quad) {
+              quadCounters.push(messageCounter);
+              return;
+            }
+            expect(prefixes).toBeDefined();
+            expect(messageCounter).toEqual(1);
+            expect(quadCounters).toEqual([0, 1]);
             expect(messages).toHaveLength(2);
             expect(messages[0][0].subject.termType).toBe('BlankNode');
             expect(messages[1][0].subject.termType).toBe('BlankNode');
@@ -1120,14 +1182,21 @@ describe('Parser', () => {
 
     it('should scope blank node labels to RDF messages with a configured blank node prefix', done => {
       const messages = [];
+      const quadCounters = [];
       new Parser({ messages: true, blankNodePrefix: '_:fixed' }).parse(
         '_:b0 <http://example.org/p> <http://example.org/o1>.\n' +
         '@message .\n' +
         '_:b0 <http://example.org/p> <http://example.org/o2>.',
         {
-          onQuad: (error, quad) => {
+          onQuad: (error, quad, prefixes, messageCounter) => {
             expect(error).toBeFalsy();
-            if (quad) return;
+            if (quad) {
+              quadCounters.push(messageCounter);
+              return;
+            }
+            expect(prefixes).toBeDefined();
+            expect(messageCounter).toEqual(1);
+            expect(quadCounters).toEqual([0, 1]);
             expect(messages).toHaveLength(2);
             expect(messages[0][0].subject.value).toMatch(/^fixed/);
             expect(messages[1][0].subject.value).toMatch(/^fixed/);
@@ -1135,6 +1204,26 @@ describe('Parser', () => {
             done();
           },
           onMessage: message => { messages.push(message); },
+        },
+      );
+    });
+
+    it('should keep messageCounter undefined outside message mode', done => {
+      const quadCounters = [];
+      new Parser({ baseIRI: BASE_IRI }).parse(
+        '<a> <b> <c>.\n<d> <e> <f>.',
+        {
+          onQuad: (error, quad, prefixes, messageCounter) => {
+            expect(error).toBeFalsy();
+            if (quad) {
+              quadCounters.push(messageCounter);
+              return;
+            }
+            expect(prefixes).toBeDefined();
+            expect(messageCounter).toEqual(undefined);
+            expect(quadCounters).toEqual([undefined, undefined]);
+            done();
+          },
         },
       );
     });

--- a/test/N3Parser-test.js
+++ b/test/N3Parser-test.js
@@ -923,6 +923,13 @@ describe('Parser', () => {
     );
 
     it(
+        'should handle RDF Messages VERSION labels',
+        shouldParse('VERSION "1.2-messages"\n' +
+            '<ex:a> <ex:b> <ex:c> .',
+            ['ex:a', 'ex:b', 'ex:c']),
+    );
+
+    it(
         'should handle @version',
         shouldParse('@version "1.2".'),
     );
@@ -971,6 +978,137 @@ describe('Parser', () => {
     it(
         'should handle unsupported VERSIONs when parseUnsupportedVersions is true',
         shouldParse(lenientParser, 'VERSION "1.2-unknown"'),
+    );
+
+    it('should parse RDF messages as a regular quad stream', shouldParse(class MessageParser extends Parser {
+      constructor() { super({ messages: true, baseIRI: BASE_IRI }); }
+    },
+                '<a> <b> <c>.\n@message .\n<d> <e> <f>.',
+                ['a', 'b', 'c'],
+                ['d', 'e', 'f']));
+
+    it('should parse SPARQL-style RDF message delimiters', shouldParse(class MessageParser extends Parser {
+      constructor() { super({ messages: true, baseIRI: BASE_IRI }); }
+    },
+                '<a> <b> <c>.\nMESSAGE\n<d> <e> <f>.',
+                ['a', 'b', 'c'],
+                ['d', 'e', 'f']));
+
+    it('should callback RDF messages at delimiters and EOF', done => {
+      const messages = [];
+      new Parser({ messages: true, baseIRI: BASE_IRI }).parse(
+        '@message .\n<a> <b> <c>.\n@message .\n@message .\n<d> <e> <f>.',
+        {
+          onQuad: (error, quad) => {
+            expect(error).toBeFalsy();
+            if (quad) return;
+            expect(messages.map(message => toSortedJSON(message))).toEqual([
+              toSortedJSON([]),
+              toSortedJSON([mapToQuad(['a', 'b', 'c'])]),
+              toSortedJSON([]),
+              toSortedJSON([mapToQuad(['d', 'e', 'f'])]),
+            ]);
+            done();
+          },
+          onMessage: message => { messages.push(message); },
+        },
+      );
+    });
+
+    it('should infer RDF message mode from a version declaration', done => {
+      const messages = [];
+      new Parser({ baseIRI: BASE_IRI }).parse(
+        'VERSION "1.2-messages"\n<a> <b> <c>.\nMESSAGE\n<d> <e> <f>.',
+        {
+          onQuad: (error, quad) => {
+            expect(error).toBeFalsy();
+            if (quad) return;
+            expect(messages.map(message => toSortedJSON(message))).toEqual([
+              toSortedJSON([mapToQuad(['a', 'b', 'c'])]),
+              toSortedJSON([mapToQuad(['d', 'e', 'f'])]),
+            ]);
+            done();
+          },
+          onMessage: message => { messages.push(message); },
+        },
+      );
+    });
+
+    it('should parse N-Quads RDF message delimiters', done => {
+      const messages = [];
+      new Parser({ format: 'N-Quads', version: '1.2-messages' }).parse(
+        '<http://a> <http://b> <http://c> <http://g> .\nMESSAGE\n' +
+        '<http://d> <http://e> <http://f> <http://h> .',
+        {
+          onQuad: (error, quad) => {
+            expect(error).toBeFalsy();
+            if (quad) return;
+            expect(messages.map(message => toSortedJSON(message))).toEqual([
+              toSortedJSON([mapToQuad(['http://a', 'http://b', 'http://c', 'http://g'])]),
+              toSortedJSON([mapToQuad(['http://d', 'http://e', 'http://f', 'http://h'])]),
+            ]);
+            done();
+          },
+          onMessage: message => { messages.push(message); },
+        },
+      );
+    });
+
+    it('should scope blank node labels to RDF messages', done => {
+      const messages = [];
+      new Parser({ messages: true }).parse(
+        '_:x <b> <c>.\nMESSAGE\n_:x <b> <d>.',
+        {
+          onQuad: (error, quad) => {
+            expect(error).toBeFalsy();
+            if (quad) return;
+            expect(messages[0][0].subject.equals(messages[1][0].subject)).toBe(false);
+            done();
+          },
+          onMessage: message => { messages.push(message); },
+        },
+      );
+    });
+
+    it('should scope the same blank node label in one string to different RDF messages', done => {
+      const messages = [];
+      new Parser({ messages: true }).parse(
+        '_:b0 <http://example.org/p> <http://example.org/o1>.\n' +
+        '@message .\n' +
+        '_:b0 <http://example.org/p> <http://example.org/o2>.',
+        {
+          onQuad: (error, quad) => {
+            expect(error).toBeFalsy();
+            if (quad) return;
+            expect(messages).toHaveLength(2);
+            expect(messages[0][0].subject.termType).toBe('BlankNode');
+            expect(messages[1][0].subject.termType).toBe('BlankNode');
+            expect(messages[0][0].subject.value).not.toBe(messages[1][0].subject.value);
+            done();
+          },
+          onMessage: message => { messages.push(message); },
+        },
+      );
+    });
+
+    it(
+        'should not handle RDF message delimiters outside message mode',
+        shouldNotParse('MESSAGE',
+            'Unexpected MESSAGE on line 1.'),
+    );
+
+    it(
+        'should not handle old-style RDF message delimiters outside message mode',
+        shouldNotParse('@message .',
+            'Unexpected @message on line 1.'),
+    );
+
+    it(
+        'should not handle old-style RDF message delimiters without a dot',
+        shouldNotParse(class MessageParser extends Parser {
+          constructor() { super({ messages: true }); }
+        }, '@message <a>',
+            'Expected dot to follow @message on line 1.'),
     );
 
     it(

--- a/test/N3Parser-test.js
+++ b/test/N3Parser-test.js
@@ -1129,6 +1129,8 @@ describe('Parser', () => {
             expect(error).toBeFalsy();
             if (quad) return;
             expect(messages).toHaveLength(2);
+            expect(messages[0][0].subject.value).toMatch(/^fixed/);
+            expect(messages[1][0].subject.value).toMatch(/^fixed/);
             expect(messages[0][0].subject.value).not.toBe(messages[1][0].subject.value);
             done();
           },

--- a/test/N3Parser-test.js
+++ b/test/N3Parser-test.js
@@ -1118,6 +1118,25 @@ describe('Parser', () => {
       );
     });
 
+    it('should scope blank node labels to RDF messages with a configured blank node prefix', done => {
+      const messages = [];
+      new Parser({ messages: true, blankNodePrefix: '_:fixed' }).parse(
+        '_:b0 <http://example.org/p> <http://example.org/o1>.\n' +
+        '@message .\n' +
+        '_:b0 <http://example.org/p> <http://example.org/o2>.',
+        {
+          onQuad: (error, quad) => {
+            expect(error).toBeFalsy();
+            if (quad) return;
+            expect(messages).toHaveLength(2);
+            expect(messages[0][0].subject.value).not.toBe(messages[1][0].subject.value);
+            done();
+          },
+          onMessage: message => { messages.push(message); },
+        },
+      );
+    });
+
     it(
         'should not handle RDF message delimiters outside message mode',
         shouldNotParse('MESSAGE',

--- a/test/N3Parser-test.js
+++ b/test/N3Parser-test.js
@@ -1160,6 +1160,17 @@ describe('Parser', () => {
     );
 
     it(
+        'should not handle RDF message delimiters inside an open graph',
+        shouldNotParse('VERSION "1.2-messages"\n' +
+            '<g> {\n' +
+            '   <a> <b> <c> .\n' +
+            '@message\n' +
+            '   <d> <e> <f> .\n' +
+            '}',
+        'Expected dot to follow @message on line 5.'),
+    );
+
+    it(
         'should not allow unsupported versions passed through the constructor',
         () => {
           expect((() => { new Parser({ version: '1.2-unknown' }).parse('<a> <b> <c>'); }))

--- a/test/N3Parser-test.js
+++ b/test/N3Parser-test.js
@@ -1054,6 +1054,33 @@ describe('Parser', () => {
       );
     });
 
+    it('should parse RDF messages with default graph and named graph quads', done => {
+      const messages = [];
+      new Parser({ messages: true, baseIRI: BASE_IRI }).parse(
+        'PREFIX ex: <http://example.org/>\n' +
+        'ex:s1 ex:p ex:o1.\n' +
+        'ex:g { ex:s2 ex:p ex:o2. ex:s3 ex:p ex:o3. }\n' +
+        '@message .\n' +
+        'ex:s4 ex:p ex:o4.',
+        {
+          onQuad: (error, quad) => {
+            expect(error).toBeFalsy();
+            if (quad) return;
+            expect(messages.map(message => toSortedJSON(message))).toEqual([
+              toSortedJSON([
+                mapToQuad(['s1', 'p', 'o1']),
+                mapToQuad(['s2', 'p', 'o2', 'g']),
+                mapToQuad(['s3', 'p', 'o3', 'g']),
+              ]),
+              toSortedJSON([mapToQuad(['s4', 'p', 'o4'])]),
+            ]);
+            done();
+          },
+          onMessage: message => { messages.push(message); },
+        },
+      );
+    });
+
     it('should scope blank node labels to RDF messages', done => {
       const messages = [];
       new Parser({ messages: true }).parse(

--- a/test/N3StreamParser-test.js
+++ b/test/N3StreamParser-test.js
@@ -90,6 +90,11 @@ describe('StreamParser', () => {
       shouldNotEmitCommentsWhenNotEnabled(['#comment1\n<a> <b> #comment2\n#comment3\n <c>. <d> <e> <f>.'], ['comment1', 'comment2', 'comment3']),
     );
 
+    it(
+      'emits "message" events',
+      shouldEmitMessages(['VERSION "1.2-messages"\n<a> <b>', ' <c>.\nMESSAGE\n<d> <e> <f>.'], [1, 1]),
+    );
+
     it('passes an error', () => {
       const input = new Readable(), parser = new StreamParser();
       let error = null;
@@ -212,6 +217,22 @@ function shouldNotEmitCommentsWhenNotEnabled(chunks, expectedComments) {
     parser.on('error', done);
     parser.on('end', error => {
       done();
+    });
+  };
+}
+
+function shouldEmitMessages(chunks, expectedLengths) {
+  return function (done) {
+    const messageLengths = [],
+        parser = new StreamParser(),
+        inputStream = new ArrayReader(chunks);
+    inputStream.pipe(parser);
+    parser.on('data', () => {});
+    parser.on('message', message => { messageLengths.push(message.length); });
+    parser.on('error', done);
+    parser.on('end', error => {
+      expect(messageLengths).toEqual(expectedLengths);
+      done(error);
     });
   };
 }

--- a/test/N3StreamParser-test.js
+++ b/test/N3StreamParser-test.js
@@ -92,7 +92,11 @@ describe('StreamParser', () => {
 
     it(
       'emits "message" events',
-      shouldEmitMessages(['VERSION "1.2-messages"\n<a> <b>', ' <c>.\nMESSAGE\n<d> <e> <f>.'], [1, 1]),
+      shouldEmitMessages(
+        ['VERSION "1.2-messages"\n<a> <b>', ' <c>.\nMESSAGE\n<d> <e> <f>.'],
+        [1, 1],
+        [0, 1],
+      ),
     );
 
     it('passes an error', () => {
@@ -221,17 +225,23 @@ function shouldNotEmitCommentsWhenNotEnabled(chunks, expectedComments) {
   };
 }
 
-function shouldEmitMessages(chunks, expectedLengths) {
+function shouldEmitMessages(chunks, expectedLengths, expectedCounters) {
   return function (done) {
     const messageLengths = [],
+        messageCounters = [],
         parser = new StreamParser(),
         inputStream = new ArrayReader(chunks);
     inputStream.pipe(parser);
     parser.on('data', () => {});
-    parser.on('message', message => { messageLengths.push(message.length); });
+    parser.on('message', (message, messageCounter) => {
+      messageLengths.push(message.length);
+      messageCounters.push(messageCounter);
+    });
     parser.on('error', done);
     parser.on('end', error => {
       expect(messageLengths).toEqual(expectedLengths);
+      if (expectedCounters)
+        expect(messageCounters).toEqual(expectedCounters);
       done(error);
     });
   };

--- a/test/N3Writer-test.js
+++ b/test/N3Writer-test.js
@@ -44,6 +44,64 @@ describe('Writer', () => {
       expect(writer.quadsToString(triples)).toBe('<a> <b> <c> .\n<d> <e> <f> .\n');
     });
 
+    it('should serialize RDF messages with @message delimiters', done => {
+      const writer = new Writer();
+      writer.addMessage([new Quad(new NamedNode('a'), new NamedNode('b'), new NamedNode('c'))]);
+      writer.addMessage([]);
+      writer.addMessage([new Quad(new NamedNode('d'), new NamedNode('e'), new NamedNode('f'))]);
+      writer.end((error, output) => {
+        expect(error).toBeFalsy();
+        expect(output).toBe('<a> <b> <c>.\n@message .\n@message .\n<d> <e> <f>.\n');
+        done();
+      });
+    });
+
+    it('should callback after adding an empty RDF message', done => {
+      const writer = new Writer();
+      writer.addMessage(undefined, error => {
+        expect(error).toBeFalsy();
+        writer.end((endError, output) => {
+          expect(endError).toBeFalsy();
+          expect(output).toBe('');
+          done();
+        });
+      });
+    });
+
+    it('should close a named graph before serializing an RDF message delimiter', done => {
+      const writer = new Writer();
+      writer.addMessage([new Quad(new NamedNode('a'), new NamedNode('b'), new NamedNode('c'), new NamedNode('g'))]);
+      writer.addMessage([new Quad(new NamedNode('d'), new NamedNode('e'), new NamedNode('f'))]);
+      writer.end((error, output) => {
+        expect(error).toBeFalsy();
+        expect(output).toBe('<g> {\n<a> <b> <c>\n}\n@message .\n<d> <e> <f>.\n');
+        done();
+      });
+    });
+
+    it('should serialize N-Triples RDF messages with MESSAGE delimiters', done => {
+      const writer = new Writer({ format: 'N-Triples' });
+      writer.addMessage([new Quad(new NamedNode('http://a'), new NamedNode('http://b'), new NamedNode('http://c'))]);
+      writer.addMessage([new Quad(new NamedNode('http://d'), new NamedNode('http://e'), new NamedNode('http://f'))]);
+      writer.end((error, output) => {
+        expect(error).toBeFalsy();
+        expect(output).toBe('<http://a> <http://b> <http://c> .\nMESSAGE\n' +
+                            '<http://d> <http://e> <http://f> .\n');
+        done();
+      });
+    });
+
+    it('should serialize N-Quads RDF messages with MESSAGE delimiters', done => {
+      const writer = new Writer({ format: 'N-Quads' });
+      writer.addMessage([new Quad(new NamedNode('http://a'), new NamedNode('http://b'), new NamedNode('http://c'), new NamedNode('http://g'))]);
+      writer.addMessage([new Quad(new NamedNode('http://d'), new NamedNode('http://e'), new NamedNode('http://f'), new NamedNode('http://h'))]);
+      writer.end((error, output) => {
+        expect(error).toBeFalsy();
+        expect(output).toBe('<http://a> <http://b> <http://c> <http://g> .\nMESSAGE\n' +
+                            '<http://d> <http://e> <http://f> <http://h> .\n');
+        done();
+      });
+    });
 
     it('should serialize 0 triples', shouldSerialize(''));
 

--- a/test/N3Writer-test.js
+++ b/test/N3Writer-test.js
@@ -79,25 +79,25 @@ describe('Writer', () => {
       });
     });
 
-    it('should serialize N-Triples RDF messages with MESSAGE delimiters', done => {
+    it('should serialize N-Triples RDF messages with @message delimiters', done => {
       const writer = new Writer({ format: 'N-Triples' });
       writer.addMessage([new Quad(new NamedNode('http://a'), new NamedNode('http://b'), new NamedNode('http://c'))]);
       writer.addMessage([new Quad(new NamedNode('http://d'), new NamedNode('http://e'), new NamedNode('http://f'))]);
       writer.end((error, output) => {
         expect(error).toBeFalsy();
-        expect(output).toBe('<http://a> <http://b> <http://c> .\nMESSAGE\n' +
+        expect(output).toBe('<http://a> <http://b> <http://c> .\n@message .\n' +
                             '<http://d> <http://e> <http://f> .\n');
         done();
       });
     });
 
-    it('should serialize N-Quads RDF messages with MESSAGE delimiters', done => {
+    it('should serialize N-Quads RDF messages with @message delimiters', done => {
       const writer = new Writer({ format: 'N-Quads' });
       writer.addMessage([new Quad(new NamedNode('http://a'), new NamedNode('http://b'), new NamedNode('http://c'), new NamedNode('http://g'))]);
       writer.addMessage([new Quad(new NamedNode('http://d'), new NamedNode('http://e'), new NamedNode('http://f'), new NamedNode('http://h'))]);
       writer.end((error, output) => {
         expect(error).toBeFalsy();
-        expect(output).toBe('<http://a> <http://b> <http://c> <http://g> .\nMESSAGE\n' +
+        expect(output).toBe('<http://a> <http://b> <http://c> <http://g> .\n@message .\n' +
                             '<http://d> <http://e> <http://f> <http://h> .\n');
         done();
       });

--- a/test/N3Writer-test.js
+++ b/test/N3Writer-test.js
@@ -56,6 +56,24 @@ describe('Writer', () => {
       });
     });
 
+    it('should callback after flushing an RDF message', done => {
+      let flushed = false;
+      const outputStream = {
+            write(chunk, encoding, callback) {
+              setImmediate(() => {
+                flushed = true;
+                callback && callback();
+              });
+            },
+          },
+          writer = new Writer(outputStream, { end: false });
+      writer.addMessage([new Quad(new NamedNode('a'), new NamedNode('b'), new NamedNode('c'))], error => {
+        expect(error).toBeFalsy();
+        expect(flushed).toBe(true);
+        done();
+      });
+    });
+
     it('should callback after adding an empty RDF message', done => {
       const writer = new Writer();
       writer.addMessage(undefined, error => {
@@ -70,12 +88,48 @@ describe('Writer', () => {
 
     it('should close a named graph before serializing an RDF message delimiter', done => {
       const writer = new Writer();
-      writer.addMessage([new Quad(new NamedNode('a'), new NamedNode('b'), new NamedNode('c'), new NamedNode('g'))]);
-      writer.addMessage([new Quad(new NamedNode('d'), new NamedNode('e'), new NamedNode('f'))]);
-      writer.end((error, output) => {
+      writer.addMessage([new Quad(new NamedNode('a'), new NamedNode('b'), new NamedNode('c'), new NamedNode('g'))], error => {
         expect(error).toBeFalsy();
-        expect(output).toBe('<g> {\n<a> <b> <c>\n}\n@message .\n<d> <e> <f>.\n');
-        done();
+        writer.addMessage([new Quad(new NamedNode('d'), new NamedNode('e'), new NamedNode('f'))], error => {
+          expect(error).toBeFalsy();
+          writer.end((error, output) => {
+            expect(error).toBeFalsy();
+            expect(output).toBe('<g> {\n<a> <b> <c>\n}\n@message .\n<d> <e> <f>.\n');
+            done();
+          });
+        });
+      });
+    });
+
+    it('should reopen a named graph after serializing an RDF message delimiter', done => {
+      const writer = new Writer();
+      writer.addMessage([new Quad(new NamedNode('a'), new NamedNode('b'), new NamedNode('c'), new NamedNode('g'))], error => {
+        expect(error).toBeFalsy();
+        writer.addMessage([new Quad(new NamedNode('d'), new NamedNode('e'), new NamedNode('f'), new NamedNode('g'))], error => {
+          expect(error).toBeFalsy();
+          writer.end((error, output) => {
+            expect(error).toBeFalsy();
+            expect(output).toBe('<g> {\n<a> <b> <c>\n}\n@message .\n<g> {\n<d> <e> <f>\n}\n');
+            done();
+          });
+        });
+      });
+    });
+
+    it('should callback with errors when closing a graph before an RDF message delimiter fails', done => {
+      const expectedError = new Error('close failed'),
+          outputStream = {
+            write(chunk, encoding, callback) {
+              callback && callback(chunk === '\n}\n' ? expectedError : undefined);
+            },
+          },
+          writer = new Writer(outputStream, { end: false });
+      writer.addMessage([new Quad(new NamedNode('a'), new NamedNode('b'), new NamedNode('c'), new NamedNode('g'))], error => {
+        expect(error).toBeFalsy();
+        writer.addMessage([], error => {
+          expect(error).toBe(expectedError);
+          done();
+        });
       });
     });
 


### PR DESCRIPTION
This is an implementation of the [RDF Messages specification](https://w3c-cg.github.io/rsp/spec/messages) by the W3C RDF Stream Processing CG that is now seeking for implementations of the spec.


More context:
 * This is also being discussed in the RDF JS data model spec: https://github.com/rdfjs/data-model-spec/issues/183
 * The poster paper we are presenting at the ESWC2026 conference: https://pietercolpaert.be/papers/eswc2026-rdf-messages/
  * @RubenVerborgh: we already discussed this in a slightly different context in the past as well, for which this now is I believe a better fix: https://github.com/rdfjs/N3.js/issues/439#issuecomment-2334155572

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * RDF message parsing support—enable via messages: true or version strings ending in -messages
  * Parser delivers grouped messages via an onMessage callback; stream parser emits message events
  * Writer can serialize message batches with addMessage(), using Turtle-style @message . delimiters

* **Behavior**
  * Blank-node labels scoped per message; quads still emitted immediately and also batched
  * MESSAGE / @message delimiters recognized; messages flushed at EOF

* **Tests**
  * Added coverage for parsing, streaming, serialization, delimiter rules, and edge cases

* **Documentation**
  * README documents message parsing, events, and serialization usage
<!-- end of auto-generated comment: release notes by coderabbit.ai -->