### PR TITLE
Disallow surrogate pairs

### DIFF
--- a/src/N3Lexer.js
+++ b/src/N3Lexer.js
@@ -15,6 +15,10 @@ const escapeReplacements = {
 };
 const illegalIriChars = /[\x00-\x20<>\\"\{\}\|\^\`]/;
 
+function isSurrogateCodePoint(charCode) {
+  return charCode >= 0xD800 && charCode <= 0xDFFF;
+}
+
 const lineModeRegExps = {
   _iri: true,
   _unescapedIri: true,
@@ -419,11 +423,21 @@ export default class N3Lexer {
     let invalid = false;
     const replaced = item.replace(escapeSequence, (sequence, unicode4, unicode8, escapedChar) => {
       // 4-digit unicode character
-      if (typeof unicode4 === 'string')
-        return String.fromCharCode(Number.parseInt(unicode4, 16));
+      if (typeof unicode4 === 'string') {
+        const charCode = Number.parseInt(unicode4, 16);
+        if (isSurrogateCodePoint(charCode)) {
+          invalid = true;
+          return '';
+        }
+        return String.fromCharCode(charCode);
+      }
       // 8-digit unicode character
       if (typeof unicode8 === 'string') {
         let charCode = Number.parseInt(unicode8, 16);
+        if (isSurrogateCodePoint(charCode)) {
+          invalid = true;
+          return '';
+        }
         return charCode <= 0xFFFF ? String.fromCharCode(Number.parseInt(unicode8, 16)) :
           String.fromCharCode(0xD800 + ((charCode -= 0x10000) >> 10), 0xDC00 + (charCode & 0x3FF));
       }

--- a/test/N3Lexer-test.js
+++ b/test/N3Lexer-test.js
@@ -356,6 +356,36 @@ describe('Lexer', () => {
     );
 
     it(
+      'should not tokenize a literal with a surrogate pair via unicode escapes',
+      shouldNotTokenize('"\\uD83C\\uDF00" ',
+                        'Unexpected ""\\uD83C\\uDF00"" on line 1.'),
+    );
+
+    it(
+      'should not tokenize a literal with a lone high surrogate unicode escape',
+      shouldNotTokenize('"\\uD800" ',
+                        'Unexpected ""\\uD800"" on line 1.'),
+    );
+
+    it(
+      'should not tokenize a literal with a lone low surrogate unicode escape',
+      shouldNotTokenize('"\\uDFFF" ',
+                        'Unexpected ""\\uDFFF"" on line 1.'),
+    );
+
+    it(
+      'should not tokenize a literal with a high surrogate 8-digit unicode escape',
+      shouldNotTokenize('"\\U0000D800" ',
+                        'Unexpected ""\\U0000D800"" on line 1.'),
+    );
+
+    it(
+      'should not tokenize a literal with a low surrogate 8-digit unicode escape',
+      shouldNotTokenize('"\\U0000DFFF" ',
+                        'Unexpected ""\\U0000DFFF"" on line 1.'),
+    );
+
+    it(
       'should not tokenize a double-quoted string ending with an escaped quote',
       shouldNotTokenize('"abc\\"',
                         'Unexpected ""abc\\"" on line 1.'),


### PR DESCRIPTION
Fixes #589

This currently breaks the build of other PRs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the lexer's Unicode escape decoding to properly reject surrogate code points. Escape sequences that decode to the UTF-16 surrogate range are now treated as invalid.

* **Tests**
  * Added test cases validating that tokenization correctly rejects surrogate code points in Unicode escape sequences, including surrogate pairs and lone surrogates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->