### PR TITLE
feat: configurable #match() semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,28 +381,29 @@ The store provides the following search methods
 ### Configuring `match()` semantics
 
 The dataset returned by `match()` is also a readable stream. By default, it is
-*lazy*: it delegates live to the parent store until its own first mutation,
-which means parent mutations made before that point are reflected in the view.
-You can choose a different behavior with the `matchSemantics` option, either
-per-call or as a store-wide default:
+*lazy*: it delegates live to the parent store until the first operation that
+materializes the view (a mutation, or a non-streaming read such as `size` or
+`has`), which means parent mutations made before that point are reflected in
+the view. You can choose a different behavior with the `matchSemantics` option,
+either as a store-wide default or per call:
 
 ```JavaScript
 import { Store, DataFactory } from 'n3';
 const { namedNode } = DataFactory;
 
-// Per call:
-const view = store.match(namedNode('s'), null, null, null, { matchSemantics: 'snapshot' });
-
-// Or as the default for every match() of a store:
+// As the default for every match() of a store:
 const store = new Store([], { matchSemantics: 'snapshot' });
+
+// Or per call:
+const view = store.match(namedNode('s'), null, null, null, { matchSemantics: 'snapshot' });
 ```
 
 Supported values:
 
 - `'lazy'` (default) — backwards-compatible behavior. The view reflects the
-  parent store until the view itself is first mutated, after which it is frozen
-  to a snapshot. Parent mutations made before that first mutation leak into the
-  view.
+  parent store until the first operation that materializes it (a mutation, or a
+  non-streaming read such as `size` or `has`), after which it is frozen to a
+  snapshot. Parent mutations made before that point leak into the view.
 - `'snapshot'` — the view reflects the parent contents *at the time of*
   `match()`. Later parent mutations never affect it. This is the most
   spec-correct interpretation of an RDF/JS dataset.

--- a/README.md
+++ b/README.md
@@ -409,6 +409,9 @@ Supported values:
 - `'forwarded'` — the view always reflects the parent state: matching parent
   mutations are forwarded to the view, and mutations on the view (`add`,
   `delete`, `addAll`, `deleteMatches`) are written through to the parent.
+  View mutations act on the parent unrestricted by the view's pattern: adding
+  a quad that does not match the pattern mutates the parent but never appears
+  in the view, and `deleteMatches` can delete parent quads outside the view.
   Calling `match()` on a `'forwarded'` view returns a `'snapshot'` sub-view:
   nested views never write through to the root store.
 

--- a/README.md
+++ b/README.md
@@ -378,6 +378,44 @@ The store provides the following search methods
 - `getGraphs` returns an array of unique graphs occurring in matching quad
 - `forGraphs` executes a callback on unique graphs occurring in matching quads
 
+### Configuring `match()` semantics
+
+The dataset returned by `match()` is also a readable stream. By default it is
+*lazy*: it delegates live to the parent store until its first own mutation,
+which means parent mutations made before that point are reflected in the view.
+You can choose a different behavior with the `matchSemantics` option, either
+per call or as a store-wide default:
+
+```JavaScript
+import { Store, DataFactory } from 'n3';
+const { namedNode } = DataFactory;
+
+// Per call:
+const view = store.match(namedNode('s'), null, null, null, { matchSemantics: 'snapshot' });
+
+// Or as the default for every match() of a store:
+const store = new Store([], { matchSemantics: 'snapshot' });
+```
+
+Supported values:
+
+- `'lazy'` (default) — backwards-compatible behavior. The view reflects the
+  parent store until the view itself is first mutated, after which it is frozen
+  to a snapshot. Parent mutations made before that first mutation leak into the
+  view.
+- `'snapshot'` — the view reflects the parent contents *at the time of*
+  `match()`. Later parent mutations never affect it. This is the most
+  spec-correct interpretation of an RDF/JS dataset.
+- `'forwarded'` — the view always reflects the parent state: matching parent
+  mutations are forwarded to the view, and mutations on the view (`add`,
+  `delete`, `addAll`, `deleteMatches`) are written through to the parent.
+
+For `'snapshot'` and `'forwarded'`, an iteration (synchronous or via the
+stream) that is already in progress keeps a stable view of the quads as of when
+it started, even if a matching parent mutation lands mid-iteration. Views are
+maintained incrementally — they only do work when a parent mutation actually
+matches the view's pattern — so the common path stays fast.
+
 ## Reasoning
 
 N3.js supports reasoning as follows:

--- a/README.md
+++ b/README.md
@@ -418,6 +418,14 @@ it started, even if a matching parent mutation lands mid-iteration. Views are
 maintained incrementally — they only do work when a parent mutation actually
 matches the view's pattern — so the common path stays fast.
 
+Such views observe the parent store: a `'snapshot'` view until its contents are
+first needed (its first matching parent mutation or first materializing read),
+a `'forwarded'` view for the lifetime of the store. The store holds a strong
+reference to each observing view — retaining it against garbage collection —
+and checks every mutation against each open view's pattern. Call
+`view.detach()` to release a view early: it is frozen to its contents at detach
+time and no longer taxes the store.
+
 ## Reasoning
 
 N3.js supports reasoning as follows:

--- a/README.md
+++ b/README.md
@@ -409,7 +409,8 @@ Supported values:
   spec-correct interpretation of an RDF/JS dataset.
 - `'forwarded'` — the view always reflects the parent state: matching parent
   mutations are forwarded to the view, and mutations on the view (`add`,
-  `delete`, `addAll`, `deleteMatches`) are written through to the parent.
+  `delete`, `addAll`, `deleteMatches`, `import`) are written through to the
+  parent.
   View mutations act on the parent unrestricted by the view's pattern: adding
   a quad that does not match the pattern mutates the parent but never appears
   in the view, and `deleteMatches` can delete parent quads outside the view.

--- a/README.md
+++ b/README.md
@@ -417,6 +417,9 @@ Supported values:
   Calling `match()` on a `'forwarded'` view returns a `'snapshot'` sub-view:
   nested views never write through to the root store.
 
+`match()` on a view takes no `matchSemantics` option: a sub-view inherits the
+view's semantics (with `'forwarded'` downgraded to `'snapshot'` as above).
+
 For `'snapshot'` and `'forwarded'`, an iteration (synchronous or via the
 stream) that is already in progress keeps a stable view of the quads as of when
 it started, even if a matching parent mutation lands mid-iteration. Views are

--- a/README.md
+++ b/README.md
@@ -409,6 +409,8 @@ Supported values:
 - `'forwarded'` — the view always reflects the parent state: matching parent
   mutations are forwarded to the view, and mutations on the view (`add`,
   `delete`, `addAll`, `deleteMatches`) are written through to the parent.
+  Calling `match()` on a `'forwarded'` view returns a `'snapshot'` sub-view:
+  nested views never write through to the root store.
 
 For `'snapshot'` and `'forwarded'`, an iteration (synchronous or via the
 stream) that is already in progress keeps a stable view of the quads as of when

--- a/README.md
+++ b/README.md
@@ -380,11 +380,11 @@ The store provides the following search methods
 
 ### Configuring `match()` semantics
 
-The dataset returned by `match()` is also a readable stream. By default it is
-*lazy*: it delegates live to the parent store until its first own mutation,
+The dataset returned by `match()` is also a readable stream. By default, it is
+*lazy*: it delegates live to the parent store until its own first mutation,
 which means parent mutations made before that point are reflected in the view.
 You can choose a different behavior with the `matchSemantics` option, either
-per call or as a store-wide default:
+per-call or as a store-wide default:
 
 ```JavaScript
 import { Store, DataFactory } from 'n3';

--- a/README.md
+++ b/README.md
@@ -503,6 +503,9 @@ Supported values:
   Calling `match()` on a `'forwarded'` view returns a `'snapshot'` sub-view:
   nested views never write through to the root store.
 
+`match()` on a view takes no `matchSemantics` option: a sub-view inherits the
+view's semantics (with `'forwarded'` downgraded to `'snapshot'` as above).
+
 For `'snapshot'` and `'forwarded'`, an iteration (synchronous or via the
 stream) that is already in progress keeps a stable view of the quads as of when
 it started, even if a matching parent mutation lands mid-iteration. Views are

--- a/README.md
+++ b/README.md
@@ -468,7 +468,7 @@ The store provides the following search methods
 
 The dataset returned by `match()` is also a readable stream. By default, it is
 *lazy*: it delegates live to the parent store until the first operation that
-materializes the view (a mutation, or a non-streaming read such as `size` or
+materializes the view (a mutation, or a materializing read such as `size` or
 `has`), which means parent mutations made before that point are reflected in
 the view. You can choose a different behavior with the `matchSemantics` option,
 either as a store-wide default or per call:
@@ -486,8 +486,8 @@ Supported values:
 
 - `'lazy'` (default) — backwards-compatible behavior. The view reflects the
   parent store until the first operation that materializes it (a mutation, or a
-  non-streaming read such as `size` or `has`), after which it is frozen to a
-  snapshot. Parent mutations made before that point leak into the view.
+  materializing read such as `size` or `has`), after which it is frozen to a
+  snapshot. Parent mutations made before that point remain visible in the view.
 - `'snapshot'` — the view reflects the parent contents *at the time of*
   `match()`. Later parent mutations never affect it. This is the most
   spec-correct interpretation of an RDF/JS dataset.
@@ -506,17 +506,15 @@ view's semantics (with `'forwarded'` downgraded to `'snapshot'` as above).
 
 For `'snapshot'` and `'forwarded'`, an iteration (synchronous or via the
 stream) that is already in progress keeps a stable view of the quads as of when
-it started, even if a matching parent mutation lands mid-iteration. Views are
-maintained incrementally — they only do work when a parent mutation actually
-matches the view's pattern — so the common path stays fast.
+it started, even if a matching parent mutation lands mid-iteration. Parent
+mutations only materialize or update a view when they match its pattern.
 
-Such views observe the parent store: a `'snapshot'` view until its contents are
-first needed (its first matching parent mutation or first materializing read),
-a `'forwarded'` view for the lifetime of the store. The store holds a strong
-reference to each observing view — retaining it against garbage collection —
-and checks every mutation against each open view's pattern. Call
-`view.detach()` to release a view early: it is frozen to its contents at detach
-time and no longer taxes the store.
+Such views observe the parent store: a `'snapshot'` view until it materializes,
+is frozen by a matching mutation, or is detached; a `'forwarded'` view until it
+is detached. The store holds a strong reference to each observing view —
+retaining it against garbage collection — and checks every mutation against
+each open view's pattern. Call `view.detach()` to release a view early: it is
+frozen to its contents at detach time and no longer taxes the store.
 
 ## Reasoning
 

--- a/README.md
+++ b/README.md
@@ -494,15 +494,17 @@ Supported values:
 - `'forwarded'` — the view always reflects the parent state: matching parent
   mutations are forwarded to the view, and mutations on the view (`add`,
   `delete`, `addAll`, `deleteMatches`, `import`) are written through to the
-  parent.
-  View mutations act on the parent unrestricted by the view's pattern: adding
-  a quad that does not match the pattern mutates the parent but never appears
-  in the view, and `deleteMatches` can delete parent quads outside the view.
-  Calling `match()` on a `'forwarded'` view returns a `'snapshot'` sub-view:
-  nested views never write through to the root store.
+  parent. Nested matches remain forwarded to the root, with every ancestor's
+  pattern applied. `add` and `addAll` throw upon encountering a quad outside
+  that combined pattern, while `import` emits an error on its input stream.
+  `delete` ignores a quad outside the pattern, and `deleteMatches` only removes
+  matching quads visible in the view.
 
-`match()` on a view takes no `matchSemantics` option: a sub-view inherits the
-view's semantics (with `'forwarded'` downgraded to `'snapshot'` as above).
+A sub-view inherits its parent's `matchSemantics`. The same value can be
+supplied explicitly, but a different value throws. Allowing a sub-view to
+change semantics would make its snapshot, materialization, and write target
+ambiguous across view boundaries; call `match()` on the root store when a
+different behavior is needed.
 
 For `'snapshot'` and `'forwarded'`, an iteration (synchronous or via the
 stream) that is already in progress keeps a stable view of the quads as of when
@@ -514,7 +516,8 @@ is frozen by a matching mutation, or is detached; a `'forwarded'` view until it
 is detached. The store holds a strong reference to each observing view —
 retaining it against garbage collection — and checks every mutation against
 each open view's pattern. Call `view.detach()` to release a view early: it is
-frozen to its contents at detach time and no longer taxes the store.
+frozen to its contents at detach time and no longer taxes the store. Detaching
+one view does not detach sub-views that were already created from it.
 
 ## Reasoning
 

--- a/README.md
+++ b/README.md
@@ -477,10 +477,8 @@ either as a store-wide default or per call:
 import { Store, DataFactory } from 'n3';
 const { namedNode } = DataFactory;
 
-// As the default for every match() of a store:
 const store = new Store([], { matchSemantics: 'snapshot' });
 
-// Or per call:
 const view = store.match(namedNode('s'), null, null, null, { matchSemantics: 'snapshot' });
 ```
 

--- a/README.md
+++ b/README.md
@@ -464,6 +464,44 @@ The store provides the following search methods
 - `getGraphs` returns an array of unique graphs occurring in matching quad
 - `forGraphs` executes a callback on unique graphs occurring in matching quads
 
+### Configuring `match()` semantics
+
+The dataset returned by `match()` is also a readable stream. By default it is
+*lazy*: it delegates live to the parent store until its first own mutation,
+which means parent mutations made before that point are reflected in the view.
+You can choose a different behavior with the `matchSemantics` option, either
+per call or as a store-wide default:
+
+```JavaScript
+import { Store, DataFactory } from 'n3';
+const { namedNode } = DataFactory;
+
+// Per call:
+const view = store.match(namedNode('s'), null, null, null, { matchSemantics: 'snapshot' });
+
+// Or as the default for every match() of a store:
+const store = new Store([], { matchSemantics: 'snapshot' });
+```
+
+Supported values:
+
+- `'lazy'` (default) — backwards-compatible behavior. The view reflects the
+  parent store until the view itself is first mutated, after which it is frozen
+  to a snapshot. Parent mutations made before that first mutation leak into the
+  view.
+- `'snapshot'` — the view reflects the parent contents *at the time of*
+  `match()`. Later parent mutations never affect it. This is the most
+  spec-correct interpretation of an RDF/JS dataset.
+- `'forwarded'` — the view always reflects the parent state: matching parent
+  mutations are forwarded to the view, and mutations on the view (`add`,
+  `delete`, `addAll`, `deleteMatches`) are written through to the parent.
+
+For `'snapshot'` and `'forwarded'`, an iteration (synchronous or via the
+stream) that is already in progress keeps a stable view of the quads as of when
+it started, even if a matching parent mutation lands mid-iteration. Views are
+maintained incrementally — they only do work when a parent mutation actually
+matches the view's pattern — so the common path stays fast.
+
 ## Reasoning
 
 N3.js supports reasoning as follows:

--- a/README.md
+++ b/README.md
@@ -504,6 +504,14 @@ it started, even if a matching parent mutation lands mid-iteration. Views are
 maintained incrementally — they only do work when a parent mutation actually
 matches the view's pattern — so the common path stays fast.
 
+Such views observe the parent store: a `'snapshot'` view until its contents are
+first needed (its first matching parent mutation or first materializing read),
+a `'forwarded'` view for the lifetime of the store. The store holds a strong
+reference to each observing view — retaining it against garbage collection —
+and checks every mutation against each open view's pattern. Call
+`view.detach()` to release a view early: it is frozen to its contents at detach
+time and no longer taxes the store.
+
 ## Reasoning
 
 N3.js supports reasoning as follows:

--- a/README.md
+++ b/README.md
@@ -495,6 +495,9 @@ Supported values:
 - `'forwarded'` — the view always reflects the parent state: matching parent
   mutations are forwarded to the view, and mutations on the view (`add`,
   `delete`, `addAll`, `deleteMatches`) are written through to the parent.
+  View mutations act on the parent unrestricted by the view's pattern: adding
+  a quad that does not match the pattern mutates the parent but never appears
+  in the view, and `deleteMatches` can delete parent quads outside the view.
   Calling `match()` on a `'forwarded'` view returns a `'snapshot'` sub-view:
   nested views never write through to the root store.
 

--- a/README.md
+++ b/README.md
@@ -467,28 +467,29 @@ The store provides the following search methods
 ### Configuring `match()` semantics
 
 The dataset returned by `match()` is also a readable stream. By default, it is
-*lazy*: it delegates live to the parent store until its own first mutation,
-which means parent mutations made before that point are reflected in the view.
-You can choose a different behavior with the `matchSemantics` option, either
-per-call or as a store-wide default:
+*lazy*: it delegates live to the parent store until the first operation that
+materializes the view (a mutation, or a non-streaming read such as `size` or
+`has`), which means parent mutations made before that point are reflected in
+the view. You can choose a different behavior with the `matchSemantics` option,
+either as a store-wide default or per call:
 
 ```JavaScript
 import { Store, DataFactory } from 'n3';
 const { namedNode } = DataFactory;
 
-// Per call:
-const view = store.match(namedNode('s'), null, null, null, { matchSemantics: 'snapshot' });
-
-// Or as the default for every match() of a store:
+// As the default for every match() of a store:
 const store = new Store([], { matchSemantics: 'snapshot' });
+
+// Or per call:
+const view = store.match(namedNode('s'), null, null, null, { matchSemantics: 'snapshot' });
 ```
 
 Supported values:
 
 - `'lazy'` (default) — backwards-compatible behavior. The view reflects the
-  parent store until the view itself is first mutated, after which it is frozen
-  to a snapshot. Parent mutations made before that first mutation leak into the
-  view.
+  parent store until the first operation that materializes it (a mutation, or a
+  non-streaming read such as `size` or `has`), after which it is frozen to a
+  snapshot. Parent mutations made before that point leak into the view.
 - `'snapshot'` — the view reflects the parent contents *at the time of*
   `match()`. Later parent mutations never affect it. This is the most
   spec-correct interpretation of an RDF/JS dataset.

--- a/README.md
+++ b/README.md
@@ -495,7 +495,8 @@ Supported values:
   spec-correct interpretation of an RDF/JS dataset.
 - `'forwarded'` — the view always reflects the parent state: matching parent
   mutations are forwarded to the view, and mutations on the view (`add`,
-  `delete`, `addAll`, `deleteMatches`) are written through to the parent.
+  `delete`, `addAll`, `deleteMatches`, `import`) are written through to the
+  parent.
   View mutations act on the parent unrestricted by the view's pattern: adding
   a quad that does not match the pattern mutates the parent but never appears
   in the view, and `deleteMatches` can delete parent quads outside the view.

--- a/README.md
+++ b/README.md
@@ -510,6 +510,8 @@ For `'snapshot'` and `'forwarded'`, an iteration (synchronous or via the
 stream) that is already in progress keeps a stable view of the quads as of when
 it started, even if a matching parent mutation lands mid-iteration. Parent
 mutations only materialize or update a view when they match its pattern.
+Each `toStream()` call has its own iteration. Snapshots used by active
+iterations are released when their last reader finishes.
 
 Such views observe the parent store: a `'snapshot'` view until it materializes,
 is frozen by a matching mutation, or is detached; a `'forwarded'` view until it

--- a/README.md
+++ b/README.md
@@ -495,6 +495,8 @@ Supported values:
 - `'forwarded'` — the view always reflects the parent state: matching parent
   mutations are forwarded to the view, and mutations on the view (`add`,
   `delete`, `addAll`, `deleteMatches`) are written through to the parent.
+  Calling `match()` on a `'forwarded'` view returns a `'snapshot'` sub-view:
+  nested views never write through to the root store.
 
 For `'snapshot'` and `'forwarded'`, an iteration (synchronous or via the
 stream) that is already in progress keeps a stable view of the quads as of when

--- a/README.md
+++ b/README.md
@@ -478,8 +478,8 @@ import { Store, DataFactory } from 'n3';
 const { namedNode } = DataFactory;
 
 const store = new Store([], { matchSemantics: 'snapshot' });
-
-const view = store.match(namedNode('s'), null, null, null, { matchSemantics: 'snapshot' });
+const snapshot = store.match(namedNode('s'));
+const forwarded = store.match(namedNode('s'), null, null, null, { matchSemantics: 'forwarded' });
 ```
 
 Supported values:

--- a/README.md
+++ b/README.md
@@ -466,11 +466,11 @@ The store provides the following search methods
 
 ### Configuring `match()` semantics
 
-The dataset returned by `match()` is also a readable stream. By default it is
-*lazy*: it delegates live to the parent store until its first own mutation,
+The dataset returned by `match()` is also a readable stream. By default, it is
+*lazy*: it delegates live to the parent store until its own first mutation,
 which means parent mutations made before that point are reflected in the view.
 You can choose a different behavior with the `matchSemantics` option, either
-per call or as a store-wide default:
+per-call or as a store-wide default:
 
 ```JavaScript
 import { Store, DataFactory } from 'n3';

--- a/perf/N3StoreMatchSemantics-perf.js
+++ b/perf/N3StoreMatchSemantics-perf.js
@@ -1,0 +1,97 @@
+#!/usr/bin/env node
+// [OPUS-4.8] Benchmark for configurable `#match()` semantics (issue #595).
+// Compares the default `lazy` path (to demonstrate no regression) against the
+// `snapshot` and `forwarded` semantics, for both materialization-free queries
+// and iteration with concurrent parent mutations.
+const assert = require('assert');
+const N3 = require('..');
+
+const { DataFactory: { namedNode } } = N3;
+
+console.log('N3Store #match() semantics performance test');
+
+// `dim` controls the dataset size: `dim` subjects x `dim` predicates x `dim`
+// objects in the default graph.
+const dim = Number.parseInt(process.argv[2], 10) || 256;
+const total = dim * dim;
+
+const prefix = 'http://example.org/#';
+const store = new N3.Store();
+
+let TEST = `- Adding ${total} triples`;
+console.time(TEST);
+for (let i = 0; i < dim; i++)
+  for (let j = 0; j < dim; j++)
+    store.addQuad(namedNode(prefix + i), namedNode('p'), namedNode(prefix + j));
+console.timeEnd(TEST);
+
+console.log(`* Memory usage after load: ${Math.round(process.memoryUsage().rss / 1024 / 1024)}MB`);
+
+// Each subject `i` has `dim` matching quads.
+function runMatchIterate(label, options) {
+  TEST = `- ${label}: match() + full iteration over ${dim} subjects`;
+  console.time(TEST);
+  for (let i = 0; i < dim; i++) {
+    const view = store.match(namedNode(prefix + i), null, null, null, options);
+    let count = 0;
+    for (const _ of view) // eslint-disable-line no-unused-vars
+      count++;
+    assert.equal(count, dim);
+  }
+  console.timeEnd(TEST);
+}
+
+// The hot path: `lazy` is the default and must not regress.
+runMatchIterate('lazy (default)', undefined);
+runMatchIterate('snapshot', { matchSemantics: 'snapshot' });
+runMatchIterate('forwarded', { matchSemantics: 'forwarded' });
+
+// Many non-matching parent mutations while many views are open: this exercises
+// the observer fan-out and the matching short-circuit.
+function runOpenViewsWithMutations(label, options) {
+  TEST = `- ${label}: ${dim} open views, ${dim} non-matching parent mutations`;
+  console.time(TEST);
+  const views = [];
+  for (let i = 0; i < dim; i++)
+    views.push(store.match(namedNode(prefix + i), null, null, null, options));
+  // Mutate a separate subject space so none of the open views match.
+  for (let j = 0; j < dim; j++)
+    store.addQuad(namedNode(`http://other/#${j}`), namedNode('p'), namedNode('o'));
+  // Clean up to keep the dataset stable across runs.
+  for (let j = 0; j < dim; j++)
+    store.removeQuad(namedNode(`http://other/#${j}`), namedNode('p'), namedNode('o'));
+  assert.equal(views.length, dim);
+  console.timeEnd(TEST);
+}
+
+runOpenViewsWithMutations('lazy (default)', undefined);
+runOpenViewsWithMutations('snapshot', { matchSemantics: 'snapshot' });
+runOpenViewsWithMutations('forwarded', { matchSemantics: 'forwarded' });
+
+// Iteration with a matching parent mutation landing mid-stream, for snapshot
+// and forwarded (the mid-stream parent->child switch).
+function runMidStreamSwitch(label, options) {
+  TEST = `- ${label}: ${dim} iterations each with a mid-stream matching mutation`;
+  console.time(TEST);
+  for (let i = 0; i < dim; i++) {
+    const view = store.match(namedNode(prefix + i), null, null, null, options);
+    let count = 0, mutated = false;
+    for (const _ of view) { // eslint-disable-line no-unused-vars
+      count++;
+      if (!mutated) {
+        mutated = true;
+        store.addQuad(namedNode(prefix + i), namedNode('p'), namedNode('mid'));
+      }
+    }
+    store.removeQuad(namedNode(prefix + i), namedNode('p'), namedNode('mid'));
+    // snapshot freezes at pre-mutation state (dim); forwarded stays stable for
+    // the in-progress pass (dim) as well.
+    assert.equal(count, dim);
+  }
+  console.timeEnd(TEST);
+}
+
+runMidStreamSwitch('snapshot', { matchSemantics: 'snapshot' });
+runMidStreamSwitch('forwarded', { matchSemantics: 'forwarded' });
+
+console.log(`* Memory usage at end: ${Math.round(process.memoryUsage().rss / 1024 / 1024)}MB`);

--- a/perf/N3StoreMatchSemantics-perf.js
+++ b/perf/N3StoreMatchSemantics-perf.js
@@ -101,8 +101,8 @@ function runMidStreamSwitch(label, options) {
     assert.equal(count, dim);
   }
   console.timeEnd(TEST);
-  // Untimed removal of the mid-stream quads; for `forwarded`,
-  // this also exercises delta removal on materialized views
+  // Untimed removal of the mid-stream quads; the `forwarded` views stay unmaterialized
+  // (iteration alone does not materialize), so this exercises the observers' no-op path
   for (let i = 0; i < dim; i++)
     store.removeQuad(namedNode(prefix + i), namedNode('p'), namedNode('mid'));
   assert.equal(store.size, total);

--- a/perf/N3StoreMatchSemantics-perf.js
+++ b/perf/N3StoreMatchSemantics-perf.js
@@ -12,18 +12,40 @@ const dim = Number.parseInt(process.argv[2], 10) || 256;
 const total = dim * dim;
 
 const prefix = 'http://example.org/#';
-const store = new N3.Store();
+
+// Each scenario gets its own store: `snapshot` and `forwarded` views keep observing
+// the parent store, so views left behind by one scenario would contaminate the next.
+function freshStore() {
+  const store = new N3.Store();
+  for (let i = 0; i < dim; i++)
+    for (let j = 0; j < dim; j++)
+      store.addQuad(namedNode(prefix + i), namedNode('p'), namedNode(prefix + j));
+  return store;
+}
+
+// Warm up all three semantics so JIT effects do not skew the first measurement.
+function warmUp() {
+  const store = new N3.Store();
+  for (let i = 0; i < 4; i++)
+    store.addQuad(namedNode(prefix + i), namedNode('p'), namedNode('o'));
+  [undefined, { matchSemantics: 'snapshot' }, { matchSemantics: 'forwarded' }].forEach((options, k) => {
+    const view = store.match(namedNode(prefix + 0), null, null, null, options);
+    assert.equal([...view].length, k + 1);
+    store.addQuad(namedNode(prefix + 0), namedNode('p'), namedNode(`warm${k}`));
+  });
+}
+warmUp();
 
 let TEST = `- Adding ${total} triples`;
 console.time(TEST);
-for (let i = 0; i < dim; i++)
-  for (let j = 0; j < dim; j++)
-    store.addQuad(namedNode(prefix + i), namedNode('p'), namedNode(prefix + j));
+const initial = freshStore();
 console.timeEnd(TEST);
+assert.equal(initial.size, total);
 
 console.log(`* Memory usage after load: ${Math.round(process.memoryUsage().rss / 1024 / 1024)}MB`);
 
 function runMatchIterate(label, options) {
+  const store = freshStore();
   TEST = `- ${label}: match() + full iteration over ${dim} subjects`;
   console.time(TEST);
   for (let i = 0; i < dim; i++) {
@@ -42,19 +64,18 @@ runMatchIterate('forwarded', { matchSemantics: 'forwarded' });
 
 // Many open views during non-matching parent mutations: exercises observer fan-out.
 function runOpenViewsWithMutations(label, options) {
-  TEST = `- ${label}: ${dim} open views, ${dim} non-matching parent mutations`;
-  console.time(TEST);
+  const store = freshStore();
   const views = [];
   for (let i = 0; i < dim; i++)
     views.push(store.match(namedNode(prefix + i), null, null, null, options));
+  TEST = `- ${label}: ${total} non-matching parent mutations with ${dim} open views`;
+  console.time(TEST);
   // Mutate a separate subject space so none of the open views match
-  for (let j = 0; j < dim; j++)
+  for (let j = 0; j < total; j++)
     store.addQuad(namedNode(`http://other/#${j}`), namedNode('p'), namedNode('o'));
-  // Clean up to keep the dataset stable across runs
-  for (let j = 0; j < dim; j++)
-    store.removeQuad(namedNode(`http://other/#${j}`), namedNode('p'), namedNode('o'));
-  assert.equal(views.length, dim);
   console.timeEnd(TEST);
+  assert.equal(views.length, dim);
+  assert.equal(store.size, total * 2);
 }
 
 runOpenViewsWithMutations('lazy (default)', undefined);
@@ -63,6 +84,7 @@ runOpenViewsWithMutations('forwarded', { matchSemantics: 'forwarded' });
 
 // Iteration with a matching parent mutation landing mid-stream.
 function runMidStreamSwitch(label, options) {
+  const store = freshStore();
   TEST = `- ${label}: ${dim} iterations each with a mid-stream matching mutation`;
   console.time(TEST);
   for (let i = 0; i < dim; i++) {
@@ -75,11 +97,15 @@ function runMidStreamSwitch(label, options) {
         store.addQuad(namedNode(prefix + i), namedNode('p'), namedNode('mid'));
       }
     }
-    store.removeQuad(namedNode(prefix + i), namedNode('p'), namedNode('mid'));
     // Both snapshot and forwarded stay stable for the in-progress pass (dim)
     assert.equal(count, dim);
   }
   console.timeEnd(TEST);
+  // Untimed removal of the mid-stream quads; for `forwarded`,
+  // this also exercises delta removal on materialized views
+  for (let i = 0; i < dim; i++)
+    store.removeQuad(namedNode(prefix + i), namedNode('p'), namedNode('mid'));
+  assert.equal(store.size, total);
 }
 
 runMidStreamSwitch('snapshot', { matchSemantics: 'snapshot' });

--- a/perf/N3StoreMatchSemantics-perf.js
+++ b/perf/N3StoreMatchSemantics-perf.js
@@ -1,8 +1,5 @@
 #!/usr/bin/env node
-// [OPUS-4.8] Benchmark for configurable `#match()` semantics (issue #595).
-// Compares the default `lazy` path (to demonstrate no regression) against the
-// `snapshot` and `forwarded` semantics, for both materialization-free queries
-// and iteration with concurrent parent mutations.
+// Benchmark for configurable `#match()` semantics, comparing `lazy`, `snapshot`, and `forwarded`.
 const assert = require('assert');
 const N3 = require('..');
 
@@ -10,8 +7,7 @@ const { DataFactory: { namedNode } } = N3;
 
 console.log('N3Store #match() semantics performance test');
 
-// `dim` controls the dataset size: `dim` subjects x `dim` predicates x `dim`
-// objects in the default graph.
+// `dim` x `dim` subjects/objects in the default graph.
 const dim = Number.parseInt(process.argv[2], 10) || 256;
 const total = dim * dim;
 
@@ -27,7 +23,6 @@ console.timeEnd(TEST);
 
 console.log(`* Memory usage after load: ${Math.round(process.memoryUsage().rss / 1024 / 1024)}MB`);
 
-// Each subject `i` has `dim` matching quads.
 function runMatchIterate(label, options) {
   TEST = `- ${label}: match() + full iteration over ${dim} subjects`;
   console.time(TEST);
@@ -41,23 +36,21 @@ function runMatchIterate(label, options) {
   console.timeEnd(TEST);
 }
 
-// The hot path: `lazy` is the default and must not regress.
 runMatchIterate('lazy (default)', undefined);
 runMatchIterate('snapshot', { matchSemantics: 'snapshot' });
 runMatchIterate('forwarded', { matchSemantics: 'forwarded' });
 
-// Many non-matching parent mutations while many views are open: this exercises
-// the observer fan-out and the matching short-circuit.
+// Many open views during non-matching parent mutations: exercises observer fan-out.
 function runOpenViewsWithMutations(label, options) {
   TEST = `- ${label}: ${dim} open views, ${dim} non-matching parent mutations`;
   console.time(TEST);
   const views = [];
   for (let i = 0; i < dim; i++)
     views.push(store.match(namedNode(prefix + i), null, null, null, options));
-  // Mutate a separate subject space so none of the open views match.
+  // Mutate a separate subject space so none of the open views match
   for (let j = 0; j < dim; j++)
     store.addQuad(namedNode(`http://other/#${j}`), namedNode('p'), namedNode('o'));
-  // Clean up to keep the dataset stable across runs.
+  // Clean up to keep the dataset stable across runs
   for (let j = 0; j < dim; j++)
     store.removeQuad(namedNode(`http://other/#${j}`), namedNode('p'), namedNode('o'));
   assert.equal(views.length, dim);
@@ -68,8 +61,7 @@ runOpenViewsWithMutations('lazy (default)', undefined);
 runOpenViewsWithMutations('snapshot', { matchSemantics: 'snapshot' });
 runOpenViewsWithMutations('forwarded', { matchSemantics: 'forwarded' });
 
-// Iteration with a matching parent mutation landing mid-stream, for snapshot
-// and forwarded (the mid-stream parent->child switch).
+// Iteration with a matching parent mutation landing mid-stream.
 function runMidStreamSwitch(label, options) {
   TEST = `- ${label}: ${dim} iterations each with a mid-stream matching mutation`;
   console.time(TEST);
@@ -84,8 +76,7 @@ function runMidStreamSwitch(label, options) {
       }
     }
     store.removeQuad(namedNode(prefix + i), namedNode('p'), namedNode('mid'));
-    // snapshot freezes at pre-mutation state (dim); forwarded stays stable for
-    // the in-progress pass (dim) as well.
+    // Both snapshot and forwarded stay stable for the in-progress pass (dim)
     assert.equal(count, dim);
   }
   console.timeEnd(TEST);

--- a/perf/N3StoreMatchSemantics-perf.js
+++ b/perf/N3StoreMatchSemantics-perf.js
@@ -1,5 +1,4 @@
 #!/usr/bin/env node
-// Benchmark for configurable `#match()` semantics, comparing `lazy`, `snapshot`, and `forwarded`.
 const assert = require('assert');
 const N3 = require('..');
 
@@ -7,31 +6,31 @@ const { DataFactory: { namedNode } } = N3;
 
 console.log('N3Store #match() semantics performance test');
 
-// `dim` x `dim` subjects/objects in the default graph.
 const dim = Number.parseInt(process.argv[2], 10) || 256;
 const total = dim * dim;
 
 const prefix = 'http://example.org/#';
+const predicate = namedNode('p');
+const object = namedNode('o');
+const mid = namedNode('mid');
 
-// Each scenario gets its own store: `snapshot` and `forwarded` views keep observing
-// the parent store, so views left behind by one scenario would contaminate the next.
+// Keep observers created by one scenario out of the next
 function freshStore() {
   const store = new N3.Store();
   for (let i = 0; i < dim; i++)
     for (let j = 0; j < dim; j++)
-      store.addQuad(namedNode(prefix + i), namedNode('p'), namedNode(prefix + j));
+      store.addQuad(namedNode(prefix + i), predicate, namedNode(prefix + j));
   return store;
 }
 
-// Warm up all three semantics so JIT effects do not skew the first measurement.
 function warmUp() {
   const store = new N3.Store();
   for (let i = 0; i < 4; i++)
-    store.addQuad(namedNode(prefix + i), namedNode('p'), namedNode('o'));
+    store.addQuad(namedNode(prefix + i), predicate, object);
   [undefined, { matchSemantics: 'snapshot' }, { matchSemantics: 'forwarded' }].forEach((options, k) => {
     const view = store.match(namedNode(prefix + 0), null, null, null, options);
     assert.equal([...view].length, k + 1);
-    store.addQuad(namedNode(prefix + 0), namedNode('p'), namedNode(`warm${k}`));
+    store.addQuad(namedNode(prefix + 0), predicate, namedNode(`warm${k}`));
   });
 }
 warmUp();
@@ -62,7 +61,7 @@ runMatchIterate('lazy (default)', undefined);
 runMatchIterate('snapshot', { matchSemantics: 'snapshot' });
 runMatchIterate('forwarded', { matchSemantics: 'forwarded' });
 
-// Many open views during non-matching parent mutations: exercises observer fan-out.
+/* Observer fan-out */
 function runOpenViewsWithMutations(label, options) {
   const store = freshStore();
   const views = [];
@@ -70,9 +69,8 @@ function runOpenViewsWithMutations(label, options) {
     views.push(store.match(namedNode(prefix + i), null, null, null, options));
   TEST = `- ${label}: ${total} non-matching parent mutations with ${dim} open views`;
   console.time(TEST);
-  // Mutate a separate subject space so none of the open views match
   for (let j = 0; j < total; j++)
-    store.addQuad(namedNode(`http://other/#${j}`), namedNode('p'), namedNode('o'));
+    store.addQuad(namedNode(`http://other/#${j}`), predicate, object);
   console.timeEnd(TEST);
   assert.equal(views.length, dim);
   assert.equal(store.size, total * 2);
@@ -82,7 +80,7 @@ runOpenViewsWithMutations('lazy (default)', undefined);
 runOpenViewsWithMutations('snapshot', { matchSemantics: 'snapshot' });
 runOpenViewsWithMutations('forwarded', { matchSemantics: 'forwarded' });
 
-// Iteration with a matching parent mutation landing mid-stream.
+/* Mid-iteration mutation */
 function runMidStreamSwitch(label, options) {
   const store = freshStore();
   TEST = `- ${label}: ${dim} iterations each with a mid-stream matching mutation`;
@@ -94,21 +92,38 @@ function runMidStreamSwitch(label, options) {
       count++;
       if (!mutated) {
         mutated = true;
-        store.addQuad(namedNode(prefix + i), namedNode('p'), namedNode('mid'));
+        store.addQuad(namedNode(prefix + i), predicate, mid);
       }
     }
-    // Both snapshot and forwarded stay stable for the in-progress pass (dim)
     assert.equal(count, dim);
   }
   console.timeEnd(TEST);
-  // Untimed removal of the mid-stream quads; the `forwarded` views stay unmaterialized
-  // (iteration alone does not materialize), so this exercises the observers' no-op path
   for (let i = 0; i < dim; i++)
-    store.removeQuad(namedNode(prefix + i), namedNode('p'), namedNode('mid'));
+    store.removeQuad(namedNode(prefix + i), predicate, mid);
   assert.equal(store.size, total);
 }
 
 runMidStreamSwitch('snapshot', { matchSemantics: 'snapshot' });
 runMidStreamSwitch('forwarded', { matchSemantics: 'forwarded' });
+
+/* Repeated mutations with a suspended iterator */
+function runSuspendedIteration() {
+  const store = freshStore();
+  const subject = namedNode(prefix + 0);
+  const view = store.match(subject, null, null, null, { matchSemantics: 'forwarded' });
+  const iterator = view[Symbol.iterator]();
+  assert.equal(iterator.next().done, false);
+
+  TEST = `- forwarded: ${dim} matching mutations with a suspended iteration`;
+  console.time(TEST);
+  for (let i = 0; i < dim; i++)
+    store.addQuad(subject, predicate, namedNode(`suspended${i}`));
+  console.timeEnd(TEST);
+
+  iterator.return();
+  assert.equal(view.size, dim * 2);
+}
+
+runSuspendedIteration();
 
 console.log(`* Memory usage at end: ${Math.round(process.memoryUsage().rss / 1024 / 1024)}MB`);

--- a/perf/N3StoreMatchSemantics-perf.js
+++ b/perf/N3StoreMatchSemantics-perf.js
@@ -83,9 +83,10 @@ runOpenViewsWithMutations('forwarded', { matchSemantics: 'forwarded' });
 /* Mid-iteration mutation */
 function runMidStreamSwitch(label, options) {
   const store = freshStore();
-  TEST = `- ${label}: ${dim} iterations each with a mid-stream matching mutation`;
-  console.time(TEST);
+  TEST = `- ${label}: ${dim} iterations with a mid-stream mutation and detach()`;
+  let elapsed = 0n;
   for (let i = 0; i < dim; i++) {
+    const start = process.hrtime.bigint();
     const view = store.match(namedNode(prefix + i), null, null, null, options);
     let count = 0, mutated = false;
     for (const _ of view) { // eslint-disable-line no-unused-vars
@@ -96,8 +97,11 @@ function runMidStreamSwitch(label, options) {
       }
     }
     assert.equal(count, dim);
+    view.detach();
+    elapsed += process.hrtime.bigint() - start;
   }
-  console.timeEnd(TEST);
+  assert.equal(store._observers, null);
+  console.log(`${TEST}: ${(Number(elapsed) / 1e6).toFixed(3)}ms`);
   for (let i = 0; i < dim; i++)
     store.removeQuad(namedNode(prefix + i), predicate, mid);
   assert.equal(store.size, total);

--- a/src/N3Store.js
+++ b/src/N3Store.js
@@ -1368,16 +1368,15 @@ class DatasetCoreAndReadableStream extends Readable {
   }
 
   union(quads) {
-    if (this._semantics !== 'lazy')
-      return this.filtered.union(quads);
+    // An unmaterialized view has seen no matching mutation, so the parent holds its exact contents;
+    // the internal view is explicitly `lazy` so that `addAll` cannot write through to the parent
     return this._filtered ?
       this._filtered.union(quads)
-      : this.n3Store.match(this.subject, this.predicate, this.object, this.graph).addAll(quads);
+      : this.n3Store.match(this.subject, this.predicate, this.object, this.graph, { matchSemantics: 'lazy' }).addAll(quads);
   }
 
   toArray() {
-    if (this._semantics !== 'lazy')
-      return this.filtered.toArray();
+    // An unmaterialized view has seen no matching mutation, so the parent holds its exact contents
     return this._filtered ? this._filtered.toArray() : this.n3Store.getQuads(this.subject, this.predicate, this.object, this.graph);
   }
 

--- a/src/N3Store.js
+++ b/src/N3Store.js
@@ -161,10 +161,7 @@ export default class N3Store {
     this._size = 0;
     // `_graphs` contains subject, predicate, and object indexes per graph
     this._graphs = Object.create(null);
-    // `_observers`, when non-null, is a set of callbacks that are notified
-    // *before* every mutation, so that derived views (e.g. `match()` results
-    // with `snapshot`/`forwarded` semantics) can react to parent mutations.
-    // It is `null` by default to keep the common mutation path allocation-free.
+    // `_observers`, when non-null, is a set of callbacks notified before every mutation
     this._observers = null;
 
     // Shift parameters if `quads` is not given
@@ -172,9 +169,7 @@ export default class N3Store {
       options = quads, quads = null;
     options = options || {};
     this._factory = options.factory || N3DataFactory;
-    // The default `match()` semantics for views derived from this store.
-    // One of `'lazy'` (default, backwards-compatible), `'snapshot'`, or
-    // `'forwarded'`. See `match()` for details.
+    // Default `match()` semantics ('lazy', 'snapshot', or 'forwarded'); see `match()`
     this._matchSemantics = options.matchSemantics || 'lazy';
     this._entityIndex = options.entityIndex || new N3EntityIndex({ factory: this._factory });
     this._entities = this._entityIndex._entities;
@@ -337,29 +332,22 @@ export default class N3Store {
     return typeof graph !== 'number' ? this._graphs : { [graph]: this._graphs[graph] };
   }
 
-  // ### `_addObserver` registers a callback that is invoked *before* every
-  // mutation of this store, receiving the numeric ids of the mutated quad and
-  // whether it is being added (`true`) or removed (`false`). Returns the
-  // callback so it can be passed back to `_removeObserver`.
+  // ### `_addObserver` registers a mutation observer and returns it.
   _addObserver(observer) {
     (this._observers || (this._observers = new Set())).add(observer);
     return observer;
   }
 
-  // ### `_removeObserver` unregisters a previously added mutation observer.
-  // Callers only invoke this with a currently-registered observer, so
-  // `_observers` is guaranteed to be non-null here.
+  // ### `_removeObserver` unregisters a mutation observer.
   _removeObserver(observer) {
     this._observers.delete(observer);
-    // Restore the allocation-free fast path once no observers remain.
     if (this._observers.size === 0)
       this._observers = null;
   }
 
-  // ### `_notifyObservers` invokes all registered observers with the numeric
-  // ids of a quad that is about to be added or removed.
+  // ### `_notifyObservers` invokes all observers with the ids of a mutated quad.
   _notifyObservers(subjectId, predicateId, objectId, graphId, added) {
-    // Iterate over a copy so observers may unregister themselves while reacting.
+    // Iterate over a copy so observers may unregister themselves while reacting
     for (const observer of [...this._observers])
       observer(subjectId, predicateId, objectId, graphId, added);
   }
@@ -414,9 +402,7 @@ export default class N3Store {
     predicate = this._termToNewNumericId(predicate);
     object    = this._termToNewNumericId(object);
 
-    // Notify observers *before* the mutation, so snapshot views can lazily
-    // capture the pre-mutation parent state. Only fire for quads that will
-    // actually change the index (i.e. quads that did not already exist).
+    // Notify observers before the mutation, but only for quads that don't already exist
     if (this._observers !== null) {
       const subjects = graphItem.subjects[subject], predicates = subjects && subjects[predicate];
       if (!predicates || !(object in predicates))
@@ -478,8 +464,7 @@ export default class N3Store {
         !(object in predicates))
       return false;
 
-    // Notify observers *before* the mutation, so snapshot views can lazily
-    // capture the pre-mutation parent state.
+    // Notify observers before the mutation
     if (this._observers !== null)
       this._notifyObservers(subject, predicate, object, graph, false);
 
@@ -589,17 +574,11 @@ export default class N3Store {
   // Note: Since a DatasetCore is an unordered set, the order of the quads within the returned sequence is arbitrary.
   // Setting any field to `undefined` or `null` indicates a wildcard.
   // For backwards compatibility, the object return also implements the Readable stream interface.
-  //
-  // The semantics of the returned view with respect to later parent mutations
-  // can be configured via `options.matchSemantics` (falling back to the
-  // store-level `matchSemantics` option, default `'lazy'`):
-  //  - `'lazy'`: backwards-compatible behavior. The view delegates live to the
-  //    parent until its first own mutation, after which it materializes a
-  //    snapshot. Parent mutations made before that first own mutation leak in.
-  //  - `'snapshot'`: the view reflects the parent contents *at the time of*
-  //    `match()`. Later parent mutations never affect it.
-  //  - `'forwarded'`: the view always reflects the parent state; matching
-  //    parent mutations are forwarded to it (a live view).
+  // `options.matchSemantics` (defaulting to the store-level option, default `'lazy'`) sets
+  // how the view reacts to later parent mutations:
+  //  - `'lazy'`: delegates live to the parent until its first own mutation (backwards-compatible).
+  //  - `'snapshot'`: reflects the parent contents at the time of `match()`.
+  //  - `'forwarded'`: stays live; matching parent mutations are forwarded to it.
   match(subject, predicate, object, graph, options) {
     return new DatasetCoreAndReadableStream(this, subject, predicate, object, graph, {
       entityIndex: this._entityIndex,
@@ -930,9 +909,7 @@ export default class N3Store {
 
     if (Array.isArray(quads))
       this.addQuads(quads);
-    // The index-merge fast path bypasses `addQuad`, so it cannot be used when
-    // observers are registered (e.g. for `forwarded` views), as they must be
-    // notified of every added quad.
+    // The index-merge fast path bypasses `addQuad`, so it can't be used when observers are registered
     else if (this._observers === null && quads instanceof N3Store && quads._entityIndex === this._entityIndex) {
       if (quads._size !== 0) {
         this._graphs = merge(this._graphs, quads._graphs);
@@ -1184,33 +1161,21 @@ class DatasetCoreAndReadableStream extends Readable {
   constructor(n3Store, subject, predicate, object, graph, options) {
     super({ objectMode: true });
     Object.assign(this, { n3Store, subject, predicate, object, graph, options });
-    // `_generation` is bumped whenever a matching parent mutation lands while an
-    // iteration is in progress, so that in-progress iterators can detect the
-    // need to switch from the live parent to a frozen baseline mid-iteration.
+    // Bumped when a matching parent mutation lands mid-iteration, signalling iterators to switch to `_baseline`
     this._generation = 0;
-    // Number of iterations currently in progress over this view. A frozen
-    // baseline is only captured on parent mutation while this is non-zero,
-    // keeping mutations cheap when nothing is being iterated.
+    // Number of in-progress iterations; a baseline is only frozen on mutation while this is non-zero
     this._activeIterators = 0;
-    // A frozen array of the matching quads as of the start of the in-progress
-    // iteration(s); used to keep iterators stable across parent mutations.
+    // Frozen array of matching quads at the start of in-progress iteration(s), to keep iterators stable
     this._baseline = null;
-    // `options.matchSemantics` is always resolved to a concrete value by the
-    // callers (`Store#match` and the view's own `match`).
     const semantics = this._semantics = options.matchSemantics;
     if (semantics !== 'lazy' && semantics !== 'snapshot' && semantics !== 'forwarded')
       throw new Error(`Unknown matchSemantics: ${semantics}`);
-    // For non-`lazy` semantics, observe parent mutations so that the view can
-    // be kept consistent without eagerly copying the whole match result.
+    // For non-`lazy` semantics, observe parent mutations to keep the view consistent
     if (semantics !== 'lazy')
       this._observer = n3Store._addObserver(this._onParentMutation.bind(this));
   }
 
-  // ### `_matchesPattern` returns whether the quad identified by the given
-  // numeric ids falls within this view's `subject`/`predicate`/`object`/`graph`
-  // pattern. A `null`/`undefined` pattern term is a wildcard; a present term is
-  // matched against the corresponding id (resolved against the parent's entity
-  // index, which never reassigns an id once given).
+  // ### `_matchesPattern` returns whether the quad ids fall within this view's pattern (absent term = wildcard).
   _matchesPattern(subjectId, predicateId, objectId, graphId) {
     const { subject, predicate, object, graph } = this;
     return (!subject   || subjectId   === this._termId(subject))   &&
@@ -1219,41 +1184,29 @@ class DatasetCoreAndReadableStream extends Readable {
            (!graph     || graphId     === (isDefaultGraph(graph) ? 1 : this._termId(graph)));
   }
 
-  // ### `_termId` returns the parent's numeric id for a pattern term, or
-  // `undefined` if the term is not (yet) present. The default graph is handled
-  // by the caller.
+  // ### `_termId` returns the parent's numeric id for a term, or `undefined` if not present.
   _termId(term) {
     return this.n3Store._termToNumericId(term);
   }
 
-  // ### `_onParentMutation` reacts to a parent mutation for `snapshot` and
-  // `forwarded` semantics. It is invoked *before* the parent index changes,
-  // so the pre-mutation state is still observable here.
+  // ### `_onParentMutation` reacts to a parent mutation, invoked before the parent index changes.
   _onParentMutation(subjectId, predicateId, objectId, graphId, added) {
-    // Only matching quads can affect this view; ignore everything else so the
-    // common path stays cheap.
+    // Only matching quads can affect this view
     if (!this._matchesPattern(subjectId, predicateId, objectId, graphId))
       return;
 
-    // If an iteration is in progress, freeze the current (pre-mutation)
-    // matching quads so those iterators keep a stable view. This is only done
-    // once per in-flight batch of iterations (until they all finish), and only
-    // while iterating, so the common, non-iterating path stays allocation-free.
+    // While iterating, freeze the pre-mutation matching quads so iterators keep a stable view
     if (this._activeIterators > 0 && this._baseline === null) {
       this._baseline = this._filtered ? [...this._filtered] :
         this.n3Store.getQuads(this.subject, this.predicate, this.object, this.graph);
       this._generation++;
     }
 
-    // Materialize the pre-mutation snapshot if it does not exist yet. For
-    // `forwarded` views `_filtered` may already exist (e.g. from an earlier
-    // mutation or query); for `snapshot` views the `filtered` getter detaches
-    // the observer once built, so this method is never re-entered afterwards.
+    // Materialize the pre-mutation snapshot if it does not exist yet
     if (!this._filtered)
       this._filtered = this.filtered;
 
-    // `forwarded`: apply the delta so the view tracks the parent. (`snapshot`
-    // views are now frozen and ignore the mutation.)
+    // `forwarded`: apply the delta so the view tracks the parent (`snapshot` views are now frozen)
     if (this._semantics === 'forwarded') {
       const quad = this._toQuad(subjectId, predicateId, objectId, graphId);
       if (added)
@@ -1314,8 +1267,7 @@ class DatasetCoreAndReadableStream extends Readable {
       }
       newStore._size = null;
 
-      // A `snapshot` view is frozen once built, so it no longer needs to
-      // observe the parent. (`forwarded` views keep observing.)
+      // A `snapshot` view is frozen once built, so it no longer needs to observe the parent
       if (this._semantics === 'snapshot' && this._observer) {
         this.n3Store._removeObserver(this._observer);
         this._observer = null;
@@ -1403,9 +1355,7 @@ class DatasetCoreAndReadableStream extends Readable {
   }
 
   toStream() {
-    // For non-`lazy` semantics, route through the (possibly materialized)
-    // snapshot so the stream reflects the configured view rather than the live
-    // parent. For `lazy`, preserve the original delegation for performance.
+    // For non-`lazy` semantics, route through the snapshot rather than the live parent
     if (this._semantics !== 'lazy')
       return this.filtered.toStream();
     return this._filtered ?
@@ -1436,8 +1386,7 @@ class DatasetCoreAndReadableStream extends Readable {
   }
 
   add(quad) {
-    // For `forwarded` views, mutations are written through to the parent store,
-    // which then forwards the change back to this view via the observer.
+    // `forwarded` views write through to the parent, which forwards the change back via the observer
     if (this._semantics === 'forwarded') {
       this.n3Store.addQuad(quad);
       return this;
@@ -1462,23 +1411,14 @@ class DatasetCoreAndReadableStream extends Readable {
   }
 
   *[Symbol.iterator]() {
-    // `lazy` semantics: original behavior. Iterate the materialized snapshot if
-    // it exists, otherwise delegate live to the parent. No observers exist for
-    // lazy views, so no mid-iteration switching can occur.
+    // `lazy`: iterate the snapshot if it exists, else delegate live to the parent
     if (this._semantics === 'lazy') {
       yield* this._filtered || this.n3Store.readQuads(this.subject, this.predicate, this.object, this.graph);
       return;
     }
 
-    // Non-`lazy` semantics: iterate a view that stays stable for the duration of
-    // this iteration, even if the parent is mutated mid-stream. We iterate the
-    // current source (the materialized snapshot if present, else the live
-    // parent). If a matching parent mutation lands while we iterate, the
-    // observer freezes the pre-mutation matching quads into `_baseline` and
-    // bumps `_generation`; we then switch to `_baseline`, skipping the quads we
-    // have already yielded. Because `_baseline` is captured in the same order
-    // the source iterates, skip-by-count yields exactly the remaining quads with
-    // no duplicates or omissions.
+    // Non-`lazy`: iterate the current source, switching to the frozen `_baseline` (skipping
+    // already-yielded quads) if a matching parent mutation bumps `_generation` mid-iteration.
     const generation = this._generation;
     let yielded = 0;
     this._activeIterators++;
@@ -1494,13 +1434,12 @@ class DatasetCoreAndReadableStream extends Readable {
         yielded++;
         yield quad;
       }
-      // A mutation may have landed exactly when the source was exhausted.
+      // A mutation may have landed exactly when the source was exhausted
       if (this._generation !== generation)
         yield* this._skip(this._baseline[Symbol.iterator](), yielded);
     }
     finally {
-      // Once no iterations remain, drop the frozen baseline so future mutations
-      // do not pay to maintain it.
+      // Drop the frozen baseline once no iterations remain
       if (--this._activeIterators === 0)
         this._baseline = null;
     }

--- a/src/N3Store.js
+++ b/src/N3Store.js
@@ -576,7 +576,8 @@ export default class N3Store {
   // For backwards compatibility, the object return also implements the Readable stream interface.
   // `options.matchSemantics` (defaulting to the store-level option, default `'lazy'`) sets
   // how the view reacts to later parent mutations:
-  //  - `'lazy'`: delegates live to the parent until its first own mutation (backwards-compatible).
+  //  - `'lazy'`: delegates live to the parent until its first mutation or materializing
+  //    read, such as `size` or `has` (backwards-compatible).
   //  - `'snapshot'`: reflects the parent contents at the time of `match()`.
   //  - `'forwarded'`: stays live; matching parent mutations are forwarded to it, and view
   //    mutations write through to the parent unrestricted by the pattern (so a

--- a/src/N3Store.js
+++ b/src/N3Store.js
@@ -1388,6 +1388,9 @@ class DatasetCoreAndReadableStream extends Readable {
   }
 
   import(stream) {
+    // `forwarded` views write imported quads through to the parent, like `add` and `addAll`
+    if (this._semantics === 'forwarded')
+      return this.n3Store.import(stream);
     return this.filtered.import(stream);
   }
 

--- a/src/N3Store.js
+++ b/src/N3Store.js
@@ -579,6 +579,8 @@ export default class N3Store {
   //  - `'lazy'`: delegates live to the parent until its first own mutation (backwards-compatible).
   //  - `'snapshot'`: reflects the parent contents at the time of `match()`.
   //  - `'forwarded'`: stays live; matching parent mutations are forwarded to it.
+  // Calling `match()` on a view yields at most a `'snapshot'` sub-view:
+  // nested views never write through to the root store.
   match(subject, predicate, object, graph, options) {
     return new DatasetCoreAndReadableStream(this, subject, predicate, object, graph, {
       entityIndex: this._entityIndex,
@@ -1425,7 +1427,13 @@ class DatasetCoreAndReadableStream extends Readable {
   }
 
   match(subject, predicate, object, graph) {
-    return new DatasetCoreAndReadableStream(this.filtered, subject, predicate, object, graph, this.options);
+    // A nested view is parented on the materialized contents, not on the root store,
+    // so `forwarded` is downgraded to `snapshot`: write-through would only reach
+    // the internal materialized store, silently desyncing this view from its parent
+    return new DatasetCoreAndReadableStream(this.filtered, subject, predicate, object, graph, {
+      entityIndex: this.options.entityIndex,
+      matchSemantics: this._semantics === 'forwarded' ? 'snapshot' : this._semantics,
+    });
   }
 
   *[Symbol.iterator]() {

--- a/src/N3Store.js
+++ b/src/N3Store.js
@@ -347,8 +347,8 @@ export default class N3Store {
 
   // ### `_notifyObservers` invokes all observers with the ids of a mutated quad.
   _notifyObservers(subjectId, predicateId, objectId, graphId, added) {
-    // Iterate over a copy so observers may unregister themselves while reacting
-    for (const observer of [...this._observers])
+    // Observers only ever unregister themselves, which is safe mid-iteration of a Set
+    for (const observer of this._observers)
       observer(subjectId, predicateId, objectId, graphId, added);
   }
 

--- a/src/N3Store.js
+++ b/src/N3Store.js
@@ -1261,6 +1261,13 @@ class DatasetCoreAndReadableStream extends Readable {
       const { n3Store, graph, object, predicate, subject } = this;
       const newStore = this._filtered = new N3Store({ factory: n3Store._factory, entityIndex: this.options.entityIndex });
 
+      // A `snapshot` view is frozen once it materializes, so it no longer needs to observe
+      // the parent — also when a pattern term is absent and the view materializes empty
+      if (this._semantics === 'snapshot' && this._observer) {
+        this.n3Store._removeObserver(this._observer);
+        this._observer = null;
+      }
+
       let subjectId, predicateId, objectId;
 
       // Translate IRIs to internal index keys.
@@ -1295,12 +1302,6 @@ class DatasetCoreAndReadableStream extends Readable {
         }
       }
       newStore._size = null;
-
-      // A `snapshot` view is frozen once built, so it no longer needs to observe the parent
-      if (this._semantics === 'snapshot' && this._observer) {
-        this.n3Store._removeObserver(this._observer);
-        this._observer = null;
-      }
     }
     return this._filtered;
   }

--- a/src/N3Store.js
+++ b/src/N3Store.js
@@ -581,6 +581,10 @@ export default class N3Store {
   //  - `'forwarded'`: stays live; matching parent mutations are forwarded to it.
   // Calling `match()` on a view yields at most a `'snapshot'` sub-view:
   // nested views never write through to the root store.
+  // A non-`lazy` view observes the store — `'snapshot'` until it first materializes,
+  // `'forwarded'` for the store's lifetime or until `detach()` — so the store retains
+  // each observing view, checks every mutation against its pattern, and cannot use
+  // the same-index `addAll` fast path while any view observes.
   match(subject, predicate, object, graph, options) {
     return new DatasetCoreAndReadableStream(this, subject, predicate, object, graph, {
       entityIndex: this._entityIndex,
@@ -1323,6 +1327,20 @@ class DatasetCoreAndReadableStream extends Readable {
       this[ITERATOR] = null;
     }
     callback(error);
+  }
+
+  // ### `detach` freezes the view to its current contents and stops observing the parent,
+  // so the parent no longer retains the view nor checks mutations against its pattern.
+  detach() {
+    // Materializing a `snapshot` view removes its observer; remove a `forwarded` observer explicitly
+    this._filtered = this.filtered;
+    if (this._observer) {
+      this.n3Store._removeObserver(this._observer);
+      this._observer = null;
+    }
+    // Parent deltas are no longer forwarded, so subsequent view mutations apply locally
+    this._semantics = 'snapshot';
+    return this;
   }
 
   addAll(quads) {

--- a/src/N3Store.js
+++ b/src/N3Store.js
@@ -1167,6 +1167,8 @@ class DatasetCoreAndReadableStream extends Readable {
     this._activeIterators = 0;
     // Frozen array of matching quads at the start of in-progress iteration(s), to keep iterators stable
     this._baseline = null;
+    // Lazily cached numeric ids of the pattern terms (immutable once present in the entity index)
+    this._subjectId = this._predicateId = this._objectId = this._graphId = undefined;
     const semantics = this._semantics = options.matchSemantics;
     if (semantics !== 'lazy' && semantics !== 'snapshot' && semantics !== 'forwarded')
       throw new Error(`Unknown matchSemantics: ${semantics}`);
@@ -1176,17 +1178,15 @@ class DatasetCoreAndReadableStream extends Readable {
   }
 
   // ### `_matchesPattern` returns whether the quad ids fall within this view's pattern (absent term = wildcard).
+  // Term ids are cached upon resolution; a pattern term may still be absent from the entity index
+  // (`_termToNumericId` then returns `undefined`, which never equals a quad id), so an
+  // unresolved id is re-resolved on every call, as the term may be interned later on.
   _matchesPattern(subjectId, predicateId, objectId, graphId) {
-    const { subject, predicate, object, graph } = this;
-    return (!subject   || subjectId   === this._termId(subject))   &&
-           (!predicate || predicateId === this._termId(predicate)) &&
-           (!object    || objectId    === this._termId(object))    &&
-           (!graph     || graphId     === (isDefaultGraph(graph) ? 1 : this._termId(graph)));
-  }
-
-  // ### `_termId` returns the parent's numeric id for a term, or `undefined` if not present.
-  _termId(term) {
-    return this.n3Store._termToNumericId(term);
+    const { subject, predicate, object, graph, n3Store } = this;
+    return (!subject   || subjectId   === (this._subjectId   || (this._subjectId   = n3Store._termToNumericId(subject))))   &&
+           (!predicate || predicateId === (this._predicateId || (this._predicateId = n3Store._termToNumericId(predicate)))) &&
+           (!object    || objectId    === (this._objectId    || (this._objectId    = n3Store._termToNumericId(object))))    &&
+           (!graph     || graphId     === (this._graphId     || (this._graphId     = isDefaultGraph(graph) ? 1 : n3Store._termToNumericId(graph))));
   }
 
   // ### `_onParentMutation` reacts to a parent mutation, invoked before the parent index changes.
@@ -1202,28 +1202,32 @@ class DatasetCoreAndReadableStream extends Readable {
       this._generation++;
     }
 
-    // Materialize the pre-mutation snapshot if it does not exist yet
-    if (!this._filtered)
-      this._filtered = this.filtered;
-
-    // `forwarded`: apply the delta so the view tracks the parent (`snapshot` views are now frozen)
+    // `forwarded`: apply the delta only if the view has materialized; otherwise,
+    // the parent remains the source of truth, and a later read captures the current state
     if (this._semantics === 'forwarded') {
-      const quad = this._toQuad(subjectId, predicateId, objectId, graphId);
-      if (added)
-        this._filtered.addQuad(quad);
-      else
-        this._filtered.removeQuad(quad);
+      if (this._filtered) {
+        const quad = this._toQuad(subjectId, predicateId, objectId, graphId);
+        if (added)
+          this._filtered.addQuad(quad);
+        else
+          this._filtered.removeQuad(quad);
+      }
+      return;
     }
+
+    // `snapshot`: materialize the pre-mutation state
+    // (`_filtered` is always null here, as its getter unregisters this observer on build)
+    this._filtered = this.filtered;
   }
 
   // ### `_toQuad` builds a Quad from numeric ids in the parent's entity index.
   _toQuad(subjectId, predicateId, objectId, graphId) {
     const { n3Store } = this, entities = n3Store._entities;
     return n3Store._factory.quad(
-      n3Store._termFromId(entities[subjectId], n3Store._factory),
-      n3Store._termFromId(entities[predicateId], n3Store._factory),
-      n3Store._termFromId(entities[objectId], n3Store._factory),
-      n3Store._termFromId(entities[graphId], n3Store._factory),
+      n3Store._termFromId(entities[subjectId]),
+      n3Store._termFromId(entities[predicateId]),
+      n3Store._termFromId(entities[objectId]),
+      n3Store._termFromId(entities[graphId]),
     );
   }
 

--- a/src/N3Store.js
+++ b/src/N3Store.js
@@ -1179,7 +1179,8 @@ class DatasetCoreAndReadableStream extends Readable {
       this._observer = n3Store._addObserver(this._onParentMutation.bind(this));
   }
 
-  // ### `_matchesPattern` returns whether the quad ids fall within this view's pattern (absent term = wildcard).
+  // ### `_matchesPattern` returns whether the quad ids fall within this view's pattern
+  // (absent term = wildcard; the legacy `''` graph argument denotes the default graph, as in `_getGraphs`).
   // Term ids are cached upon resolution; a pattern term may still be absent from the entity index
   // (`_termToNumericId` then returns `undefined`, which never equals a quad id), so an
   // unresolved id is re-resolved on every call, as the term may be interned later on.
@@ -1188,7 +1189,8 @@ class DatasetCoreAndReadableStream extends Readable {
     return (!subject   || subjectId   === (this._subjectId   || (this._subjectId   = n3Store._termToNumericId(subject))))   &&
            (!predicate || predicateId === (this._predicateId || (this._predicateId = n3Store._termToNumericId(predicate)))) &&
            (!object    || objectId    === (this._objectId    || (this._objectId    = n3Store._termToNumericId(object))))    &&
-           (!graph     || graphId     === (this._graphId     || (this._graphId     = isDefaultGraph(graph) ? 1 : n3Store._termToNumericId(graph))));
+           (graph == null || graphId  === (this._graphId     || (this._graphId     =
+             graph === '' || isDefaultGraph(graph) ? 1 : n3Store._termToNumericId(graph))));
   }
 
   // ### `_onParentMutation` reacts to a parent mutation, invoked before the parent index changes.

--- a/src/N3Store.js
+++ b/src/N3Store.js
@@ -1219,7 +1219,9 @@ class DatasetCoreAndReadableStream extends Readable {
 
     // While iterating, freeze the pre-mutation matching quads under the current generation,
     // so every iteration in progress (each started during some generation) keeps a stable view.
-    // This costs O(view size) per matching mutation for as long as any iteration remains open.
+    // While any iteration remains open, each matching mutation costs O(view size) and retains
+    // one frozen array (even for generations at which no iteration started); all baselines
+    // are released once the last iteration closes.
     if (this._activeIterators > 0) {
       if (!this._baselines)
         this._baselines = new Map();
@@ -1463,6 +1465,7 @@ class DatasetCoreAndReadableStream extends Readable {
   }
 
   match(subject, predicate, object, graph) {
+    // Unlike the store's `match`, this takes no `options`: sub-views inherit these semantics.
     // A nested view is parented on the materialized contents, not on the root store,
     // so `forwarded` is downgraded to `snapshot`: write-through would only reach
     // the internal materialized store, silently desyncing this view from its parent

--- a/src/N3Store.js
+++ b/src/N3Store.js
@@ -968,7 +968,8 @@ export default class N3Store {
    * @param graph     The optional exact graph to match.
    */
   deleteMatches(subject, predicate, object, graph) {
-    for (const quad of this.match(subject, predicate, object, graph))
+    // Internal matching is explicitly `lazy`: a non-`lazy` view would register an observer that is never released
+    for (const quad of this.match(subject, predicate, object, graph, { matchSemantics: 'lazy' }))
       this.removeQuad(quad);
     return this;
   }
@@ -1094,9 +1095,10 @@ export default class N3Store {
 
   /**
    * Returns a stream that contains all quads of the dataset.
+   * The stream is explicitly `lazy`: a non-`lazy` view would register an observer that is never released.
    */
   toStream() {
-    return this.match();
+    return this.match(null, null, null, null, { matchSemantics: 'lazy' });
   }
 
   /**
@@ -1362,9 +1364,10 @@ class DatasetCoreAndReadableStream extends Readable {
     // For non-`lazy` semantics, route through the snapshot rather than the live parent
     if (this._semantics !== 'lazy')
       return this.filtered.toStream();
+    // The internal view is explicitly `lazy`, so a non-`lazy` store default cannot leak an observer
     return this._filtered ?
       this._filtered.toStream()
-      : this.n3Store.match(this.subject, this.predicate, this.object, this.graph);
+      : this.n3Store.match(this.subject, this.predicate, this.object, this.graph, { matchSemantics: 'lazy' });
   }
 
   union(quads) {

--- a/src/N3Store.js
+++ b/src/N3Store.js
@@ -1165,12 +1165,12 @@ class DatasetCoreAndReadableStream extends Readable {
   constructor(n3Store, subject, predicate, object, graph, options) {
     super({ objectMode: true });
     Object.assign(this, { n3Store, subject, predicate, object, graph, options });
-    // Bumped when a matching parent mutation lands mid-iteration, signalling iterators to switch to `_baseline`
+    // Bumped when a matching parent mutation lands mid-iteration, signalling iterators to switch to their baseline
     this._generation = 0;
-    // Number of in-progress iterations; a baseline is only frozen on mutation while this is non-zero
+    // Number of in-progress iterations; baselines are only frozen on mutation while this is non-zero
     this._activeIterators = 0;
-    // Frozen array of matching quads at the start of in-progress iteration(s), to keep iterators stable
-    this._baseline = null;
+    // Frozen arrays of matching quads per generation, keeping in-progress iterations stable
+    this._baselines = null;
     // Lazily cached numeric ids of the pattern terms (immutable once present in the entity index)
     this._subjectId = this._predicateId = this._objectId = this._graphId = undefined;
     const semantics = this._semantics = options.matchSemantics;
@@ -1202,11 +1202,14 @@ class DatasetCoreAndReadableStream extends Readable {
     if (!this._matchesPattern(subjectId, predicateId, objectId, graphId))
       return;
 
-    // While iterating, freeze the pre-mutation matching quads so iterators keep a stable view
-    if (this._activeIterators > 0 && this._baseline === null) {
-      this._baseline = this._filtered ? [...this._filtered] :
-        this.n3Store.getQuads(this.subject, this.predicate, this.object, this.graph);
-      this._generation++;
+    // While iterating, freeze the pre-mutation matching quads under the current generation,
+    // so every iteration in progress (each started during some generation) keeps a stable view.
+    // This costs O(view size) per matching mutation for as long as any iteration remains open.
+    if (this._activeIterators > 0) {
+      if (!this._baselines)
+        this._baselines = new Map();
+      this._baselines.set(this._generation++, this._filtered ? [...this._filtered] :
+        this.n3Store.getQuads(this.subject, this.predicate, this.object, this.graph));
     }
 
     // `forwarded`: apply the delta only if the view has materialized; otherwise,
@@ -1443,8 +1446,8 @@ class DatasetCoreAndReadableStream extends Readable {
       return;
     }
 
-    // Non-`lazy`: iterate the current source, switching to the frozen `_baseline` (skipping
-    // already-yielded quads) if a matching parent mutation bumps `_generation` mid-iteration.
+    // Non-`lazy`: iterate the current source, switching to this iteration's frozen baseline
+    // if a matching parent mutation bumps `_generation` mid-iteration.
     const generation = this._generation;
     let yielded = 0;
     this._activeIterators++;
@@ -1453,28 +1456,23 @@ class DatasetCoreAndReadableStream extends Readable {
         this._filtered[Symbol.iterator]() :
         this.n3Store.readQuads(this.subject, this.predicate, this.object, this.graph);
       for (const quad of source) {
-        if (this._generation !== generation) {
-          yield* this._skip(this._baseline[Symbol.iterator](), yielded);
-          return;
-        }
+        if (this._generation !== generation)
+          break;
         yielded++;
         yield quad;
       }
-      // A mutation may have landed exactly when the source was exhausted
-      if (this._generation !== generation)
-        yield* this._skip(this._baseline[Symbol.iterator](), yielded);
+      // A matching mutation landed mid-iteration (possibly exactly as the source was exhausted):
+      // continue from the baseline frozen at this iteration's generation, skipping already-yielded quads
+      if (this._generation !== generation) {
+        const baseline = this._baselines.get(generation);
+        for (let i = yielded; i < baseline.length; i++)
+          yield baseline[i];
+      }
     }
     finally {
-      // Drop the frozen baseline once no iterations remain
+      // Drop the frozen baselines once no iterations remain
       if (--this._activeIterators === 0)
-        this._baseline = null;
+        this._baselines = null;
     }
-  }
-
-  // ### `_skip` advances `iterator` past `count` quads and yields the rest.
-  *_skip(iterator, count) {
-    while (count-- > 0)
-      iterator.next();
-    yield* iterator;
   }
 }

--- a/src/N3Store.js
+++ b/src/N3Store.js
@@ -1303,6 +1303,15 @@ class DatasetCoreAndReadableStream extends Readable {
     }
   }
 
+  // ### `_destroy` closes the cached iterator, so a destroyed stream releases its iteration state.
+  _destroy(error, callback) {
+    if (this[ITERATOR]) {
+      this[ITERATOR].return();
+      this[ITERATOR] = null;
+    }
+    callback(error);
+  }
+
   addAll(quads) {
     if (this._semantics === 'forwarded') {
       this.n3Store.addAll(quads);

--- a/src/N3Store.js
+++ b/src/N3Store.js
@@ -1189,8 +1189,9 @@ class DatasetCoreAndReadableStream extends Readable {
     return (!subject   || subjectId   === (this._subjectId   || (this._subjectId   = n3Store._termToNumericId(subject))))   &&
            (!predicate || predicateId === (this._predicateId || (this._predicateId = n3Store._termToNumericId(predicate)))) &&
            (!object    || objectId    === (this._objectId    || (this._objectId    = n3Store._termToNumericId(object))))    &&
-           (graph == null || graphId  === (this._graphId     || (this._graphId     =
-             graph === '' || isDefaultGraph(graph) ? 1 : n3Store._termToNumericId(graph))));
+           (graph === null || graph === undefined ||
+             graphId === (this._graphId || (this._graphId =
+               graph === '' || isDefaultGraph(graph) ? 1 : n3Store._termToNumericId(graph))));
   }
 
   // ### `_onParentMutation` reacts to a parent mutation, invoked before the parent index changes.

--- a/src/N3Store.js
+++ b/src/N3Store.js
@@ -578,7 +578,9 @@ export default class N3Store {
   // how the view reacts to later parent mutations:
   //  - `'lazy'`: delegates live to the parent until its first own mutation (backwards-compatible).
   //  - `'snapshot'`: reflects the parent contents at the time of `match()`.
-  //  - `'forwarded'`: stays live; matching parent mutations are forwarded to it.
+  //  - `'forwarded'`: stays live; matching parent mutations are forwarded to it, and view
+  //    mutations write through to the parent unrestricted by the pattern (so a
+  //    non-matching `add` mutates the parent without appearing in the view).
   // Calling `match()` on a view yields at most a `'snapshot'` sub-view:
   // nested views never write through to the root store.
   // A non-`lazy` view observes the store — `'snapshot'` until it first materializes,

--- a/src/N3Store.js
+++ b/src/N3Store.js
@@ -161,12 +161,21 @@ export default class N3Store {
     this._size = 0;
     // `_graphs` contains subject, predicate, and object indexes per graph
     this._graphs = Object.create(null);
+    // `_observers`, when non-null, is a set of callbacks that are notified
+    // *before* every mutation, so that derived views (e.g. `match()` results
+    // with `snapshot`/`forwarded` semantics) can react to parent mutations.
+    // It is `null` by default to keep the common mutation path allocation-free.
+    this._observers = null;
 
     // Shift parameters if `quads` is not given
     if (!options && quads && !quads[0] && !(typeof quads.match === 'function'))
       options = quads, quads = null;
     options = options || {};
     this._factory = options.factory || N3DataFactory;
+    // The default `match()` semantics for views derived from this store.
+    // One of `'lazy'` (default, backwards-compatible), `'snapshot'`, or
+    // `'forwarded'`. See `match()` for details.
+    this._matchSemantics = options.matchSemantics || 'lazy';
     this._entityIndex = options.entityIndex || new N3EntityIndex({ factory: this._factory });
     this._entities = this._entityIndex._entities;
     this._termFromId = this._entityIndex._termFromId.bind(this._entityIndex);
@@ -328,6 +337,33 @@ export default class N3Store {
     return typeof graph !== 'number' ? this._graphs : { [graph]: this._graphs[graph] };
   }
 
+  // ### `_addObserver` registers a callback that is invoked *before* every
+  // mutation of this store, receiving the numeric ids of the mutated quad and
+  // whether it is being added (`true`) or removed (`false`). Returns the
+  // callback so it can be passed back to `_removeObserver`.
+  _addObserver(observer) {
+    (this._observers || (this._observers = new Set())).add(observer);
+    return observer;
+  }
+
+  // ### `_removeObserver` unregisters a previously added mutation observer.
+  // Callers only invoke this with a currently-registered observer, so
+  // `_observers` is guaranteed to be non-null here.
+  _removeObserver(observer) {
+    this._observers.delete(observer);
+    // Restore the allocation-free fast path once no observers remain.
+    if (this._observers.size === 0)
+      this._observers = null;
+  }
+
+  // ### `_notifyObservers` invokes all registered observers with the numeric
+  // ids of a quad that is about to be added or removed.
+  _notifyObservers(subjectId, predicateId, objectId, graphId, added) {
+    // Iterate over a copy so observers may unregister themselves while reacting.
+    for (const observer of [...this._observers])
+      observer(subjectId, predicateId, objectId, graphId, added);
+  }
+
   // ### `_uniqueEntities` returns a function that accepts an entity ID
   // and passes the corresponding entity to callback if it hasn't occurred before.
   _uniqueEntities(callback) {
@@ -377,6 +413,15 @@ export default class N3Store {
     subject   = this._termToNewNumericId(subject);
     predicate = this._termToNewNumericId(predicate);
     object    = this._termToNewNumericId(object);
+
+    // Notify observers *before* the mutation, so snapshot views can lazily
+    // capture the pre-mutation parent state. Only fire for quads that will
+    // actually change the index (i.e. quads that did not already exist).
+    if (this._observers !== null) {
+      const subjects = graphItem.subjects[subject], predicates = subjects && subjects[predicate];
+      if (!predicates || !(object in predicates))
+        this._notifyObservers(subject, predicate, object, graph, true);
+    }
 
     if (!this._addToIndex(graphItem.subjects,   subject,   predicate, object))
       return false;
@@ -432,6 +477,11 @@ export default class N3Store {
         !(predicates = subjects[predicate]) ||
         !(object in predicates))
       return false;
+
+    // Notify observers *before* the mutation, so snapshot views can lazily
+    // capture the pre-mutation parent state.
+    if (this._observers !== null)
+      this._notifyObservers(subject, predicate, object, graph, false);
 
     // Remove it from all indexes
     this._removeFromIndex(graphItem.subjects,   subject,   predicate, object);
@@ -539,8 +589,22 @@ export default class N3Store {
   // Note: Since a DatasetCore is an unordered set, the order of the quads within the returned sequence is arbitrary.
   // Setting any field to `undefined` or `null` indicates a wildcard.
   // For backwards compatibility, the object return also implements the Readable stream interface.
-  match(subject, predicate, object, graph) {
-    return new DatasetCoreAndReadableStream(this, subject, predicate, object, graph, { entityIndex: this._entityIndex });
+  //
+  // The semantics of the returned view with respect to later parent mutations
+  // can be configured via `options.matchSemantics` (falling back to the
+  // store-level `matchSemantics` option, default `'lazy'`):
+  //  - `'lazy'`: backwards-compatible behavior. The view delegates live to the
+  //    parent until its first own mutation, after which it materializes a
+  //    snapshot. Parent mutations made before that first own mutation leak in.
+  //  - `'snapshot'`: the view reflects the parent contents *at the time of*
+  //    `match()`. Later parent mutations never affect it.
+  //  - `'forwarded'`: the view always reflects the parent state; matching
+  //    parent mutations are forwarded to it (a live view).
+  match(subject, predicate, object, graph, options) {
+    return new DatasetCoreAndReadableStream(this, subject, predicate, object, graph, {
+      entityIndex: this._entityIndex,
+      matchSemantics: (options && options.matchSemantics) || this._matchSemantics,
+    });
   }
 
   // ### `countQuads` returns the number of quads matching a pattern.
@@ -866,7 +930,10 @@ export default class N3Store {
 
     if (Array.isArray(quads))
       this.addQuads(quads);
-    else if (quads instanceof N3Store && quads._entityIndex === this._entityIndex) {
+    // The index-merge fast path bypasses `addQuad`, so it cannot be used when
+    // observers are registered (e.g. for `forwarded` views), as they must be
+    // notified of every added quad.
+    else if (this._observers === null && quads instanceof N3Store && quads._entityIndex === this._entityIndex) {
       if (quads._size !== 0) {
         this._graphs = merge(this._graphs, quads._graphs);
         this._size = null; // Invalidate the cached size
@@ -1117,6 +1184,94 @@ class DatasetCoreAndReadableStream extends Readable {
   constructor(n3Store, subject, predicate, object, graph, options) {
     super({ objectMode: true });
     Object.assign(this, { n3Store, subject, predicate, object, graph, options });
+    // `_generation` is bumped whenever a matching parent mutation lands while an
+    // iteration is in progress, so that in-progress iterators can detect the
+    // need to switch from the live parent to a frozen baseline mid-iteration.
+    this._generation = 0;
+    // Number of iterations currently in progress over this view. A frozen
+    // baseline is only captured on parent mutation while this is non-zero,
+    // keeping mutations cheap when nothing is being iterated.
+    this._activeIterators = 0;
+    // A frozen array of the matching quads as of the start of the in-progress
+    // iteration(s); used to keep iterators stable across parent mutations.
+    this._baseline = null;
+    // `options.matchSemantics` is always resolved to a concrete value by the
+    // callers (`Store#match` and the view's own `match`).
+    const semantics = this._semantics = options.matchSemantics;
+    if (semantics !== 'lazy' && semantics !== 'snapshot' && semantics !== 'forwarded')
+      throw new Error(`Unknown matchSemantics: ${semantics}`);
+    // For non-`lazy` semantics, observe parent mutations so that the view can
+    // be kept consistent without eagerly copying the whole match result.
+    if (semantics !== 'lazy')
+      this._observer = n3Store._addObserver(this._onParentMutation.bind(this));
+  }
+
+  // ### `_matchesPattern` returns whether the quad identified by the given
+  // numeric ids falls within this view's `subject`/`predicate`/`object`/`graph`
+  // pattern. A `null`/`undefined` pattern term is a wildcard; a present term is
+  // matched against the corresponding id (resolved against the parent's entity
+  // index, which never reassigns an id once given).
+  _matchesPattern(subjectId, predicateId, objectId, graphId) {
+    const { subject, predicate, object, graph } = this;
+    return (!subject   || subjectId   === this._termId(subject))   &&
+           (!predicate || predicateId === this._termId(predicate)) &&
+           (!object    || objectId    === this._termId(object))    &&
+           (!graph     || graphId     === (isDefaultGraph(graph) ? 1 : this._termId(graph)));
+  }
+
+  // ### `_termId` returns the parent's numeric id for a pattern term, or
+  // `undefined` if the term is not (yet) present. The default graph is handled
+  // by the caller.
+  _termId(term) {
+    return this.n3Store._termToNumericId(term);
+  }
+
+  // ### `_onParentMutation` reacts to a parent mutation for `snapshot` and
+  // `forwarded` semantics. It is invoked *before* the parent index changes,
+  // so the pre-mutation state is still observable here.
+  _onParentMutation(subjectId, predicateId, objectId, graphId, added) {
+    // Only matching quads can affect this view; ignore everything else so the
+    // common path stays cheap.
+    if (!this._matchesPattern(subjectId, predicateId, objectId, graphId))
+      return;
+
+    // If an iteration is in progress, freeze the current (pre-mutation)
+    // matching quads so those iterators keep a stable view. This is only done
+    // once per in-flight batch of iterations (until they all finish), and only
+    // while iterating, so the common, non-iterating path stays allocation-free.
+    if (this._activeIterators > 0 && this._baseline === null) {
+      this._baseline = this._filtered ? [...this._filtered] :
+        this.n3Store.getQuads(this.subject, this.predicate, this.object, this.graph);
+      this._generation++;
+    }
+
+    // Materialize the pre-mutation snapshot if it does not exist yet. For
+    // `forwarded` views `_filtered` may already exist (e.g. from an earlier
+    // mutation or query); for `snapshot` views the `filtered` getter detaches
+    // the observer once built, so this method is never re-entered afterwards.
+    if (!this._filtered)
+      this._filtered = this.filtered;
+
+    // `forwarded`: apply the delta so the view tracks the parent. (`snapshot`
+    // views are now frozen and ignore the mutation.)
+    if (this._semantics === 'forwarded') {
+      const quad = this._toQuad(subjectId, predicateId, objectId, graphId);
+      if (added)
+        this._filtered.addQuad(quad);
+      else
+        this._filtered.removeQuad(quad);
+    }
+  }
+
+  // ### `_toQuad` builds a Quad from numeric ids in the parent's entity index.
+  _toQuad(subjectId, predicateId, objectId, graphId) {
+    const { n3Store } = this, entities = n3Store._entities;
+    return n3Store._factory.quad(
+      n3Store._termFromId(entities[subjectId], n3Store._factory),
+      n3Store._termFromId(entities[predicateId], n3Store._factory),
+      n3Store._termFromId(entities[objectId], n3Store._factory),
+      n3Store._termFromId(entities[graphId], n3Store._factory),
+    );
   }
 
   get filtered() {
@@ -1158,6 +1313,13 @@ class DatasetCoreAndReadableStream extends Readable {
         }
       }
       newStore._size = null;
+
+      // A `snapshot` view is frozen once built, so it no longer needs to
+      // observe the parent. (`forwarded` views keep observing.)
+      if (this._semantics === 'snapshot' && this._observer) {
+        this.n3Store._removeObserver(this._observer);
+        this._observer = null;
+      }
     }
     return this._filtered;
   }
@@ -1181,6 +1343,10 @@ class DatasetCoreAndReadableStream extends Readable {
   }
 
   addAll(quads) {
+    if (this._semantics === 'forwarded') {
+      this.n3Store.addAll(quads);
+      return this;
+    }
     return this.filtered.addAll(quads);
   }
 
@@ -1189,6 +1355,10 @@ class DatasetCoreAndReadableStream extends Readable {
   }
 
   deleteMatches(subject, predicate, object, graph) {
+    if (this._semantics === 'forwarded') {
+      this.n3Store.deleteMatches(subject, predicate, object, graph);
+      return this;
+    }
     return this.filtered.deleteMatches(subject, predicate, object, graph);
   }
 
@@ -1233,18 +1403,27 @@ class DatasetCoreAndReadableStream extends Readable {
   }
 
   toStream() {
+    // For non-`lazy` semantics, route through the (possibly materialized)
+    // snapshot so the stream reflects the configured view rather than the live
+    // parent. For `lazy`, preserve the original delegation for performance.
+    if (this._semantics !== 'lazy')
+      return this.filtered.toStream();
     return this._filtered ?
       this._filtered.toStream()
       : this.n3Store.match(this.subject, this.predicate, this.object, this.graph);
   }
 
   union(quads) {
+    if (this._semantics !== 'lazy')
+      return this.filtered.union(quads);
     return this._filtered ?
       this._filtered.union(quads)
       : this.n3Store.match(this.subject, this.predicate, this.object, this.graph).addAll(quads);
   }
 
   toArray() {
+    if (this._semantics !== 'lazy')
+      return this.filtered.toArray();
     return this._filtered ? this._filtered.toArray() : this.n3Store.getQuads(this.subject, this.predicate, this.object, this.graph);
   }
 
@@ -1257,10 +1436,20 @@ class DatasetCoreAndReadableStream extends Readable {
   }
 
   add(quad) {
+    // For `forwarded` views, mutations are written through to the parent store,
+    // which then forwards the change back to this view via the observer.
+    if (this._semantics === 'forwarded') {
+      this.n3Store.addQuad(quad);
+      return this;
+    }
     return this.filtered.add(quad);
   }
 
   delete(quad) {
+    if (this._semantics === 'forwarded') {
+      this.n3Store.removeQuad(quad);
+      return this;
+    }
     return this.filtered.delete(quad);
   }
 
@@ -1273,6 +1462,54 @@ class DatasetCoreAndReadableStream extends Readable {
   }
 
   *[Symbol.iterator]() {
-    yield* this._filtered || this.n3Store.readQuads(this.subject, this.predicate, this.object, this.graph);
+    // `lazy` semantics: original behavior. Iterate the materialized snapshot if
+    // it exists, otherwise delegate live to the parent. No observers exist for
+    // lazy views, so no mid-iteration switching can occur.
+    if (this._semantics === 'lazy') {
+      yield* this._filtered || this.n3Store.readQuads(this.subject, this.predicate, this.object, this.graph);
+      return;
+    }
+
+    // Non-`lazy` semantics: iterate a view that stays stable for the duration of
+    // this iteration, even if the parent is mutated mid-stream. We iterate the
+    // current source (the materialized snapshot if present, else the live
+    // parent). If a matching parent mutation lands while we iterate, the
+    // observer freezes the pre-mutation matching quads into `_baseline` and
+    // bumps `_generation`; we then switch to `_baseline`, skipping the quads we
+    // have already yielded. Because `_baseline` is captured in the same order
+    // the source iterates, skip-by-count yields exactly the remaining quads with
+    // no duplicates or omissions.
+    const generation = this._generation;
+    let yielded = 0;
+    this._activeIterators++;
+    try {
+      const source = this._filtered ?
+        this._filtered[Symbol.iterator]() :
+        this.n3Store.readQuads(this.subject, this.predicate, this.object, this.graph);
+      for (const quad of source) {
+        if (this._generation !== generation) {
+          yield* this._skip(this._baseline[Symbol.iterator](), yielded);
+          return;
+        }
+        yielded++;
+        yield quad;
+      }
+      // A mutation may have landed exactly when the source was exhausted.
+      if (this._generation !== generation)
+        yield* this._skip(this._baseline[Symbol.iterator](), yielded);
+    }
+    finally {
+      // Once no iterations remain, drop the frozen baseline so future mutations
+      // do not pay to maintain it.
+      if (--this._activeIterators === 0)
+        this._baseline = null;
+    }
+  }
+
+  // ### `_skip` advances `iterator` past `count` quads and yields the rest.
+  *_skip(iterator, count) {
+    while (count-- > 0)
+      iterator.next();
+    yield* iterator;
   }
 }

--- a/src/N3Store.js
+++ b/src/N3Store.js
@@ -170,7 +170,7 @@ export default class N3Store {
     options = options || {};
     this._factory = options.factory || N3DataFactory;
     // Default `match()` semantics ('lazy', 'snapshot', or 'forwarded'); see `match()`
-    this._matchSemantics = options.matchSemantics || 'lazy';
+    this._matchSemantics = validateMatchSemantics(options.matchSemantics || 'lazy');
     this._entityIndex = options.entityIndex || new N3EntityIndex({ factory: this._factory });
     this._entities = this._entityIndex._entities;
     this._termFromId = this._entityIndex._termFromId.bind(this._entityIndex);
@@ -1159,6 +1159,16 @@ function indexMatch(index, ids, depth = 0) {
 }
 
 /**
+ * Returns `semantics` if it is a supported `matchSemantics` value,
+ * and throws otherwise, so misconfiguration fails at the call site.
+ */
+function validateMatchSemantics(semantics) {
+  if (semantics !== 'lazy' && semantics !== 'snapshot' && semantics !== 'forwarded')
+    throw new Error(`Unknown matchSemantics: ${semantics}`);
+  return semantics;
+}
+
+/**
  * A class that implements both DatasetCore and Readable.
  */
 class DatasetCoreAndReadableStream extends Readable {
@@ -1173,9 +1183,7 @@ class DatasetCoreAndReadableStream extends Readable {
     this._baselines = null;
     // Lazily cached numeric ids of the pattern terms (immutable once present in the entity index)
     this._subjectId = this._predicateId = this._objectId = this._graphId = undefined;
-    const semantics = this._semantics = options.matchSemantics;
-    if (semantics !== 'lazy' && semantics !== 'snapshot' && semantics !== 'forwarded')
-      throw new Error(`Unknown matchSemantics: ${semantics}`);
+    const semantics = this._semantics = validateMatchSemantics(options.matchSemantics);
     // For non-`lazy` semantics, observe parent mutations to keep the view consistent
     if (semantics !== 'lazy')
       this._observer = n3Store._addObserver(this._onParentMutation.bind(this));

--- a/src/N3Store.js
+++ b/src/N3Store.js
@@ -189,7 +189,7 @@ export default class N3Store {
     this._size = 0;
     // `_graphs` contains subject, predicate, and object indexes per graph
     this._graphs = Object.create(null);
-    // `_observers`, when non-null, is a set of callbacks notified before every mutation
+    // `_observers` contains callbacks notified before every mutation
     this._observers = null;
 
     // Shift parameters if `quads` is not given
@@ -197,7 +197,6 @@ export default class N3Store {
       options = quads, quads = null;
     options = options || {};
     this._factory = options.factory || N3DataFactory;
-    // Default `match()` semantics ('lazy', 'snapshot', or 'forwarded'); see `match()`
     this._matchSemantics = validateMatchSemantics(options.matchSemantics || 'lazy');
     this._entityIndex = options.entityIndex || new N3EntityIndex({ factory: this._factory });
     this._entities = this._entityIndex._entities;
@@ -406,10 +405,9 @@ export default class N3Store {
     return typeof graph !== 'number' ? this._graphs : { [graph]: this._graphs[graph] };
   }
 
-  // ### `_addObserver` registers a mutation observer and returns it.
+  // ### `_addObserver` registers a mutation observer.
   _addObserver(observer) {
     (this._observers || (this._observers = new Set())).add(observer);
-    return observer;
   }
 
   // ### `_removeObserver` unregisters a mutation observer.
@@ -419,9 +417,9 @@ export default class N3Store {
       this._observers = null;
   }
 
-  // ### `_notifyObservers` invokes all observers with the ids of a mutated quad.
+  // ### `_notifyObservers` notifies observers of a mutation.
   _notifyObservers(subjectId, predicateId, objectId, graphId, added) {
-    // Observers only ever unregister themselves, which is safe mid-iteration of a Set
+    // Observers can remove themselves during Set iteration
     for (const observer of this._observers)
       observer(subjectId, predicateId, objectId, graphId, added);
   }
@@ -480,7 +478,7 @@ export default class N3Store {
     predicate = this._termToNewNumericId(predicate);
     object    = this._termToNewNumericId(object);
 
-    // Notify observers before the mutation, but only for quads that don't already exist
+    // Notify observers only for new quads
     if (this._observers !== null) {
       const subjects = graphItem.subjects[subject], predicates = subjects && subjects[predicate];
       if (!predicates || !(object in predicates))
@@ -662,20 +660,7 @@ export default class N3Store {
   // Note: Since a DatasetCore is an unordered set, the order of the quads within the returned sequence is arbitrary.
   // Setting any field to `undefined` or `null` indicates a wildcard.
   // For backwards compatibility, the object return also implements the Readable stream interface.
-  // `options.matchSemantics` (defaulting to the store-level option, default `'lazy'`) sets
-  // how the view reacts to later parent mutations:
-  //  - `'lazy'`: delegates live to the parent until its first mutation or materializing
-  //    read, such as `size` or `has` (backwards-compatible).
-  //  - `'snapshot'`: reflects the parent contents at the time of `match()`.
-  //  - `'forwarded'`: stays live; matching parent mutations are forwarded to it, and view
-  //    mutations write through to the parent unrestricted by the pattern (so a
-  //    non-matching `add` mutates the parent without appearing in the view).
-  // Calling `match()` on a view yields at most a `'snapshot'` sub-view:
-  // nested views never write through to the root store.
-  // A non-`lazy` view observes the store — `'snapshot'` until it first materializes,
-  // `'forwarded'` for the store's lifetime or until `detach()` — so the store retains
-  // each observing view, checks every mutation against its pattern, and cannot use
-  // the same-index `addAll` fast path while any view observes.
+  // `options.matchSemantics` controls how the view reacts to later mutations.
   match(subject, predicate, object, graph, options) {
     return new DatasetCoreAndReadableStream(this, subject, predicate, object, graph, {
       entityIndex: this._entityIndex,
@@ -1009,7 +994,7 @@ export default class N3Store {
 
     if (Array.isArray(quads))
       this.addQuads(quads);
-    // The index-merge fast path bypasses `addQuad`, so it can't be used when observers are registered
+    // Index merging bypasses observer notifications
     else if (this._observers === null && quads instanceof N3Store && quads._entityIndex === this._entityIndex) {
       if (quads._size !== 0) {
         this._graphs = merge(this._graphs, quads._graphs);
@@ -1068,7 +1053,6 @@ export default class N3Store {
    * @param graph     The optional exact graph to match.
    */
   deleteMatches(subject, predicate, object, graph) {
-    // Internal matching is explicitly `lazy`: a non-`lazy` view would register an observer that is never released
     for (const quad of this.match(subject, predicate, object, graph, { matchSemantics: 'lazy' }))
       this.removeQuad(quad);
     return this;
@@ -1195,7 +1179,6 @@ export default class N3Store {
 
   /**
    * Returns a stream that contains all quads of the dataset.
-   * The stream is explicitly `lazy`: a non-`lazy` view would register an observer that is never released.
    */
   toStream() {
     return this.match(null, null, null, null, { matchSemantics: 'lazy' });
@@ -1258,10 +1241,6 @@ function indexMatch(index, ids, depth = 0) {
   return target;
 }
 
-/**
- * Returns `semantics` if it is a supported `matchSemantics` value,
- * and throws otherwise, so misconfiguration fails at the call site.
- */
 function validateMatchSemantics(semantics) {
   if (semantics !== 'lazy' && semantics !== 'snapshot' && semantics !== 'forwarded')
     throw new Error(`Unknown matchSemantics: ${semantics}`);
@@ -1275,55 +1254,49 @@ class DatasetCoreAndReadableStream extends Readable {
   constructor(n3Store, subject, predicate, object, graph, options) {
     super({ objectMode: true });
     Object.assign(this, { n3Store, subject, predicate, object, graph, options });
-    // Bumped when a matching parent mutation lands mid-iteration, signalling iterators to switch to their baseline
-    this._generation = 0;
-    // Number of in-progress iterations; baselines are only frozen on mutation while this is non-zero
-    this._activeIterators = 0;
-    // Frozen arrays of matching quads per generation, keeping in-progress iterations stable
-    this._baselines = null;
-    // Lazily cached numeric ids of the pattern terms (immutable once present in the entity index)
-    this._subjectId = this._predicateId = this._objectId = this._graphId = undefined;
     const semantics = this._semantics = validateMatchSemantics(options.matchSemantics);
-    // For non-`lazy` semantics, observe parent mutations to keep the view consistent
-    if (semantics !== 'lazy')
-      this._observer = n3Store._addObserver(this._onParentMutation.bind(this));
+
+    if (semantics !== 'lazy') {
+      // Track stable reads across parent mutations
+      this._generation = 0;
+      this._activeIterators = this._currentIterators = 0;
+      this._baselines = null;
+      // Cache pattern ids on first use
+      this._subjectId = this._predicateId = this._objectId = this._graphId = undefined;
+      this._observer = this._onParentMutation.bind(this);
+      n3Store._addObserver(this._observer);
+    }
   }
 
-  // ### `_matchesPattern` returns whether the quad ids fall within this view's pattern
-  // (absent term = wildcard; the legacy `''` graph argument denotes the default graph, as in `_getGraphs`).
-  // Term ids are cached upon resolution; a pattern term may still be absent from the entity index
-  // (`_termToNumericId` then returns `undefined`, which never equals a quad id), so an
-  // unresolved id is re-resolved on every call, as the term may be interned later on.
+  // ### `_matchesPattern` tests quad ids against this view.
   _matchesPattern(subjectId, predicateId, objectId, graphId) {
     const { subject, predicate, object, graph, n3Store } = this;
-    return (!subject   || subjectId   === (this._subjectId   || (this._subjectId   = n3Store._termToNumericId(subject))))   &&
-           (!predicate || predicateId === (this._predicateId || (this._predicateId = n3Store._termToNumericId(predicate)))) &&
-           (!object    || objectId    === (this._objectId    || (this._objectId    = n3Store._termToNumericId(object))))    &&
-           (graph === null || graph === undefined ||
-             graphId === (this._graphId || (this._graphId =
-               graph === '' || isDefaultGraph(graph) ? 1 : n3Store._termToNumericId(graph))));
+    if (subject && subjectId !== (this._subjectId || (this._subjectId = n3Store._termToNumericId(subject))))
+      return false;
+    if (predicate && predicateId !== (this._predicateId || (this._predicateId = n3Store._termToNumericId(predicate))))
+      return false;
+    if (object && objectId !== (this._objectId || (this._objectId = n3Store._termToNumericId(object))))
+      return false;
+    return graph === null || graph === undefined ||
+      graphId === (this._graphId || (this._graphId =
+        graph === '' || isDefaultGraph(graph) ? 1 : n3Store._termToNumericId(graph)));
   }
 
-  // ### `_onParentMutation` reacts to a parent mutation, invoked before the parent index changes.
+  // ### `_onParentMutation` applies a parent mutation to this view.
   _onParentMutation(subjectId, predicateId, objectId, graphId, added) {
-    // Only matching quads can affect this view
     if (!this._matchesPattern(subjectId, predicateId, objectId, graphId))
       return;
 
-    // While iterating, freeze the pre-mutation matching quads under the current generation,
-    // so every iteration in progress (each started during some generation) keeps a stable view.
-    // While any iteration remains open, each matching mutation costs O(view size) and retains
-    // one frozen array (even for generations at which no iteration started); all baselines
-    // are released once the last iteration closes.
-    if (this._activeIterators > 0) {
+    // Freeze active readers before the mutation
+    if (this._currentIterators > 0) {
       if (!this._baselines)
         this._baselines = new Map();
       this._baselines.set(this._generation++, this._filtered ? [...this._filtered] :
         this.n3Store.getQuads(this.subject, this.predicate, this.object, this.graph));
+      this._currentIterators = 0;
     }
 
-    // `forwarded`: apply the delta only if the view has materialized; otherwise,
-    // the parent remains the source of truth, and a later read captures the current state
+    // Keep using the parent until materialization
     if (this._semantics === 'forwarded') {
       if (this._filtered) {
         const quad = this._toQuad(subjectId, predicateId, objectId, graphId);
@@ -1335,12 +1308,11 @@ class DatasetCoreAndReadableStream extends Readable {
       return;
     }
 
-    // `snapshot`: materialize the pre-mutation state
-    // (`_filtered` is always null here, as its getter unregisters this observer on build)
+    // Capture the pre-mutation snapshot
     this._filtered = this.filtered;
   }
 
-  // ### `_toQuad` builds a Quad from numeric ids in the parent's entity index.
+  // ### `_toQuad` reconstructs a Quad from numeric ids.
   _toQuad(subjectId, predicateId, objectId, graphId) {
     const { n3Store } = this, entities = n3Store._entities;
     return n3Store._factory.quad(
@@ -1356,8 +1328,6 @@ class DatasetCoreAndReadableStream extends Readable {
       const { n3Store, graph, object, predicate, subject } = this;
       const newStore = this._filtered = new N3Store({ factory: n3Store._factory, entityIndex: this.options.entityIndex });
 
-      // A `snapshot` view is frozen once it materializes, so it no longer needs to observe
-      // the parent — also when a pattern term is absent and the view materializes empty
       if (this._semantics === 'snapshot' && this._observer) {
         this.n3Store._removeObserver(this._observer);
         this._observer = null;
@@ -1419,7 +1389,7 @@ class DatasetCoreAndReadableStream extends Readable {
     }
   }
 
-  // ### `_destroy` closes the cached iterator, so a destroyed stream releases its iteration state.
+  // ### `_destroy` closes the cached iterator.
   _destroy(error, callback) {
     if (this[ITERATOR]) {
       this[ITERATOR].return();
@@ -1428,16 +1398,19 @@ class DatasetCoreAndReadableStream extends Readable {
     callback(error);
   }
 
-  // ### `detach` freezes the view to its current contents and stops observing the parent,
-  // so the parent no longer retains the view nor checks mutations against its pattern.
+  // ### `detach` freezes the view and stops observing the parent.
   detach() {
-    // Materializing a `snapshot` view removes its observer; remove a `forwarded` observer explicitly
     this._filtered = this.filtered;
     if (this._observer) {
       this.n3Store._removeObserver(this._observer);
       this._observer = null;
     }
-    // Parent deltas are no longer forwarded, so subsequent view mutations apply locally
+    // Lazy views deferred this state
+    if (this._semantics === 'lazy') {
+      this._generation = 0;
+      this._activeIterators = this._currentIterators = 0;
+      this._baselines = null;
+    }
     this._semantics = 'snapshot';
     return this;
   }
@@ -1483,7 +1456,6 @@ class DatasetCoreAndReadableStream extends Readable {
   }
 
   import(stream) {
-    // `forwarded` views write imported quads through to the parent, like `add` and `addAll`
     if (this._semantics === 'forwarded')
       return this.n3Store.import(stream);
     return this.filtered.import(stream);
@@ -1506,25 +1478,20 @@ class DatasetCoreAndReadableStream extends Readable {
   }
 
   toStream() {
-    // For non-`lazy` semantics, route through the snapshot rather than the live parent
     if (this._semantics !== 'lazy')
       return this.filtered.toStream();
-    // The internal view is explicitly `lazy`, so a non-`lazy` store default cannot leak an observer
     return this._filtered ?
       this._filtered.toStream()
       : this.n3Store.match(this.subject, this.predicate, this.object, this.graph, { matchSemantics: 'lazy' });
   }
 
   union(quads) {
-    // An unmaterialized view has seen no matching mutation, so the parent holds its exact contents;
-    // the internal view is explicitly `lazy` so that `addAll` cannot write through to the parent
     return this._filtered ?
       this._filtered.union(quads)
       : this.n3Store.match(this.subject, this.predicate, this.object, this.graph, { matchSemantics: 'lazy' }).addAll(quads);
   }
 
   toArray() {
-    // An unmaterialized view has seen no matching mutation, so the parent holds its exact contents
     return this._filtered ? this._filtered.toArray() : this.n3Store.getQuads(this.subject, this.predicate, this.object, this.graph);
   }
 
@@ -1537,7 +1504,6 @@ class DatasetCoreAndReadableStream extends Readable {
   }
 
   add(quad) {
-    // `forwarded` views write through to the parent, which forwards the change back via the observer
     if (this._semantics === 'forwarded') {
       this.n3Store.addQuad(quad);
       return this;
@@ -1558,10 +1524,7 @@ class DatasetCoreAndReadableStream extends Readable {
   }
 
   match(subject, predicate, object, graph) {
-    // Unlike the store's `match`, this takes no `options`: sub-views inherit these semantics.
-    // A nested view is parented on the materialized contents, not on the root store,
-    // so `forwarded` is downgraded to `snapshot`: write-through would only reach
-    // the internal materialized store, silently desyncing this view from its parent
+    // Nested views cannot write through to the root
     return new DatasetCoreAndReadableStream(this.filtered, subject, predicate, object, graph, {
       entityIndex: this.options.entityIndex,
       matchSemantics: this._semantics === 'forwarded' ? 'snapshot' : this._semantics,
@@ -1569,17 +1532,16 @@ class DatasetCoreAndReadableStream extends Readable {
   }
 
   *[Symbol.iterator]() {
-    // `lazy`: iterate the snapshot if it exists, else delegate live to the parent
     if (this._semantics === 'lazy') {
       yield* this._filtered || this.n3Store.readQuads(this.subject, this.predicate, this.object, this.graph);
       return;
     }
 
-    // Non-`lazy`: iterate the current source, switching to this iteration's frozen baseline
-    // if a matching parent mutation bumps `_generation` mid-iteration.
+    // Use a snapshot if the parent changes mid-iteration
     const generation = this._generation;
     let yielded = 0;
     this._activeIterators++;
+    this._currentIterators++;
     try {
       const source = this._filtered ?
         this._filtered[Symbol.iterator]() :
@@ -1590,8 +1552,6 @@ class DatasetCoreAndReadableStream extends Readable {
         yielded++;
         yield quad;
       }
-      // A matching mutation landed mid-iteration (possibly exactly as the source was exhausted):
-      // continue from the baseline frozen at this iteration's generation, skipping already-yielded quads
       if (this._generation !== generation) {
         const baseline = this._baselines.get(generation);
         for (let i = yielded; i < baseline.length; i++)
@@ -1599,7 +1559,8 @@ class DatasetCoreAndReadableStream extends Readable {
       }
     }
     finally {
-      // Drop the frozen baselines once no iterations remain
+      if (this._generation === generation)
+        this._currentIterators--;
       if (--this._activeIterators === 0)
         this._baselines = null;
     }

--- a/src/N3Store.js
+++ b/src/N3Store.js
@@ -421,8 +421,8 @@ export default class N3Store {
 
   // ### `_notifyObservers` invokes all observers with the ids of a mutated quad.
   _notifyObservers(subjectId, predicateId, objectId, graphId, added) {
-    // Iterate over a copy so observers may unregister themselves while reacting
-    for (const observer of [...this._observers])
+    // Observers only ever unregister themselves, which is safe mid-iteration of a Set
+    for (const observer of this._observers)
       observer(subjectId, predicateId, objectId, graphId, added);
   }
 

--- a/src/N3Store.js
+++ b/src/N3Store.js
@@ -664,7 +664,8 @@ export default class N3Store {
   // For backwards compatibility, the object return also implements the Readable stream interface.
   // `options.matchSemantics` (defaulting to the store-level option, default `'lazy'`) sets
   // how the view reacts to later parent mutations:
-  //  - `'lazy'`: delegates live to the parent until its first own mutation (backwards-compatible).
+  //  - `'lazy'`: delegates live to the parent until its first mutation or materializing
+  //    read, such as `size` or `has` (backwards-compatible).
   //  - `'snapshot'`: reflects the parent contents at the time of `match()`.
   //  - `'forwarded'`: stays live; matching parent mutations are forwarded to it, and view
   //    mutations write through to the parent unrestricted by the pattern (so a

--- a/src/N3Store.js
+++ b/src/N3Store.js
@@ -189,10 +189,7 @@ export default class N3Store {
     this._size = 0;
     // `_graphs` contains subject, predicate, and object indexes per graph
     this._graphs = Object.create(null);
-    // `_observers`, when non-null, is a set of callbacks that are notified
-    // *before* every mutation, so that derived views (e.g. `match()` results
-    // with `snapshot`/`forwarded` semantics) can react to parent mutations.
-    // It is `null` by default to keep the common mutation path allocation-free.
+    // `_observers`, when non-null, is a set of callbacks notified before every mutation
     this._observers = null;
 
     // Shift parameters if `quads` is not given
@@ -200,9 +197,7 @@ export default class N3Store {
       options = quads, quads = null;
     options = options || {};
     this._factory = options.factory || N3DataFactory;
-    // The default `match()` semantics for views derived from this store.
-    // One of `'lazy'` (default, backwards-compatible), `'snapshot'`, or
-    // `'forwarded'`. See `match()` for details.
+    // Default `match()` semantics ('lazy', 'snapshot', or 'forwarded'); see `match()`
     this._matchSemantics = options.matchSemantics || 'lazy';
     this._entityIndex = options.entityIndex || new N3EntityIndex({ factory: this._factory });
     this._entities = this._entityIndex._entities;
@@ -411,29 +406,22 @@ export default class N3Store {
     return typeof graph !== 'number' ? this._graphs : { [graph]: this._graphs[graph] };
   }
 
-  // ### `_addObserver` registers a callback that is invoked *before* every
-  // mutation of this store, receiving the numeric ids of the mutated quad and
-  // whether it is being added (`true`) or removed (`false`). Returns the
-  // callback so it can be passed back to `_removeObserver`.
+  // ### `_addObserver` registers a mutation observer and returns it.
   _addObserver(observer) {
     (this._observers || (this._observers = new Set())).add(observer);
     return observer;
   }
 
-  // ### `_removeObserver` unregisters a previously added mutation observer.
-  // Callers only invoke this with a currently-registered observer, so
-  // `_observers` is guaranteed to be non-null here.
+  // ### `_removeObserver` unregisters a mutation observer.
   _removeObserver(observer) {
     this._observers.delete(observer);
-    // Restore the allocation-free fast path once no observers remain.
     if (this._observers.size === 0)
       this._observers = null;
   }
 
-  // ### `_notifyObservers` invokes all registered observers with the numeric
-  // ids of a quad that is about to be added or removed.
+  // ### `_notifyObservers` invokes all observers with the ids of a mutated quad.
   _notifyObservers(subjectId, predicateId, objectId, graphId, added) {
-    // Iterate over a copy so observers may unregister themselves while reacting.
+    // Iterate over a copy so observers may unregister themselves while reacting
     for (const observer of [...this._observers])
       observer(subjectId, predicateId, objectId, graphId, added);
   }
@@ -492,9 +480,7 @@ export default class N3Store {
     predicate = this._termToNewNumericId(predicate);
     object    = this._termToNewNumericId(object);
 
-    // Notify observers *before* the mutation, so snapshot views can lazily
-    // capture the pre-mutation parent state. Only fire for quads that will
-    // actually change the index (i.e. quads that did not already exist).
+    // Notify observers before the mutation, but only for quads that don't already exist
     if (this._observers !== null) {
       const subjects = graphItem.subjects[subject], predicates = subjects && subjects[predicate];
       if (!predicates || !(object in predicates))
@@ -566,8 +552,7 @@ export default class N3Store {
         !(object in predicates))
       return false;
 
-    // Notify observers *before* the mutation, so snapshot views can lazily
-    // capture the pre-mutation parent state.
+    // Notify observers before the mutation
     if (this._observers !== null)
       this._notifyObservers(subject, predicate, object, graph, false);
 
@@ -677,17 +662,11 @@ export default class N3Store {
   // Note: Since a DatasetCore is an unordered set, the order of the quads within the returned sequence is arbitrary.
   // Setting any field to `undefined` or `null` indicates a wildcard.
   // For backwards compatibility, the object return also implements the Readable stream interface.
-  //
-  // The semantics of the returned view with respect to later parent mutations
-  // can be configured via `options.matchSemantics` (falling back to the
-  // store-level `matchSemantics` option, default `'lazy'`):
-  //  - `'lazy'`: backwards-compatible behavior. The view delegates live to the
-  //    parent until its first own mutation, after which it materializes a
-  //    snapshot. Parent mutations made before that first own mutation leak in.
-  //  - `'snapshot'`: the view reflects the parent contents *at the time of*
-  //    `match()`. Later parent mutations never affect it.
-  //  - `'forwarded'`: the view always reflects the parent state; matching
-  //    parent mutations are forwarded to it (a live view).
+  // `options.matchSemantics` (defaulting to the store-level option, default `'lazy'`) sets
+  // how the view reacts to later parent mutations:
+  //  - `'lazy'`: delegates live to the parent until its first own mutation (backwards-compatible).
+  //  - `'snapshot'`: reflects the parent contents at the time of `match()`.
+  //  - `'forwarded'`: stays live; matching parent mutations are forwarded to it.
   match(subject, predicate, object, graph, options) {
     return new DatasetCoreAndReadableStream(this, subject, predicate, object, graph, {
       entityIndex: this._entityIndex,
@@ -1021,9 +1000,7 @@ export default class N3Store {
 
     if (Array.isArray(quads))
       this.addQuads(quads);
-    // The index-merge fast path bypasses `addQuad`, so it cannot be used when
-    // observers are registered (e.g. for `forwarded` views), as they must be
-    // notified of every added quad.
+    // The index-merge fast path bypasses `addQuad`, so it can't be used when observers are registered
     else if (this._observers === null && quads instanceof N3Store && quads._entityIndex === this._entityIndex) {
       if (quads._size !== 0) {
         this._graphs = merge(this._graphs, quads._graphs);
@@ -1277,33 +1254,21 @@ class DatasetCoreAndReadableStream extends Readable {
   constructor(n3Store, subject, predicate, object, graph, options) {
     super({ objectMode: true });
     Object.assign(this, { n3Store, subject, predicate, object, graph, options });
-    // `_generation` is bumped whenever a matching parent mutation lands while an
-    // iteration is in progress, so that in-progress iterators can detect the
-    // need to switch from the live parent to a frozen baseline mid-iteration.
+    // Bumped when a matching parent mutation lands mid-iteration, signalling iterators to switch to `_baseline`
     this._generation = 0;
-    // Number of iterations currently in progress over this view. A frozen
-    // baseline is only captured on parent mutation while this is non-zero,
-    // keeping mutations cheap when nothing is being iterated.
+    // Number of in-progress iterations; a baseline is only frozen on mutation while this is non-zero
     this._activeIterators = 0;
-    // A frozen array of the matching quads as of the start of the in-progress
-    // iteration(s); used to keep iterators stable across parent mutations.
+    // Frozen array of matching quads at the start of in-progress iteration(s), to keep iterators stable
     this._baseline = null;
-    // `options.matchSemantics` is always resolved to a concrete value by the
-    // callers (`Store#match` and the view's own `match`).
     const semantics = this._semantics = options.matchSemantics;
     if (semantics !== 'lazy' && semantics !== 'snapshot' && semantics !== 'forwarded')
       throw new Error(`Unknown matchSemantics: ${semantics}`);
-    // For non-`lazy` semantics, observe parent mutations so that the view can
-    // be kept consistent without eagerly copying the whole match result.
+    // For non-`lazy` semantics, observe parent mutations to keep the view consistent
     if (semantics !== 'lazy')
       this._observer = n3Store._addObserver(this._onParentMutation.bind(this));
   }
 
-  // ### `_matchesPattern` returns whether the quad identified by the given
-  // numeric ids falls within this view's `subject`/`predicate`/`object`/`graph`
-  // pattern. A `null`/`undefined` pattern term is a wildcard; a present term is
-  // matched against the corresponding id (resolved against the parent's entity
-  // index, which never reassigns an id once given).
+  // ### `_matchesPattern` returns whether the quad ids fall within this view's pattern (absent term = wildcard).
   _matchesPattern(subjectId, predicateId, objectId, graphId) {
     const { subject, predicate, object, graph } = this;
     return (!subject   || subjectId   === this._termId(subject))   &&
@@ -1312,41 +1277,29 @@ class DatasetCoreAndReadableStream extends Readable {
            (!graph     || graphId     === (isDefaultGraph(graph) ? 1 : this._termId(graph)));
   }
 
-  // ### `_termId` returns the parent's numeric id for a pattern term, or
-  // `undefined` if the term is not (yet) present. The default graph is handled
-  // by the caller.
+  // ### `_termId` returns the parent's numeric id for a term, or `undefined` if not present.
   _termId(term) {
     return this.n3Store._termToNumericId(term);
   }
 
-  // ### `_onParentMutation` reacts to a parent mutation for `snapshot` and
-  // `forwarded` semantics. It is invoked *before* the parent index changes,
-  // so the pre-mutation state is still observable here.
+  // ### `_onParentMutation` reacts to a parent mutation, invoked before the parent index changes.
   _onParentMutation(subjectId, predicateId, objectId, graphId, added) {
-    // Only matching quads can affect this view; ignore everything else so the
-    // common path stays cheap.
+    // Only matching quads can affect this view
     if (!this._matchesPattern(subjectId, predicateId, objectId, graphId))
       return;
 
-    // If an iteration is in progress, freeze the current (pre-mutation)
-    // matching quads so those iterators keep a stable view. This is only done
-    // once per in-flight batch of iterations (until they all finish), and only
-    // while iterating, so the common, non-iterating path stays allocation-free.
+    // While iterating, freeze the pre-mutation matching quads so iterators keep a stable view
     if (this._activeIterators > 0 && this._baseline === null) {
       this._baseline = this._filtered ? [...this._filtered] :
         this.n3Store.getQuads(this.subject, this.predicate, this.object, this.graph);
       this._generation++;
     }
 
-    // Materialize the pre-mutation snapshot if it does not exist yet. For
-    // `forwarded` views `_filtered` may already exist (e.g. from an earlier
-    // mutation or query); for `snapshot` views the `filtered` getter detaches
-    // the observer once built, so this method is never re-entered afterwards.
+    // Materialize the pre-mutation snapshot if it does not exist yet
     if (!this._filtered)
       this._filtered = this.filtered;
 
-    // `forwarded`: apply the delta so the view tracks the parent. (`snapshot`
-    // views are now frozen and ignore the mutation.)
+    // `forwarded`: apply the delta so the view tracks the parent (`snapshot` views are now frozen)
     if (this._semantics === 'forwarded') {
       const quad = this._toQuad(subjectId, predicateId, objectId, graphId);
       if (added)
@@ -1407,8 +1360,7 @@ class DatasetCoreAndReadableStream extends Readable {
       }
       newStore._size = null;
 
-      // A `snapshot` view is frozen once built, so it no longer needs to
-      // observe the parent. (`forwarded` views keep observing.)
+      // A `snapshot` view is frozen once built, so it no longer needs to observe the parent
       if (this._semantics === 'snapshot' && this._observer) {
         this.n3Store._removeObserver(this._observer);
         this._observer = null;
@@ -1496,9 +1448,7 @@ class DatasetCoreAndReadableStream extends Readable {
   }
 
   toStream() {
-    // For non-`lazy` semantics, route through the (possibly materialized)
-    // snapshot so the stream reflects the configured view rather than the live
-    // parent. For `lazy`, preserve the original delegation for performance.
+    // For non-`lazy` semantics, route through the snapshot rather than the live parent
     if (this._semantics !== 'lazy')
       return this.filtered.toStream();
     return this._filtered ?
@@ -1529,8 +1479,7 @@ class DatasetCoreAndReadableStream extends Readable {
   }
 
   add(quad) {
-    // For `forwarded` views, mutations are written through to the parent store,
-    // which then forwards the change back to this view via the observer.
+    // `forwarded` views write through to the parent, which forwards the change back via the observer
     if (this._semantics === 'forwarded') {
       this.n3Store.addQuad(quad);
       return this;
@@ -1555,23 +1504,14 @@ class DatasetCoreAndReadableStream extends Readable {
   }
 
   *[Symbol.iterator]() {
-    // `lazy` semantics: original behavior. Iterate the materialized snapshot if
-    // it exists, otherwise delegate live to the parent. No observers exist for
-    // lazy views, so no mid-iteration switching can occur.
+    // `lazy`: iterate the snapshot if it exists, else delegate live to the parent
     if (this._semantics === 'lazy') {
       yield* this._filtered || this.n3Store.readQuads(this.subject, this.predicate, this.object, this.graph);
       return;
     }
 
-    // Non-`lazy` semantics: iterate a view that stays stable for the duration of
-    // this iteration, even if the parent is mutated mid-stream. We iterate the
-    // current source (the materialized snapshot if present, else the live
-    // parent). If a matching parent mutation lands while we iterate, the
-    // observer freezes the pre-mutation matching quads into `_baseline` and
-    // bumps `_generation`; we then switch to `_baseline`, skipping the quads we
-    // have already yielded. Because `_baseline` is captured in the same order
-    // the source iterates, skip-by-count yields exactly the remaining quads with
-    // no duplicates or omissions.
+    // Non-`lazy`: iterate the current source, switching to the frozen `_baseline` (skipping
+    // already-yielded quads) if a matching parent mutation bumps `_generation` mid-iteration.
     const generation = this._generation;
     let yielded = 0;
     this._activeIterators++;
@@ -1587,13 +1527,12 @@ class DatasetCoreAndReadableStream extends Readable {
         yielded++;
         yield quad;
       }
-      // A mutation may have landed exactly when the source was exhausted.
+      // A mutation may have landed exactly when the source was exhausted
       if (this._generation !== generation)
         yield* this._skip(this._baseline[Symbol.iterator](), yielded);
     }
     finally {
-      // Once no iterations remain, drop the frozen baseline so future mutations
-      // do not pay to maintain it.
+      // Drop the frozen baseline once no iterations remain
       if (--this._activeIterators === 0)
         this._baseline = null;
     }

--- a/src/N3Store.js
+++ b/src/N3Store.js
@@ -1396,6 +1396,15 @@ class DatasetCoreAndReadableStream extends Readable {
     }
   }
 
+  // ### `_destroy` closes the cached iterator, so a destroyed stream releases its iteration state.
+  _destroy(error, callback) {
+    if (this[ITERATOR]) {
+      this[ITERATOR].return();
+      this[ITERATOR] = null;
+    }
+    callback(error);
+  }
+
   addAll(quads) {
     if (this._semantics === 'forwarded') {
       this.n3Store.addAll(quads);

--- a/src/N3Store.js
+++ b/src/N3Store.js
@@ -1272,7 +1272,8 @@ class DatasetCoreAndReadableStream extends Readable {
       this._observer = n3Store._addObserver(this._onParentMutation.bind(this));
   }
 
-  // ### `_matchesPattern` returns whether the quad ids fall within this view's pattern (absent term = wildcard).
+  // ### `_matchesPattern` returns whether the quad ids fall within this view's pattern
+  // (absent term = wildcard; the legacy `''` graph argument denotes the default graph, as in `_getGraphs`).
   // Term ids are cached upon resolution; a pattern term may still be absent from the entity index
   // (`_termToNumericId` then returns `undefined`, which never equals a quad id), so an
   // unresolved id is re-resolved on every call, as the term may be interned later on.
@@ -1281,7 +1282,8 @@ class DatasetCoreAndReadableStream extends Readable {
     return (!subject   || subjectId   === (this._subjectId   || (this._subjectId   = n3Store._termToNumericId(subject))))   &&
            (!predicate || predicateId === (this._predicateId || (this._predicateId = n3Store._termToNumericId(predicate)))) &&
            (!object    || objectId    === (this._objectId    || (this._objectId    = n3Store._termToNumericId(object))))    &&
-           (!graph     || graphId     === (this._graphId     || (this._graphId     = isDefaultGraph(graph) ? 1 : n3Store._termToNumericId(graph))));
+           (graph == null || graphId  === (this._graphId     || (this._graphId     =
+             graph === '' || isDefaultGraph(graph) ? 1 : n3Store._termToNumericId(graph))));
   }
 
   // ### `_onParentMutation` reacts to a parent mutation, invoked before the parent index changes.

--- a/src/N3Store.js
+++ b/src/N3Store.js
@@ -1245,6 +1245,21 @@ function validateMatchSemantics(semantics = 'lazy') {
   return semantics;
 }
 
+// Returns the intersection of two quad patterns, or false if they conflict.
+function intersectMatchPatterns(left, right) {
+  const result = new Array(4);
+  for (let i = 0; i < 4; i++) {
+    const leftTerm = left[i], rightTerm = right[i];
+    if (leftTerm === null || leftTerm === undefined)
+      result[i] = rightTerm;
+    else if (rightTerm === null || rightTerm === undefined || termToId(leftTerm) === termToId(rightTerm))
+      result[i] = leftTerm;
+    else
+      return false;
+  }
+  return result;
+}
+
 /**
  * A class that implements both DatasetCore and Readable.
  */
@@ -1254,6 +1269,11 @@ class DatasetCoreAndReadableStream extends Readable {
     Object.assign(this, { n3Store, subject, predicate, object, graph, options });
     const semantics = this._semantics = validateMatchSemantics(options.matchSemantics);
 
+    if (options.matchesNothing) {
+      this._matchesNothing = true;
+      this._filtered = new N3Store({ factory: n3Store._factory, entityIndex: options.entityIndex });
+    }
+
     if (semantics !== 'lazy') {
       // Track stable reads across parent mutations
       this._generation = 0;
@@ -1261,8 +1281,10 @@ class DatasetCoreAndReadableStream extends Readable {
       this._baselines = null;
       // Cache pattern ids on first use
       this._subjectId = this._predicateId = this._objectId = this._graphId = undefined;
-      this._observer = this._onParentMutation.bind(this);
-      n3Store._addObserver(this._observer);
+      if (!this._matchesNothing) {
+        this._observer = this._onParentMutation.bind(this);
+        n3Store._addObserver(this._observer);
+      }
     }
   }
 
@@ -1278,6 +1300,22 @@ class DatasetCoreAndReadableStream extends Readable {
     return graph === null || graph === undefined ||
       graphId === (this._graphId || (this._graphId =
         graph === '' || isDefaultGraph(graph) ? 1 : n3Store._termToNumericId(graph)));
+  }
+
+  // ### `_matchesQuad` tests a Quad against this view.
+  _matchesQuad(quad) {
+    const { subject, predicate, object, graph } = this;
+    return !this._matchesNothing &&
+      (subject === null || subject === undefined || termToId(subject) === termToId(quad.subject)) &&
+      (predicate === null || predicate === undefined || termToId(predicate) === termToId(quad.predicate)) &&
+      (object === null || object === undefined || termToId(object) === termToId(quad.object)) &&
+      (graph === null || graph === undefined || termToId(graph) === termToId(quad.graph));
+  }
+
+  // ### `_assertMatchesPattern` rejects a Quad outside this view.
+  _assertMatchesPattern(quad) {
+    if (!this._matchesQuad(quad))
+      throw new Error('Cannot add a quad that does not match the forwarded view pattern');
   }
 
   // ### `_sourceIterator` returns an iterator over the current backing store.
@@ -1429,7 +1467,10 @@ class DatasetCoreAndReadableStream extends Readable {
 
   addAll(quads) {
     if (this._semantics === 'forwarded') {
-      this.n3Store.addAll(quads);
+      for (const quad of quads) {
+        this._assertMatchesPattern(quad);
+        this.n3Store.addQuad(quad);
+      }
       return this;
     }
     return this.filtered.addAll(quads);
@@ -1441,7 +1482,12 @@ class DatasetCoreAndReadableStream extends Readable {
 
   deleteMatches(subject, predicate, object, graph) {
     if (this._semantics === 'forwarded') {
-      this.n3Store.deleteMatches(subject, predicate, object, graph);
+      const pattern = !this._matchesNothing && intersectMatchPatterns(
+        [this.subject, this.predicate, this.object, this.graph],
+        [subject, predicate, object, graph],
+      );
+      if (pattern)
+        this.n3Store.deleteMatches(...pattern);
       return this;
     }
     return this.filtered.deleteMatches(subject, predicate, object, graph);
@@ -1468,8 +1514,19 @@ class DatasetCoreAndReadableStream extends Readable {
   }
 
   import(stream) {
-    if (this._semantics === 'forwarded')
-      return this.n3Store.import(stream);
+    if (this._semantics === 'forwarded') {
+      const n3Store = this.n3Store;
+      stream.on('data', quad => {
+        try {
+          this._assertMatchesPattern(quad);
+          n3Store.addQuad(quad);
+        }
+        catch (error) {
+          stream.destroy(error);
+        }
+      });
+      return stream;
+    }
     return this.filtered.import(stream);
   }
 
@@ -1517,6 +1574,7 @@ class DatasetCoreAndReadableStream extends Readable {
 
   add(quad) {
     if (this._semantics === 'forwarded') {
+      this._assertMatchesPattern(quad);
       this.n3Store.addQuad(quad);
       return this;
     }
@@ -1525,7 +1583,8 @@ class DatasetCoreAndReadableStream extends Readable {
 
   delete(quad) {
     if (this._semantics === 'forwarded') {
-      this.n3Store.removeQuad(quad);
+      if (this._matchesQuad(quad))
+        this.n3Store.removeQuad(quad);
       return this;
     }
     return this.filtered.delete(quad);
@@ -1535,12 +1594,31 @@ class DatasetCoreAndReadableStream extends Readable {
     return this.filtered.has(quad);
   }
 
-  match(subject, predicate, object, graph) {
-    // Nested views cannot write through to the root
-    return new DatasetCoreAndReadableStream(this.filtered, subject, predicate, object, graph, {
-      entityIndex: this.options.entityIndex,
-      matchSemantics: this._semantics === 'forwarded' ? 'snapshot' : this._semantics,
-    });
+  match(subject, predicate, object, graph, options = null) {
+    const requestedSemantics = options && options.matchSemantics;
+    if (options && requestedSemantics !== undefined) {
+      validateMatchSemantics(requestedSemantics);
+      if (requestedSemantics !== this._semantics)
+        throw new Error(`Cannot override matchSemantics on a view: inherited "${this._semantics}", received "${requestedSemantics}"`);
+    }
+
+    if (this._semantics !== 'forwarded')
+      return new DatasetCoreAndReadableStream(this.filtered, subject, predicate, object, graph, {
+        entityIndex: this.options.entityIndex,
+        matchSemantics: this._semantics,
+      });
+
+    const pattern = !this._matchesNothing && intersectMatchPatterns(
+      [this.subject, this.predicate, this.object, this.graph],
+      [subject, predicate, object, graph],
+    );
+    const [matchedSubject, matchedPredicate, matchedObject, matchedGraph] = pattern || [null, null, null, null];
+    return new DatasetCoreAndReadableStream(
+      this.n3Store, matchedSubject, matchedPredicate, matchedObject, matchedGraph, {
+        entityIndex: this.options.entityIndex,
+        matchSemantics: 'forwarded',
+        matchesNothing: !pattern,
+      });
   }
 
   [Symbol.iterator]() {

--- a/src/N3Store.js
+++ b/src/N3Store.js
@@ -197,7 +197,7 @@ export default class N3Store {
       options = quads, quads = null;
     options = options || {};
     this._factory = options.factory || N3DataFactory;
-    this._matchSemantics = validateMatchSemantics(options.matchSemantics || 'lazy');
+    this._matchSemantics = validateMatchSemantics(options.matchSemantics);
     this._entityIndex = options.entityIndex || new N3EntityIndex({ factory: this._factory });
     this._entities = this._entityIndex._entities;
     this._termFromId = this._entityIndex._termFromId.bind(this._entityIndex);
@@ -479,11 +479,8 @@ export default class N3Store {
     object    = this._termToNewNumericId(object);
 
     // Notify observers only for new quads
-    if (this._observers !== null) {
-      const subjects = graphItem.subjects[subject], predicates = subjects && subjects[predicate];
-      if (!predicates || !(object in predicates))
-        this._notifyObservers(subject, predicate, object, graph, true);
-    }
+    if (this._observers !== null && !hasInIndex(graphItem.subjects, subject, predicate, object))
+      this._notifyObservers(subject, predicate, object, graph, true);
 
     if (!this._addToIndex(graphItem.subjects,   subject,   predicate, object))
       return false;
@@ -661,10 +658,11 @@ export default class N3Store {
   // Setting any field to `undefined` or `null` indicates a wildcard.
   // For backwards compatibility, the object return also implements the Readable stream interface.
   // `options.matchSemantics` controls how the view reacts to later mutations.
-  match(subject, predicate, object, graph, options) {
+  match(subject, predicate, object, graph, options = null) {
     return new DatasetCoreAndReadableStream(this, subject, predicate, object, graph, {
       entityIndex: this._entityIndex,
-      matchSemantics: (options && options.matchSemantics) || this._matchSemantics,
+      matchSemantics: options && options.matchSemantics !== undefined ?
+        options.matchSemantics : this._matchSemantics,
     });
   }
 
@@ -1241,7 +1239,7 @@ function indexMatch(index, ids, depth = 0) {
   return target;
 }
 
-function validateMatchSemantics(semantics) {
+function validateMatchSemantics(semantics = 'lazy') {
   if (semantics !== 'lazy' && semantics !== 'snapshot' && semantics !== 'forwarded')
     throw new Error(`Unknown matchSemantics: ${semantics}`);
   return semantics;
@@ -1282,19 +1280,28 @@ class DatasetCoreAndReadableStream extends Readable {
         graph === '' || isDefaultGraph(graph) ? 1 : n3Store._termToNumericId(graph)));
   }
 
+  // ### `_sourceIterator` returns an iterator over the current backing store.
+  _sourceIterator() {
+    return this._filtered ? this._filtered[Symbol.iterator]() :
+      this.n3Store.readQuads(this.subject, this.predicate, this.object, this.graph);
+  }
+
+  // ### `_freezeCurrentIterators` snapshots readers in the current generation.
+  _freezeCurrentIterators() {
+    if (this._currentIterators === 0)
+      return;
+    if (!this._baselines)
+      this._baselines = new Map();
+    this._baselines.set(this._generation++, [...this._sourceIterator()]);
+    this._currentIterators = 0;
+  }
+
   // ### `_onParentMutation` applies a parent mutation to this view.
   _onParentMutation(subjectId, predicateId, objectId, graphId, added) {
     if (!this._matchesPattern(subjectId, predicateId, objectId, graphId))
       return;
 
-    // Freeze active readers before the mutation
-    if (this._currentIterators > 0) {
-      if (!this._baselines)
-        this._baselines = new Map();
-      this._baselines.set(this._generation++, this._filtered ? [...this._filtered] :
-        this.n3Store.getQuads(this.subject, this.predicate, this.object, this.graph));
-      this._currentIterators = 0;
-    }
+    this._freezeCurrentIterators();
 
     // Keep using the parent until materialization
     if (this._semantics === 'forwarded') {
@@ -1326,6 +1333,8 @@ class DatasetCoreAndReadableStream extends Readable {
   get filtered() {
     if (!this._filtered) {
       const { n3Store, graph, object, predicate, subject } = this;
+      if (this._semantics !== 'lazy')
+        this._freezeCurrentIterators();
       const newStore = this._filtered = new N3Store({ factory: n3Store._factory, entityIndex: this.options.entityIndex });
 
       if (this._semantics === 'snapshot')
@@ -1529,11 +1538,11 @@ class DatasetCoreAndReadableStream extends Readable {
     });
   }
 
-  *[Symbol.iterator]() {
-    if (this._semantics === 'lazy') {
-      yield* this._filtered || this.n3Store.readQuads(this.subject, this.predicate, this.object, this.graph);
-      return;
-    }
+  [Symbol.iterator]() {
+    return this._semantics === 'lazy' ? this._sourceIterator() : this._iterateStable();
+  }
+
+  *_iterateStable() {
 
     // Use a snapshot if the parent changes mid-iteration
     const generation = this._generation;
@@ -1541,10 +1550,7 @@ class DatasetCoreAndReadableStream extends Readable {
     this._activeIterators++;
     this._currentIterators++;
     try {
-      const source = this._filtered ?
-        this._filtered[Symbol.iterator]() :
-        this.n3Store.readQuads(this.subject, this.predicate, this.object, this.graph);
-      for (const quad of source) {
+      for (const quad of this._sourceIterator()) {
         if (this._generation !== generation)
           break;
         yielded++;

--- a/src/N3Store.js
+++ b/src/N3Store.js
@@ -1059,7 +1059,8 @@ export default class N3Store {
    * @param graph     The optional exact graph to match.
    */
   deleteMatches(subject, predicate, object, graph) {
-    for (const quad of this.match(subject, predicate, object, graph))
+    // Internal matching is explicitly `lazy`: a non-`lazy` view would register an observer that is never released
+    for (const quad of this.match(subject, predicate, object, graph, { matchSemantics: 'lazy' }))
       this.removeQuad(quad);
     return this;
   }
@@ -1185,9 +1186,10 @@ export default class N3Store {
 
   /**
    * Returns a stream that contains all quads of the dataset.
+   * The stream is explicitly `lazy`: a non-`lazy` view would register an observer that is never released.
    */
   toStream() {
-    return this.match();
+    return this.match(null, null, null, null, { matchSemantics: 'lazy' });
   }
 
   /**
@@ -1455,9 +1457,10 @@ class DatasetCoreAndReadableStream extends Readable {
     // For non-`lazy` semantics, route through the snapshot rather than the live parent
     if (this._semantics !== 'lazy')
       return this.filtered.toStream();
+    // The internal view is explicitly `lazy`, so a non-`lazy` store default cannot leak an observer
     return this._filtered ?
       this._filtered.toStream()
-      : this.n3Store.match(this.subject, this.predicate, this.object, this.graph);
+      : this.n3Store.match(this.subject, this.predicate, this.object, this.graph, { matchSemantics: 'lazy' });
   }
 
   union(quads) {

--- a/src/N3Store.js
+++ b/src/N3Store.js
@@ -478,7 +478,7 @@ export default class N3Store {
     predicate = this._termToNewNumericId(predicate);
     object    = this._termToNewNumericId(object);
 
-    // Notify observers only for new quads
+    // Notify observers before inserting a new quad so snapshots retain their prior contents
     if (this._observers !== null && !hasInIndex(graphItem.subjects, subject, predicate, object))
       this._notifyObservers(subject, predicate, object, graph, true);
 
@@ -1626,7 +1626,6 @@ class DatasetCoreAndReadableStream extends Readable {
   }
 
   *_iterateStable() {
-
     // Use a snapshot if the parent changes mid-iteration
     const generation = this._generation;
     let yielded = 0;

--- a/src/N3Store.js
+++ b/src/N3Store.js
@@ -1260,6 +1260,8 @@ class DatasetCoreAndReadableStream extends Readable {
     this._activeIterators = 0;
     // Frozen array of matching quads at the start of in-progress iteration(s), to keep iterators stable
     this._baseline = null;
+    // Lazily cached numeric ids of the pattern terms (immutable once present in the entity index)
+    this._subjectId = this._predicateId = this._objectId = this._graphId = undefined;
     const semantics = this._semantics = options.matchSemantics;
     if (semantics !== 'lazy' && semantics !== 'snapshot' && semantics !== 'forwarded')
       throw new Error(`Unknown matchSemantics: ${semantics}`);
@@ -1269,17 +1271,15 @@ class DatasetCoreAndReadableStream extends Readable {
   }
 
   // ### `_matchesPattern` returns whether the quad ids fall within this view's pattern (absent term = wildcard).
+  // Term ids are cached upon resolution; a pattern term may still be absent from the entity index
+  // (`_termToNumericId` then returns `undefined`, which never equals a quad id), so an
+  // unresolved id is re-resolved on every call, as the term may be interned later on.
   _matchesPattern(subjectId, predicateId, objectId, graphId) {
-    const { subject, predicate, object, graph } = this;
-    return (!subject   || subjectId   === this._termId(subject))   &&
-           (!predicate || predicateId === this._termId(predicate)) &&
-           (!object    || objectId    === this._termId(object))    &&
-           (!graph     || graphId     === (isDefaultGraph(graph) ? 1 : this._termId(graph)));
-  }
-
-  // ### `_termId` returns the parent's numeric id for a term, or `undefined` if not present.
-  _termId(term) {
-    return this.n3Store._termToNumericId(term);
+    const { subject, predicate, object, graph, n3Store } = this;
+    return (!subject   || subjectId   === (this._subjectId   || (this._subjectId   = n3Store._termToNumericId(subject))))   &&
+           (!predicate || predicateId === (this._predicateId || (this._predicateId = n3Store._termToNumericId(predicate)))) &&
+           (!object    || objectId    === (this._objectId    || (this._objectId    = n3Store._termToNumericId(object))))    &&
+           (!graph     || graphId     === (this._graphId     || (this._graphId     = isDefaultGraph(graph) ? 1 : n3Store._termToNumericId(graph))));
   }
 
   // ### `_onParentMutation` reacts to a parent mutation, invoked before the parent index changes.
@@ -1295,28 +1295,32 @@ class DatasetCoreAndReadableStream extends Readable {
       this._generation++;
     }
 
-    // Materialize the pre-mutation snapshot if it does not exist yet
-    if (!this._filtered)
-      this._filtered = this.filtered;
-
-    // `forwarded`: apply the delta so the view tracks the parent (`snapshot` views are now frozen)
+    // `forwarded`: apply the delta only if the view has materialized; otherwise,
+    // the parent remains the source of truth, and a later read captures the current state
     if (this._semantics === 'forwarded') {
-      const quad = this._toQuad(subjectId, predicateId, objectId, graphId);
-      if (added)
-        this._filtered.addQuad(quad);
-      else
-        this._filtered.removeQuad(quad);
+      if (this._filtered) {
+        const quad = this._toQuad(subjectId, predicateId, objectId, graphId);
+        if (added)
+          this._filtered.addQuad(quad);
+        else
+          this._filtered.removeQuad(quad);
+      }
+      return;
     }
+
+    // `snapshot`: materialize the pre-mutation state
+    // (`_filtered` is always null here, as its getter unregisters this observer on build)
+    this._filtered = this.filtered;
   }
 
   // ### `_toQuad` builds a Quad from numeric ids in the parent's entity index.
   _toQuad(subjectId, predicateId, objectId, graphId) {
     const { n3Store } = this, entities = n3Store._entities;
     return n3Store._factory.quad(
-      n3Store._termFromId(entities[subjectId], n3Store._factory),
-      n3Store._termFromId(entities[predicateId], n3Store._factory),
-      n3Store._termFromId(entities[objectId], n3Store._factory),
-      n3Store._termFromId(entities[graphId], n3Store._factory),
+      n3Store._termFromId(entities[subjectId]),
+      n3Store._termFromId(entities[predicateId]),
+      n3Store._termFromId(entities[objectId]),
+      n3Store._termFromId(entities[graphId]),
     );
   }
 

--- a/src/N3Store.js
+++ b/src/N3Store.js
@@ -198,7 +198,7 @@ export default class N3Store {
     options = options || {};
     this._factory = options.factory || N3DataFactory;
     // Default `match()` semantics ('lazy', 'snapshot', or 'forwarded'); see `match()`
-    this._matchSemantics = options.matchSemantics || 'lazy';
+    this._matchSemantics = validateMatchSemantics(options.matchSemantics || 'lazy');
     this._entityIndex = options.entityIndex || new N3EntityIndex({ factory: this._factory });
     this._entities = this._entityIndex._entities;
     this._termFromId = this._entityIndex._termFromId.bind(this._entityIndex);
@@ -1252,6 +1252,16 @@ function indexMatch(index, ids, depth = 0) {
 }
 
 /**
+ * Returns `semantics` if it is a supported `matchSemantics` value,
+ * and throws otherwise, so misconfiguration fails at the call site.
+ */
+function validateMatchSemantics(semantics) {
+  if (semantics !== 'lazy' && semantics !== 'snapshot' && semantics !== 'forwarded')
+    throw new Error(`Unknown matchSemantics: ${semantics}`);
+  return semantics;
+}
+
+/**
  * A class that implements both DatasetCore and Readable.
  */
 class DatasetCoreAndReadableStream extends Readable {
@@ -1266,9 +1276,7 @@ class DatasetCoreAndReadableStream extends Readable {
     this._baselines = null;
     // Lazily cached numeric ids of the pattern terms (immutable once present in the entity index)
     this._subjectId = this._predicateId = this._objectId = this._graphId = undefined;
-    const semantics = this._semantics = options.matchSemantics;
-    if (semantics !== 'lazy' && semantics !== 'snapshot' && semantics !== 'forwarded')
-      throw new Error(`Unknown matchSemantics: ${semantics}`);
+    const semantics = this._semantics = validateMatchSemantics(options.matchSemantics);
     // For non-`lazy` semantics, observe parent mutations to keep the view consistent
     if (semantics !== 'lazy')
       this._observer = n3Store._addObserver(this._onParentMutation.bind(this));

--- a/src/N3Store.js
+++ b/src/N3Store.js
@@ -1282,8 +1282,9 @@ class DatasetCoreAndReadableStream extends Readable {
     return (!subject   || subjectId   === (this._subjectId   || (this._subjectId   = n3Store._termToNumericId(subject))))   &&
            (!predicate || predicateId === (this._predicateId || (this._predicateId = n3Store._termToNumericId(predicate)))) &&
            (!object    || objectId    === (this._objectId    || (this._objectId    = n3Store._termToNumericId(object))))    &&
-           (graph == null || graphId  === (this._graphId     || (this._graphId     =
-             graph === '' || isDefaultGraph(graph) ? 1 : n3Store._termToNumericId(graph))));
+           (graph === null || graph === undefined ||
+             graphId === (this._graphId || (this._graphId =
+               graph === '' || isDefaultGraph(graph) ? 1 : n3Store._termToNumericId(graph))));
   }
 
   // ### `_onParentMutation` reacts to a parent mutation, invoked before the parent index changes.

--- a/src/N3Store.js
+++ b/src/N3Store.js
@@ -1427,15 +1427,12 @@ class DatasetCoreAndReadableStream extends Readable {
     return this;
   }
 
-  // ### `_mutationStore` returns the store targeted by mutations.
-  get _mutationStore() {
-    return this._semantics === 'forwarded' ? this.n3Store : this.filtered;
-  }
-
   addAll(quads) {
-    const store = this._mutationStore;
-    store.addAll(quads);
-    return store === this.n3Store ? this : store;
+    if (this._semantics === 'forwarded') {
+      this.n3Store.addAll(quads);
+      return this;
+    }
+    return this.filtered.addAll(quads);
   }
 
   contains(other) {
@@ -1443,9 +1440,11 @@ class DatasetCoreAndReadableStream extends Readable {
   }
 
   deleteMatches(subject, predicate, object, graph) {
-    const store = this._mutationStore;
-    store.deleteMatches(subject, predicate, object, graph);
-    return store === this.n3Store ? this : store;
+    if (this._semantics === 'forwarded') {
+      this.n3Store.deleteMatches(subject, predicate, object, graph);
+      return this;
+    }
+    return this.filtered.deleteMatches(subject, predicate, object, graph);
   }
 
   difference(other) {
@@ -1469,7 +1468,9 @@ class DatasetCoreAndReadableStream extends Readable {
   }
 
   import(stream) {
-    return this._mutationStore.import(stream);
+    if (this._semantics === 'forwarded')
+      return this.n3Store.import(stream);
+    return this.filtered.import(stream);
   }
 
   intersection(other) {
@@ -1515,15 +1516,19 @@ class DatasetCoreAndReadableStream extends Readable {
   }
 
   add(quad) {
-    const store = this._mutationStore;
-    store.addQuad(quad);
-    return store === this.n3Store ? this : store;
+    if (this._semantics === 'forwarded') {
+      this.n3Store.addQuad(quad);
+      return this;
+    }
+    return this.filtered.add(quad);
   }
 
   delete(quad) {
-    const store = this._mutationStore;
-    store.removeQuad(quad);
-    return store === this.n3Store ? this : store;
+    if (this._semantics === 'forwarded') {
+      this.n3Store.removeQuad(quad);
+      return this;
+    }
+    return this.filtered.delete(quad);
   }
 
   has(quad) {

--- a/src/N3Store.js
+++ b/src/N3Store.js
@@ -1312,7 +1312,9 @@ class DatasetCoreAndReadableStream extends Readable {
 
     // While iterating, freeze the pre-mutation matching quads under the current generation,
     // so every iteration in progress (each started during some generation) keeps a stable view.
-    // This costs O(view size) per matching mutation for as long as any iteration remains open.
+    // While any iteration remains open, each matching mutation costs O(view size) and retains
+    // one frozen array (even for generations at which no iteration started); all baselines
+    // are released once the last iteration closes.
     if (this._activeIterators > 0) {
       if (!this._baselines)
         this._baselines = new Map();
@@ -1556,6 +1558,7 @@ class DatasetCoreAndReadableStream extends Readable {
   }
 
   match(subject, predicate, object, graph) {
+    // Unlike the store's `match`, this takes no `options`: sub-views inherit these semantics.
     // A nested view is parented on the materialized contents, not on the root store,
     // so `forwarded` is downgraded to `snapshot`: write-through would only reach
     // the internal materialized store, silently desyncing this view from its parent

--- a/src/N3Store.js
+++ b/src/N3Store.js
@@ -189,12 +189,21 @@ export default class N3Store {
     this._size = 0;
     // `_graphs` contains subject, predicate, and object indexes per graph
     this._graphs = Object.create(null);
+    // `_observers`, when non-null, is a set of callbacks that are notified
+    // *before* every mutation, so that derived views (e.g. `match()` results
+    // with `snapshot`/`forwarded` semantics) can react to parent mutations.
+    // It is `null` by default to keep the common mutation path allocation-free.
+    this._observers = null;
 
     // Shift parameters if `quads` is not given
     if (!options && quads && !quads[0] && !(typeof quads.match === 'function'))
       options = quads, quads = null;
     options = options || {};
     this._factory = options.factory || N3DataFactory;
+    // The default `match()` semantics for views derived from this store.
+    // One of `'lazy'` (default, backwards-compatible), `'snapshot'`, or
+    // `'forwarded'`. See `match()` for details.
+    this._matchSemantics = options.matchSemantics || 'lazy';
     this._entityIndex = options.entityIndex || new N3EntityIndex({ factory: this._factory });
     this._entities = this._entityIndex._entities;
     this._termFromId = this._entityIndex._termFromId.bind(this._entityIndex);
@@ -402,6 +411,33 @@ export default class N3Store {
     return typeof graph !== 'number' ? this._graphs : { [graph]: this._graphs[graph] };
   }
 
+  // ### `_addObserver` registers a callback that is invoked *before* every
+  // mutation of this store, receiving the numeric ids of the mutated quad and
+  // whether it is being added (`true`) or removed (`false`). Returns the
+  // callback so it can be passed back to `_removeObserver`.
+  _addObserver(observer) {
+    (this._observers || (this._observers = new Set())).add(observer);
+    return observer;
+  }
+
+  // ### `_removeObserver` unregisters a previously added mutation observer.
+  // Callers only invoke this with a currently-registered observer, so
+  // `_observers` is guaranteed to be non-null here.
+  _removeObserver(observer) {
+    this._observers.delete(observer);
+    // Restore the allocation-free fast path once no observers remain.
+    if (this._observers.size === 0)
+      this._observers = null;
+  }
+
+  // ### `_notifyObservers` invokes all registered observers with the numeric
+  // ids of a quad that is about to be added or removed.
+  _notifyObservers(subjectId, predicateId, objectId, graphId, added) {
+    // Iterate over a copy so observers may unregister themselves while reacting.
+    for (const observer of [...this._observers])
+      observer(subjectId, predicateId, objectId, graphId, added);
+  }
+
   // ### `_uniqueEntities` returns a function that accepts an entity ID
   // and passes the corresponding entity to callback if it hasn't occurred before.
   _uniqueEntities(callback) {
@@ -455,6 +491,15 @@ export default class N3Store {
     subject   = this._termToNewNumericId(subject);
     predicate = this._termToNewNumericId(predicate);
     object    = this._termToNewNumericId(object);
+
+    // Notify observers *before* the mutation, so snapshot views can lazily
+    // capture the pre-mutation parent state. Only fire for quads that will
+    // actually change the index (i.e. quads that did not already exist).
+    if (this._observers !== null) {
+      const subjects = graphItem.subjects[subject], predicates = subjects && subjects[predicate];
+      if (!predicates || !(object in predicates))
+        this._notifyObservers(subject, predicate, object, graph, true);
+    }
 
     if (!this._addToIndex(graphItem.subjects,   subject,   predicate, object))
       return false;
@@ -520,6 +565,11 @@ export default class N3Store {
         !(predicates = subjects[predicate]) ||
         !(object in predicates))
       return false;
+
+    // Notify observers *before* the mutation, so snapshot views can lazily
+    // capture the pre-mutation parent state.
+    if (this._observers !== null)
+      this._notifyObservers(subject, predicate, object, graph, false);
 
     // Remove it from all indexes
     this._removeFromIndex(graphItem.subjects,   subject,   predicate, object);
@@ -627,8 +677,22 @@ export default class N3Store {
   // Note: Since a DatasetCore is an unordered set, the order of the quads within the returned sequence is arbitrary.
   // Setting any field to `undefined` or `null` indicates a wildcard.
   // For backwards compatibility, the object return also implements the Readable stream interface.
-  match(subject, predicate, object, graph) {
-    return new DatasetCoreAndReadableStream(this, subject, predicate, object, graph, { entityIndex: this._entityIndex });
+  //
+  // The semantics of the returned view with respect to later parent mutations
+  // can be configured via `options.matchSemantics` (falling back to the
+  // store-level `matchSemantics` option, default `'lazy'`):
+  //  - `'lazy'`: backwards-compatible behavior. The view delegates live to the
+  //    parent until its first own mutation, after which it materializes a
+  //    snapshot. Parent mutations made before that first own mutation leak in.
+  //  - `'snapshot'`: the view reflects the parent contents *at the time of*
+  //    `match()`. Later parent mutations never affect it.
+  //  - `'forwarded'`: the view always reflects the parent state; matching
+  //    parent mutations are forwarded to it (a live view).
+  match(subject, predicate, object, graph, options) {
+    return new DatasetCoreAndReadableStream(this, subject, predicate, object, graph, {
+      entityIndex: this._entityIndex,
+      matchSemantics: (options && options.matchSemantics) || this._matchSemantics,
+    });
   }
 
   // ### `countQuads` returns the number of quads matching a pattern.
@@ -957,7 +1021,10 @@ export default class N3Store {
 
     if (Array.isArray(quads))
       this.addQuads(quads);
-    else if (quads instanceof N3Store && quads._entityIndex === this._entityIndex) {
+    // The index-merge fast path bypasses `addQuad`, so it cannot be used when
+    // observers are registered (e.g. for `forwarded` views), as they must be
+    // notified of every added quad.
+    else if (this._observers === null && quads instanceof N3Store && quads._entityIndex === this._entityIndex) {
       if (quads._size !== 0) {
         this._graphs = merge(this._graphs, quads._graphs);
         this._size = null; // Invalidate the cached size
@@ -1210,6 +1277,94 @@ class DatasetCoreAndReadableStream extends Readable {
   constructor(n3Store, subject, predicate, object, graph, options) {
     super({ objectMode: true });
     Object.assign(this, { n3Store, subject, predicate, object, graph, options });
+    // `_generation` is bumped whenever a matching parent mutation lands while an
+    // iteration is in progress, so that in-progress iterators can detect the
+    // need to switch from the live parent to a frozen baseline mid-iteration.
+    this._generation = 0;
+    // Number of iterations currently in progress over this view. A frozen
+    // baseline is only captured on parent mutation while this is non-zero,
+    // keeping mutations cheap when nothing is being iterated.
+    this._activeIterators = 0;
+    // A frozen array of the matching quads as of the start of the in-progress
+    // iteration(s); used to keep iterators stable across parent mutations.
+    this._baseline = null;
+    // `options.matchSemantics` is always resolved to a concrete value by the
+    // callers (`Store#match` and the view's own `match`).
+    const semantics = this._semantics = options.matchSemantics;
+    if (semantics !== 'lazy' && semantics !== 'snapshot' && semantics !== 'forwarded')
+      throw new Error(`Unknown matchSemantics: ${semantics}`);
+    // For non-`lazy` semantics, observe parent mutations so that the view can
+    // be kept consistent without eagerly copying the whole match result.
+    if (semantics !== 'lazy')
+      this._observer = n3Store._addObserver(this._onParentMutation.bind(this));
+  }
+
+  // ### `_matchesPattern` returns whether the quad identified by the given
+  // numeric ids falls within this view's `subject`/`predicate`/`object`/`graph`
+  // pattern. A `null`/`undefined` pattern term is a wildcard; a present term is
+  // matched against the corresponding id (resolved against the parent's entity
+  // index, which never reassigns an id once given).
+  _matchesPattern(subjectId, predicateId, objectId, graphId) {
+    const { subject, predicate, object, graph } = this;
+    return (!subject   || subjectId   === this._termId(subject))   &&
+           (!predicate || predicateId === this._termId(predicate)) &&
+           (!object    || objectId    === this._termId(object))    &&
+           (!graph     || graphId     === (isDefaultGraph(graph) ? 1 : this._termId(graph)));
+  }
+
+  // ### `_termId` returns the parent's numeric id for a pattern term, or
+  // `undefined` if the term is not (yet) present. The default graph is handled
+  // by the caller.
+  _termId(term) {
+    return this.n3Store._termToNumericId(term);
+  }
+
+  // ### `_onParentMutation` reacts to a parent mutation for `snapshot` and
+  // `forwarded` semantics. It is invoked *before* the parent index changes,
+  // so the pre-mutation state is still observable here.
+  _onParentMutation(subjectId, predicateId, objectId, graphId, added) {
+    // Only matching quads can affect this view; ignore everything else so the
+    // common path stays cheap.
+    if (!this._matchesPattern(subjectId, predicateId, objectId, graphId))
+      return;
+
+    // If an iteration is in progress, freeze the current (pre-mutation)
+    // matching quads so those iterators keep a stable view. This is only done
+    // once per in-flight batch of iterations (until they all finish), and only
+    // while iterating, so the common, non-iterating path stays allocation-free.
+    if (this._activeIterators > 0 && this._baseline === null) {
+      this._baseline = this._filtered ? [...this._filtered] :
+        this.n3Store.getQuads(this.subject, this.predicate, this.object, this.graph);
+      this._generation++;
+    }
+
+    // Materialize the pre-mutation snapshot if it does not exist yet. For
+    // `forwarded` views `_filtered` may already exist (e.g. from an earlier
+    // mutation or query); for `snapshot` views the `filtered` getter detaches
+    // the observer once built, so this method is never re-entered afterwards.
+    if (!this._filtered)
+      this._filtered = this.filtered;
+
+    // `forwarded`: apply the delta so the view tracks the parent. (`snapshot`
+    // views are now frozen and ignore the mutation.)
+    if (this._semantics === 'forwarded') {
+      const quad = this._toQuad(subjectId, predicateId, objectId, graphId);
+      if (added)
+        this._filtered.addQuad(quad);
+      else
+        this._filtered.removeQuad(quad);
+    }
+  }
+
+  // ### `_toQuad` builds a Quad from numeric ids in the parent's entity index.
+  _toQuad(subjectId, predicateId, objectId, graphId) {
+    const { n3Store } = this, entities = n3Store._entities;
+    return n3Store._factory.quad(
+      n3Store._termFromId(entities[subjectId], n3Store._factory),
+      n3Store._termFromId(entities[predicateId], n3Store._factory),
+      n3Store._termFromId(entities[objectId], n3Store._factory),
+      n3Store._termFromId(entities[graphId], n3Store._factory),
+    );
   }
 
   get filtered() {
@@ -1251,6 +1406,13 @@ class DatasetCoreAndReadableStream extends Readable {
         }
       }
       newStore._size = null;
+
+      // A `snapshot` view is frozen once built, so it no longer needs to
+      // observe the parent. (`forwarded` views keep observing.)
+      if (this._semantics === 'snapshot' && this._observer) {
+        this.n3Store._removeObserver(this._observer);
+        this._observer = null;
+      }
     }
     return this._filtered;
   }
@@ -1274,6 +1436,10 @@ class DatasetCoreAndReadableStream extends Readable {
   }
 
   addAll(quads) {
+    if (this._semantics === 'forwarded') {
+      this.n3Store.addAll(quads);
+      return this;
+    }
     return this.filtered.addAll(quads);
   }
 
@@ -1282,6 +1448,10 @@ class DatasetCoreAndReadableStream extends Readable {
   }
 
   deleteMatches(subject, predicate, object, graph) {
+    if (this._semantics === 'forwarded') {
+      this.n3Store.deleteMatches(subject, predicate, object, graph);
+      return this;
+    }
     return this.filtered.deleteMatches(subject, predicate, object, graph);
   }
 
@@ -1326,18 +1496,27 @@ class DatasetCoreAndReadableStream extends Readable {
   }
 
   toStream() {
+    // For non-`lazy` semantics, route through the (possibly materialized)
+    // snapshot so the stream reflects the configured view rather than the live
+    // parent. For `lazy`, preserve the original delegation for performance.
+    if (this._semantics !== 'lazy')
+      return this.filtered.toStream();
     return this._filtered ?
       this._filtered.toStream()
       : this.n3Store.match(this.subject, this.predicate, this.object, this.graph);
   }
 
   union(quads) {
+    if (this._semantics !== 'lazy')
+      return this.filtered.union(quads);
     return this._filtered ?
       this._filtered.union(quads)
       : this.n3Store.match(this.subject, this.predicate, this.object, this.graph).addAll(quads);
   }
 
   toArray() {
+    if (this._semantics !== 'lazy')
+      return this.filtered.toArray();
     return this._filtered ? this._filtered.toArray() : this.n3Store.getQuads(this.subject, this.predicate, this.object, this.graph);
   }
 
@@ -1350,10 +1529,20 @@ class DatasetCoreAndReadableStream extends Readable {
   }
 
   add(quad) {
+    // For `forwarded` views, mutations are written through to the parent store,
+    // which then forwards the change back to this view via the observer.
+    if (this._semantics === 'forwarded') {
+      this.n3Store.addQuad(quad);
+      return this;
+    }
     return this.filtered.add(quad);
   }
 
   delete(quad) {
+    if (this._semantics === 'forwarded') {
+      this.n3Store.removeQuad(quad);
+      return this;
+    }
     return this.filtered.delete(quad);
   }
 
@@ -1365,8 +1554,55 @@ class DatasetCoreAndReadableStream extends Readable {
     return new DatasetCoreAndReadableStream(this.filtered, subject, predicate, object, graph, this.options);
   }
 
-  [Symbol.iterator]() {
-    return this._filtered ? this._filtered[Symbol.iterator]() :
-      this.n3Store.readQuads(this.subject, this.predicate, this.object, this.graph);
+  *[Symbol.iterator]() {
+    // `lazy` semantics: original behavior. Iterate the materialized snapshot if
+    // it exists, otherwise delegate live to the parent. No observers exist for
+    // lazy views, so no mid-iteration switching can occur.
+    if (this._semantics === 'lazy') {
+      yield* this._filtered || this.n3Store.readQuads(this.subject, this.predicate, this.object, this.graph);
+      return;
+    }
+
+    // Non-`lazy` semantics: iterate a view that stays stable for the duration of
+    // this iteration, even if the parent is mutated mid-stream. We iterate the
+    // current source (the materialized snapshot if present, else the live
+    // parent). If a matching parent mutation lands while we iterate, the
+    // observer freezes the pre-mutation matching quads into `_baseline` and
+    // bumps `_generation`; we then switch to `_baseline`, skipping the quads we
+    // have already yielded. Because `_baseline` is captured in the same order
+    // the source iterates, skip-by-count yields exactly the remaining quads with
+    // no duplicates or omissions.
+    const generation = this._generation;
+    let yielded = 0;
+    this._activeIterators++;
+    try {
+      const source = this._filtered ?
+        this._filtered[Symbol.iterator]() :
+        this.n3Store.readQuads(this.subject, this.predicate, this.object, this.graph);
+      for (const quad of source) {
+        if (this._generation !== generation) {
+          yield* this._skip(this._baseline[Symbol.iterator](), yielded);
+          return;
+        }
+        yielded++;
+        yield quad;
+      }
+      // A mutation may have landed exactly when the source was exhausted.
+      if (this._generation !== generation)
+        yield* this._skip(this._baseline[Symbol.iterator](), yielded);
+    }
+    finally {
+      // Once no iterations remain, drop the frozen baseline so future mutations
+      // do not pay to maintain it.
+      if (--this._activeIterators === 0)
+        this._baseline = null;
+    }
+  }
+
+  // ### `_skip` advances `iterator` past `count` quads and yields the rest.
+  *_skip(iterator, count) {
+    while (count-- > 0)
+      iterator.next();
+    yield* iterator;
   }
 }

--- a/src/N3Store.js
+++ b/src/N3Store.js
@@ -1328,10 +1328,8 @@ class DatasetCoreAndReadableStream extends Readable {
       const { n3Store, graph, object, predicate, subject } = this;
       const newStore = this._filtered = new N3Store({ factory: n3Store._factory, entityIndex: this.options.entityIndex });
 
-      if (this._semantics === 'snapshot' && this._observer) {
-        this.n3Store._removeObserver(this._observer);
-        this._observer = null;
-      }
+      if (this._semantics === 'snapshot')
+        this._detachObserver();
 
       let subjectId, predicateId, objectId;
 
@@ -1398,13 +1396,18 @@ class DatasetCoreAndReadableStream extends Readable {
     callback(error);
   }
 
-  // ### `detach` freezes the view and stops observing the parent.
-  detach() {
-    this._filtered = this.filtered;
+  // ### `_detachObserver` stops observing the parent store.
+  _detachObserver() {
     if (this._observer) {
       this.n3Store._removeObserver(this._observer);
       this._observer = null;
     }
+  }
+
+  // ### `detach` freezes the view and stops observing the parent.
+  detach() {
+    this._filtered = this.filtered;
+    this._detachObserver();
     // Lazy views deferred this state
     if (this._semantics === 'lazy') {
       this._generation = 0;

--- a/src/N3Store.js
+++ b/src/N3Store.js
@@ -666,7 +666,9 @@ export default class N3Store {
   // how the view reacts to later parent mutations:
   //  - `'lazy'`: delegates live to the parent until its first own mutation (backwards-compatible).
   //  - `'snapshot'`: reflects the parent contents at the time of `match()`.
-  //  - `'forwarded'`: stays live; matching parent mutations are forwarded to it.
+  //  - `'forwarded'`: stays live; matching parent mutations are forwarded to it, and view
+  //    mutations write through to the parent unrestricted by the pattern (so a
+  //    non-matching `add` mutates the parent without appearing in the view).
   // Calling `match()` on a view yields at most a `'snapshot'` sub-view:
   // nested views never write through to the root store.
   // A non-`lazy` view observes the store — `'snapshot'` until it first materializes,

--- a/src/N3Store.js
+++ b/src/N3Store.js
@@ -1415,12 +1415,15 @@ class DatasetCoreAndReadableStream extends Readable {
     return this;
   }
 
+  // ### `_mutationStore` returns the store targeted by mutations.
+  get _mutationStore() {
+    return this._semantics === 'forwarded' ? this.n3Store : this.filtered;
+  }
+
   addAll(quads) {
-    if (this._semantics === 'forwarded') {
-      this.n3Store.addAll(quads);
-      return this;
-    }
-    return this.filtered.addAll(quads);
+    const store = this._mutationStore;
+    store.addAll(quads);
+    return store === this.n3Store ? this : store;
   }
 
   contains(other) {
@@ -1428,11 +1431,9 @@ class DatasetCoreAndReadableStream extends Readable {
   }
 
   deleteMatches(subject, predicate, object, graph) {
-    if (this._semantics === 'forwarded') {
-      this.n3Store.deleteMatches(subject, predicate, object, graph);
-      return this;
-    }
-    return this.filtered.deleteMatches(subject, predicate, object, graph);
+    const store = this._mutationStore;
+    store.deleteMatches(subject, predicate, object, graph);
+    return store === this.n3Store ? this : store;
   }
 
   difference(other) {
@@ -1456,9 +1457,7 @@ class DatasetCoreAndReadableStream extends Readable {
   }
 
   import(stream) {
-    if (this._semantics === 'forwarded')
-      return this.n3Store.import(stream);
-    return this.filtered.import(stream);
+    return this._mutationStore.import(stream);
   }
 
   intersection(other) {
@@ -1504,19 +1503,15 @@ class DatasetCoreAndReadableStream extends Readable {
   }
 
   add(quad) {
-    if (this._semantics === 'forwarded') {
-      this.n3Store.addQuad(quad);
-      return this;
-    }
-    return this.filtered.add(quad);
+    const store = this._mutationStore;
+    store.addQuad(quad);
+    return store === this.n3Store ? this : store;
   }
 
   delete(quad) {
-    if (this._semantics === 'forwarded') {
-      this.n3Store.removeQuad(quad);
-      return this;
-    }
-    return this.filtered.delete(quad);
+    const store = this._mutationStore;
+    store.removeQuad(quad);
+    return store === this.n3Store ? this : store;
   }
 
   has(quad) {

--- a/src/N3Store.js
+++ b/src/N3Store.js
@@ -1330,7 +1330,10 @@ class DatasetCoreAndReadableStream extends Readable {
       return;
     if (!this._baselines)
       this._baselines = new Map();
-    this._baselines.set(this._generation++, [...this._sourceIterator()]);
+    this._baselines.set(this._generation++, {
+      readers: this._currentIterators,
+      quads: [...this._sourceIterator()],
+    });
     this._currentIterators = 0;
   }
 
@@ -1502,15 +1505,18 @@ class DatasetCoreAndReadableStream extends Readable {
   }
 
   every(callback, subject, predicate, object, graph) {
-    return this.filtered.every(callback, subject, predicate, object, graph);
+    return this.filtered.every(this._semantics === 'forwarded' ?
+      quad => callback(quad, this) : callback, subject, predicate, object, graph);
   }
 
   filter(iteratee) {
-    return this.filtered.filter(iteratee);
+    return this.filtered.filter(this._semantics === 'forwarded' ?
+      quad => iteratee(quad, this) : iteratee);
   }
 
   forEach(callback, subject, predicate, object, graph) {
-    return this.filtered.forEach(callback, subject, predicate, object, graph);
+    return this.filtered.forEach(this._semantics === 'forwarded' ?
+      quad => callback(quad, this) : callback, subject, predicate, object, graph);
   }
 
   import(stream) {
@@ -1535,11 +1541,13 @@ class DatasetCoreAndReadableStream extends Readable {
   }
 
   map(iteratee) {
-    return this.filtered.map(iteratee);
+    return this.filtered.map(this._semantics === 'forwarded' ?
+      quad => iteratee(quad, this) : iteratee);
   }
 
   some(callback, subject, predicate, object, graph) {
-    return this.filtered.some(callback, subject, predicate, object, graph);
+    return this.filtered.some(this._semantics === 'forwarded' ?
+      quad => callback(quad, this) : callback, subject, predicate, object, graph);
   }
 
   toCanonical() {
@@ -1548,7 +1556,8 @@ class DatasetCoreAndReadableStream extends Readable {
 
   toStream() {
     if (this._semantics !== 'lazy')
-      return this.filtered.toStream();
+      // Use a fresh sync iterator instead of consuming this view's own readable stream.
+      return Readable.from(this[Symbol.iterator]());
     return this._filtered ?
       this._filtered.toStream()
       : this.n3Store.match(this.subject, this.predicate, this.object, this.graph, { matchSemantics: 'lazy' });
@@ -1565,7 +1574,8 @@ class DatasetCoreAndReadableStream extends Readable {
   }
 
   reduce(callback, initialValue) {
-    return this.filtered.reduce(callback, initialValue);
+    return this.filtered.reduce(this._semantics === 'forwarded' ?
+      (accumulator, quad) => callback(accumulator, quad, this) : callback, initialValue);
   }
 
   toString() {
@@ -1639,7 +1649,7 @@ class DatasetCoreAndReadableStream extends Readable {
         yield quad;
       }
       if (this._generation !== generation) {
-        const baseline = this._baselines.get(generation);
+        const baseline = this._baselines.get(generation).quads;
         for (let i = yielded; i < baseline.length; i++)
           yield baseline[i];
       }
@@ -1647,6 +1657,12 @@ class DatasetCoreAndReadableStream extends Readable {
     finally {
       if (this._generation === generation)
         this._currentIterators--;
+      else {
+        const baseline = this._baselines.get(generation);
+        // A slow reader must not retain snapshots of later, completed generations.
+        if (--baseline.readers === 0)
+          this._baselines.delete(generation);
+      }
       if (--this._activeIterators === 0)
         this._baselines = null;
     }

--- a/src/N3Store.js
+++ b/src/N3Store.js
@@ -669,6 +669,10 @@ export default class N3Store {
   //  - `'forwarded'`: stays live; matching parent mutations are forwarded to it.
   // Calling `match()` on a view yields at most a `'snapshot'` sub-view:
   // nested views never write through to the root store.
+  // A non-`lazy` view observes the store — `'snapshot'` until it first materializes,
+  // `'forwarded'` for the store's lifetime or until `detach()` — so the store retains
+  // each observing view, checks every mutation against its pattern, and cannot use
+  // the same-index `addAll` fast path while any view observes.
   match(subject, predicate, object, graph, options) {
     return new DatasetCoreAndReadableStream(this, subject, predicate, object, graph, {
       entityIndex: this._entityIndex,
@@ -1416,6 +1420,20 @@ class DatasetCoreAndReadableStream extends Readable {
       this[ITERATOR] = null;
     }
     callback(error);
+  }
+
+  // ### `detach` freezes the view to its current contents and stops observing the parent,
+  // so the parent no longer retains the view nor checks mutations against its pattern.
+  detach() {
+    // Materializing a `snapshot` view removes its observer; remove a `forwarded` observer explicitly
+    this._filtered = this.filtered;
+    if (this._observer) {
+      this.n3Store._removeObserver(this._observer);
+      this._observer = null;
+    }
+    // Parent deltas are no longer forwarded, so subsequent view mutations apply locally
+    this._semantics = 'snapshot';
+    return this;
   }
 
   addAll(quads) {

--- a/src/N3Store.js
+++ b/src/N3Store.js
@@ -1461,16 +1461,15 @@ class DatasetCoreAndReadableStream extends Readable {
   }
 
   union(quads) {
-    if (this._semantics !== 'lazy')
-      return this.filtered.union(quads);
+    // An unmaterialized view has seen no matching mutation, so the parent holds its exact contents;
+    // the internal view is explicitly `lazy` so that `addAll` cannot write through to the parent
     return this._filtered ?
       this._filtered.union(quads)
-      : this.n3Store.match(this.subject, this.predicate, this.object, this.graph).addAll(quads);
+      : this.n3Store.match(this.subject, this.predicate, this.object, this.graph, { matchSemantics: 'lazy' }).addAll(quads);
   }
 
   toArray() {
-    if (this._semantics !== 'lazy')
-      return this.filtered.toArray();
+    // An unmaterialized view has seen no matching mutation, so the parent holds its exact contents
     return this._filtered ? this._filtered.toArray() : this.n3Store.getQuads(this.subject, this.predicate, this.object, this.graph);
   }
 

--- a/src/N3Store.js
+++ b/src/N3Store.js
@@ -1258,12 +1258,12 @@ class DatasetCoreAndReadableStream extends Readable {
   constructor(n3Store, subject, predicate, object, graph, options) {
     super({ objectMode: true });
     Object.assign(this, { n3Store, subject, predicate, object, graph, options });
-    // Bumped when a matching parent mutation lands mid-iteration, signalling iterators to switch to `_baseline`
+    // Bumped when a matching parent mutation lands mid-iteration, signalling iterators to switch to their baseline
     this._generation = 0;
-    // Number of in-progress iterations; a baseline is only frozen on mutation while this is non-zero
+    // Number of in-progress iterations; baselines are only frozen on mutation while this is non-zero
     this._activeIterators = 0;
-    // Frozen array of matching quads at the start of in-progress iteration(s), to keep iterators stable
-    this._baseline = null;
+    // Frozen arrays of matching quads per generation, keeping in-progress iterations stable
+    this._baselines = null;
     // Lazily cached numeric ids of the pattern terms (immutable once present in the entity index)
     this._subjectId = this._predicateId = this._objectId = this._graphId = undefined;
     const semantics = this._semantics = options.matchSemantics;
@@ -1295,11 +1295,14 @@ class DatasetCoreAndReadableStream extends Readable {
     if (!this._matchesPattern(subjectId, predicateId, objectId, graphId))
       return;
 
-    // While iterating, freeze the pre-mutation matching quads so iterators keep a stable view
-    if (this._activeIterators > 0 && this._baseline === null) {
-      this._baseline = this._filtered ? [...this._filtered] :
-        this.n3Store.getQuads(this.subject, this.predicate, this.object, this.graph);
-      this._generation++;
+    // While iterating, freeze the pre-mutation matching quads under the current generation,
+    // so every iteration in progress (each started during some generation) keeps a stable view.
+    // This costs O(view size) per matching mutation for as long as any iteration remains open.
+    if (this._activeIterators > 0) {
+      if (!this._baselines)
+        this._baselines = new Map();
+      this._baselines.set(this._generation++, this._filtered ? [...this._filtered] :
+        this.n3Store.getQuads(this.subject, this.predicate, this.object, this.graph));
     }
 
     // `forwarded`: apply the delta only if the view has materialized; otherwise,
@@ -1536,8 +1539,8 @@ class DatasetCoreAndReadableStream extends Readable {
       return;
     }
 
-    // Non-`lazy`: iterate the current source, switching to the frozen `_baseline` (skipping
-    // already-yielded quads) if a matching parent mutation bumps `_generation` mid-iteration.
+    // Non-`lazy`: iterate the current source, switching to this iteration's frozen baseline
+    // if a matching parent mutation bumps `_generation` mid-iteration.
     const generation = this._generation;
     let yielded = 0;
     this._activeIterators++;
@@ -1546,28 +1549,23 @@ class DatasetCoreAndReadableStream extends Readable {
         this._filtered[Symbol.iterator]() :
         this.n3Store.readQuads(this.subject, this.predicate, this.object, this.graph);
       for (const quad of source) {
-        if (this._generation !== generation) {
-          yield* this._skip(this._baseline[Symbol.iterator](), yielded);
-          return;
-        }
+        if (this._generation !== generation)
+          break;
         yielded++;
         yield quad;
       }
-      // A mutation may have landed exactly when the source was exhausted
-      if (this._generation !== generation)
-        yield* this._skip(this._baseline[Symbol.iterator](), yielded);
+      // A matching mutation landed mid-iteration (possibly exactly as the source was exhausted):
+      // continue from the baseline frozen at this iteration's generation, skipping already-yielded quads
+      if (this._generation !== generation) {
+        const baseline = this._baselines.get(generation);
+        for (let i = yielded; i < baseline.length; i++)
+          yield baseline[i];
+      }
     }
     finally {
-      // Drop the frozen baseline once no iterations remain
+      // Drop the frozen baselines once no iterations remain
       if (--this._activeIterators === 0)
-        this._baseline = null;
+        this._baselines = null;
     }
-  }
-
-  // ### `_skip` advances `iterator` past `count` quads and yields the rest.
-  *_skip(iterator, count) {
-    while (count-- > 0)
-      iterator.next();
-    yield* iterator;
   }
 }

--- a/src/N3Store.js
+++ b/src/N3Store.js
@@ -1354,6 +1354,13 @@ class DatasetCoreAndReadableStream extends Readable {
       const { n3Store, graph, object, predicate, subject } = this;
       const newStore = this._filtered = new N3Store({ factory: n3Store._factory, entityIndex: this.options.entityIndex });
 
+      // A `snapshot` view is frozen once it materializes, so it no longer needs to observe
+      // the parent — also when a pattern term is absent and the view materializes empty
+      if (this._semantics === 'snapshot' && this._observer) {
+        this.n3Store._removeObserver(this._observer);
+        this._observer = null;
+      }
+
       let subjectId, predicateId, objectId;
 
       // Translate IRIs to internal index keys.
@@ -1388,12 +1395,6 @@ class DatasetCoreAndReadableStream extends Readable {
         }
       }
       newStore._size = null;
-
-      // A `snapshot` view is frozen once built, so it no longer needs to observe the parent
-      if (this._semantics === 'snapshot' && this._observer) {
-        this.n3Store._removeObserver(this._observer);
-        this._observer = null;
-      }
     }
     return this._filtered;
   }

--- a/src/N3Store.js
+++ b/src/N3Store.js
@@ -1481,6 +1481,9 @@ class DatasetCoreAndReadableStream extends Readable {
   }
 
   import(stream) {
+    // `forwarded` views write imported quads through to the parent, like `add` and `addAll`
+    if (this._semantics === 'forwarded')
+      return this.n3Store.import(stream);
     return this.filtered.import(stream);
   }
 

--- a/src/N3Store.js
+++ b/src/N3Store.js
@@ -667,6 +667,8 @@ export default class N3Store {
   //  - `'lazy'`: delegates live to the parent until its first own mutation (backwards-compatible).
   //  - `'snapshot'`: reflects the parent contents at the time of `match()`.
   //  - `'forwarded'`: stays live; matching parent mutations are forwarded to it.
+  // Calling `match()` on a view yields at most a `'snapshot'` sub-view:
+  // nested views never write through to the root store.
   match(subject, predicate, object, graph, options) {
     return new DatasetCoreAndReadableStream(this, subject, predicate, object, graph, {
       entityIndex: this._entityIndex,
@@ -1518,7 +1520,13 @@ class DatasetCoreAndReadableStream extends Readable {
   }
 
   match(subject, predicate, object, graph) {
-    return new DatasetCoreAndReadableStream(this.filtered, subject, predicate, object, graph, this.options);
+    // A nested view is parented on the materialized contents, not on the root store,
+    // so `forwarded` is downgraded to `snapshot`: write-through would only reach
+    // the internal materialized store, silently desyncing this view from its parent
+    return new DatasetCoreAndReadableStream(this.filtered, subject, predicate, object, graph, {
+      entityIndex: this.options.entityIndex,
+      matchSemantics: this._semantics === 'forwarded' ? 'snapshot' : this._semantics,
+    });
   }
 
   *[Symbol.iterator]() {

--- a/test/N3Store-test.js
+++ b/test/N3Store-test.js
@@ -830,6 +830,17 @@ describe('Store', () => {
         expect([...b]).toHaveLength(5);
       });
 
+      it('should stop observing when a snapshot with an absent pattern term materializes', () => {
+        const store = buildStore();
+        const view = store.match(namedNode('sNONE'), null, null, null, { matchSemantics: 'snapshot' });
+        expect(view.size).toBe(0);
+        // Materialization removes the observer also on the absent-term path
+        expect(store._observers).toBe(null);
+        // The view stays frozen to its (empty) contents
+        store.addQuad(q('sNONE', 'p1', 'o1'));
+        expect([...view]).toHaveLength(0);
+      });
+
       describe('snapshot', () => {
         const opts = { matchSemantics: 'snapshot' };
 

--- a/test/N3Store-test.js
+++ b/test/N3Store-test.js
@@ -1193,6 +1193,45 @@ describe('Store', () => {
           expect([...view]).toHaveLength(1);
         });
 
+        it('releases iteration state when its stream is destroyed mid-read', done => {
+          const store = new Store();
+          for (let i = 0; i < 20; i++)
+            store.addQuad(q('s1', 'p1', `o${i}`));
+          const view = store.match(namedNode('s1'), null, null, null, opts);
+          // A partial read leaves the internal iterator suspended
+          expect(view.read()).not.toBeNull();
+          expect(view._activeIterators).toBe(1);
+          view.once('close', () => {
+            expect(view._activeIterators).toBe(0);
+            // With no live iterators, this mutation must not freeze a baseline
+            store.addQuad(q('s1', 'p1', 'oNEW'));
+            // A later pass is still protected against mid-pass mutations
+            const seen = [];
+            let mutated = false;
+            for (const quad of view) {
+              seen.push(quad.object.value);
+              if (!mutated) {
+                mutated = true;
+                store.addQuad(q('s1', 'p1', 'oNEW2'));
+              }
+            }
+            expect(seen).toHaveLength(21);
+            done();
+          });
+          view.destroy();
+        });
+
+        it('supports destroying its stream before any read', done => {
+          const store = buildStore();
+          const view = store.match(namedNode('s1'), null, null, null, opts);
+          view.once('close', () => {
+            // The dataset side of the view remains usable
+            expect(view.size).toBe(5);
+            done();
+          });
+          view.destroy();
+        });
+
         it('keeps concurrent iterations stable', () => {
           const store = buildStore();
           const view = store.match(namedNode('s1'), null, null, null, opts);

--- a/test/N3Store-test.js
+++ b/test/N3Store-test.js
@@ -996,6 +996,28 @@ describe('Store', () => {
           expect(store.has(q('s1', 'p1', 'oA'))).toBe(false);
         });
 
+        it('defers materialization of an unread view across parent mutations', () => {
+          const store = buildStore();
+          const view = store.match(namedNode('s1'), null, null, null, opts);
+          store.addQuad(q('s1', 'p1', 'oNEW'));
+          store.removeQuad(q('s1', 'p1', 'o0'));
+          // Nothing has been read from the view, so it has not materialized
+          expect(view._filtered).toBeFalsy();
+          expect(values(view)).toEqual(['o1', 'o2', 'o3', 'o4', 'oNEW']);
+        });
+
+        it('applies parent mutations to an already-materialized view', () => {
+          const store = buildStore();
+          const view = store.match(namedNode('s1'), null, null, null, opts);
+          // Materialize the view before any parent mutation
+          expect(view.size).toBe(5);
+          store.addQuad(q('s1', 'p1', 'oNEW'));
+          store.removeQuad(q('s1', 'p1', 'o0'));
+          expect(view.has(q('s1', 'p1', 'oNEW'))).toBe(true);
+          expect(view.has(q('s1', 'p1', 'o0'))).toBe(false);
+          expect(view.size).toBe(5);
+        });
+
         it('forwards a Store addAll (bypassing the index-merge fast path) when observed', () => {
           const store = buildStore();
           const view = store.match(namedNode('s1'), null, null, null, opts);
@@ -1060,6 +1082,9 @@ describe('Store', () => {
           // The subject `s9` is not present when the view is created.
           const view = store.match(namedNode('s9'), null, null, null, opts);
           expect([...view]).toHaveLength(0);
+          // A mutation while `s9` is still absent cannot match the view
+          store.addQuad(q('sOther', 'p1', 'o1'));
+          expect([...view]).toHaveLength(0);
           store.addQuad(q('s9', 'p1', 'o1'));
           expect([...view]).toHaveLength(1);
           expect(view.has(q('s9', 'p1', 'o1'))).toBe(true);
@@ -1096,6 +1121,7 @@ describe('Store', () => {
           store.addQuad(new Quad(namedNode('s1'), namedNode('pX'), namedNode('o1'), namedNode('g1')));
           store.addQuad(new Quad(namedNode('s1'), namedNode('p1'), namedNode('oX'), namedNode('g1')));
           store.addQuad(new Quad(namedNode('s1'), namedNode('p1'), namedNode('o1'), namedNode('gX')));
+          store.addQuad(new Quad(namedNode('s1'), namedNode('p1'), namedNode('o1'), namedNode('gY')));
           expect([...view]).toHaveLength(1);
         });
 

--- a/test/N3Store-test.js
+++ b/test/N3Store-test.js
@@ -1274,6 +1274,38 @@ describe('Store', () => {
           expect(inner).toHaveLength(5);
           expect(outer.sort()).toEqual(['o0', 'o1', 'o2', 'o3', 'o4']);
         });
+
+        it('keeps an overlapping iteration stable after a baseline freeze', () => {
+          const store = new Store();
+          // Spread the quads across predicate buckets, so deletions hit levels not yet iterated
+          for (let i = 0; i < 5; i++)
+            store.addQuad(q('s1', `p${i}`, 'o1'));
+          const view = store.match(namedNode('s1'), null, null, null, opts);
+          const outer = view[Symbol.iterator]();
+          expect(outer.next().done).toBe(false);
+          // This mutation freezes a baseline for the in-progress outer iteration
+          store.addQuad(q('s1', 'pNEW', 'o1'));
+          // An iteration starting now must also stay stable across further matching mutations
+          const seen = [];
+          let mutated = false;
+          for (const quad of view) {
+            seen.push(quad.predicate.value);
+            if (!mutated) {
+              mutated = true;
+              store.removeQuad(q('s1', 'p3', 'o1'));
+              store.removeQuad(q('s1', 'p4', 'o1'));
+            }
+          }
+          expect(seen).toHaveLength(6);
+          expect(seen).toEqual(expect.arrayContaining(['p3', 'p4', 'pNEW']));
+          // The outer iteration still yields the quads from its own start
+          const rest = [];
+          for (let next = outer.next(); !next.done; next = outer.next())
+            rest.push(next.value.predicate.value);
+          expect(rest).toHaveLength(4);
+          expect(rest).toEqual(expect.arrayContaining(['p3', 'p4']));
+          expect(rest).not.toContain('pNEW');
+        });
       });
     });
 

--- a/test/N3Store-test.js
+++ b/test/N3Store-test.js
@@ -746,7 +746,7 @@ describe('Store', () => {
         return s;
       }
 
-      it('defaults to lazy semantics', () => {
+      it('should default to lazy semantics', () => {
         const store = buildStore();
         const view = store.match(namedNode('s1'), null, null);
         store.addQuad(q('s1', 'p1', 'oNEW'));
@@ -755,18 +755,18 @@ describe('Store', () => {
         expect([...view]).toHaveLength(6);
       });
 
-      it('throws on an unknown matchSemantics value', () => {
+      it('should throw on an unknown matchSemantics value', () => {
         const store = buildStore();
         expect(() => store.match(namedNode('s1'), null, null, null, { matchSemantics: 'bogus' }))
           .toThrow('Unknown matchSemantics: bogus');
       });
 
-      it('throws on an unknown store-level matchSemantics value', () => {
+      it('should throw on an unknown store-level matchSemantics value', () => {
         expect(() => new Store([], { matchSemantics: 'bogus' }))
           .toThrow('Unknown matchSemantics: bogus');
       });
 
-      it('uses the store-level default matchSemantics', () => {
+      it('should use the store-level default matchSemantics', () => {
         const store = buildStore({ matchSemantics: 'snapshot' });
         const view = store.match(namedNode('s1'), null, null);
         store.addQuad(q('s1', 'p1', 'oNEW'));
@@ -774,21 +774,21 @@ describe('Store', () => {
         expect([...view]).toHaveLength(5);
       });
 
-      it('lets a per-call matchSemantics override the store default', () => {
+      it('should let a per-call matchSemantics override the store default', () => {
         const store = buildStore({ matchSemantics: 'snapshot' });
         const view = store.match(namedNode('s1'), null, null, null, { matchSemantics: 'forwarded' });
         store.addQuad(q('s1', 'p1', 'oNEW'));
         expect(values(view)).toContain('oNEW');
       });
 
-      it('falls back to the store default when an options object omits matchSemantics', () => {
+      it('should fall back to the store default when an options object omits matchSemantics', () => {
         const store = buildStore({ matchSemantics: 'snapshot' });
         const view = store.match(namedNode('s1'), null, null, null, {});
         store.addQuad(q('s1', 'p1', 'oNEW'));
         expect(values(view)).not.toContain('oNEW');
       });
 
-      it('keeps internal match() calls lazy under a non-lazy store default', async () => {
+      it('should keep internal match() calls lazy under a non-lazy store default', async () => {
         for (const matchSemantics of ['snapshot', 'forwarded']) {
           const store = buildStore({ matchSemantics });
           store.deleteMatches(namedNode('s2'), null, null);
@@ -799,14 +799,14 @@ describe('Store', () => {
         }
       });
 
-      it('keeps toStream() on a lazy view lazy under a forwarded store default', async () => {
+      it('should keep toStream() on a lazy view lazy under a forwarded store default', async () => {
         const store = buildStore({ matchSemantics: 'forwarded' });
         const view = store.match(namedNode('s1'), null, null, null, { matchSemantics: 'lazy' });
         await expect(arrayifyStream(view.toStream())).resolves.toHaveLength(5);
         expect(store._observers).toBe(null);
       });
 
-      it('does not write union() contents through to a store with a forwarded default', () => {
+      it('should not write union() contents through to a store with a forwarded default', () => {
         const store = buildStore({ matchSemantics: 'forwarded' });
         const view = store.match(namedNode('s1'), null, null, null, { matchSemantics: 'lazy' });
         const union = view.union([q('s1', 'p1', 'oU')]);
@@ -816,7 +816,7 @@ describe('Store', () => {
         expect(store.has(q('s1', 'p1', 'oU'))).toBe(false);
       });
 
-      it('detaches a single observer while another remains attached', () => {
+      it('should detach a single observer while another remains attached', () => {
         const store = buildStore();
         // Two snapshot views observe the store concurrently.
         const a = store.match(namedNode('s1'), null, null, null, { matchSemantics: 'snapshot' });
@@ -833,9 +833,13 @@ describe('Store', () => {
       describe('snapshot', () => {
         const opts = { matchSemantics: 'snapshot' };
 
-        it('ignores parent additions made BEFORE iteration', () => {
-          const store = buildStore();
-          const view = store.match(namedNode('s1'), null, null, null, opts);
+        let store, view;
+        beforeEach(() => {
+          store = buildStore();
+          view = store.match(namedNode('s1'), null, null, null, opts);
+        });
+
+        it('should ignore parent additions made before iteration', () => {
           store.addQuad(q('s1', 'p1', 'oNEW'));
           expect([...view]).toHaveLength(5);
           expect(view.size).toBe(5);
@@ -843,17 +847,13 @@ describe('Store', () => {
           expect(view.has(q('s1', 'p1', 'o0'))).toBe(true);
         });
 
-        it('ignores parent deletions made BEFORE iteration', () => {
-          const store = buildStore();
-          const view = store.match(namedNode('s1'), null, null, null, opts);
+        it('should ignore parent deletions made before iteration', () => {
           store.removeQuad(q('s1', 'p1', 'o0'));
           expect([...view]).toHaveLength(5);
           expect(view.has(q('s1', 'p1', 'o0'))).toBe(true);
         });
 
-        it('ignores a parent mutation that lands DURING sync iteration', () => {
-          const store = buildStore();
-          const view = store.match(namedNode('s1'), null, null, null, opts);
+        it('should ignore a parent mutation that lands during sync iteration', () => {
           const seen = [];
           let mutated = false;
           for (const quad of view) {
@@ -867,9 +867,7 @@ describe('Store', () => {
           expect(seen.sort()).toEqual(['o0', 'o1', 'o2', 'o3', 'o4']);
         });
 
-        it('ignores a parent mutation that lands DURING async iteration', async () => {
-          const store = buildStore();
-          const view = store.match(namedNode('s1'), null, null, null, opts);
+        it('should ignore a parent mutation that lands during async iteration', async () => {
           const seen = [];
           await new Promise((resolve, reject) => {
             let mutated = false;
@@ -887,48 +885,36 @@ describe('Store', () => {
           expect(seen.sort()).toEqual(['o0', 'o1', 'o2', 'o3', 'o4']);
         });
 
-        it('ignores parent mutations made AFTER iteration', () => {
-          const store = buildStore();
-          const view = store.match(namedNode('s1'), null, null, null, opts);
+        it('should ignore parent mutations made after iteration', () => {
           expect([...view]).toHaveLength(5);
           store.addQuad(q('s1', 'p1', 'oNEW'));
           expect([...view]).toHaveLength(5);
         });
 
-        it('ignores non-matching parent mutations', () => {
-          const store = buildStore();
-          const view = store.match(namedNode('s1'), null, null, null, opts);
+        it('should ignore non-matching parent mutations', () => {
           store.addQuad(q('s2', 'p1', 'oNEW'));
           expect([...view]).toHaveLength(5);
         });
 
-        it('supports its own independent mutations', () => {
-          const store = buildStore();
-          const view = store.match(namedNode('s1'), null, null, null, opts);
+        it('should support its own independent mutations', () => {
           view.add(q('s1', 'p1', 'oOWN'));
           expect(view.has(q('s1', 'p1', 'oOWN'))).toBe(true);
           // The parent is not affected by snapshot view mutations.
           expect(store.has(q('s1', 'p1', 'oOWN'))).toBe(false);
         });
 
-        it('exposes a stable toArray/toStream/union', async () => {
-          const store = buildStore();
-          const view = store.match(namedNode('s1'), null, null, null, opts);
+        it('should expose a stable toArray/toStream/union', async () => {
           expect(view.toArray()).toHaveLength(5);
           await expect(arrayifyStream(view.toStream())).resolves.toHaveLength(5);
           expect(view.union(new Store([q('s1', 'p1', 'oU')])).size).toBe(6);
         });
 
-        it('freezes on a matching mutation before a first toArray', () => {
-          const store = buildStore();
-          const view = store.match(namedNode('s1'), null, null, null, opts);
+        it('should freeze on a matching mutation before a first toArray', () => {
           store.addQuad(q('s1', 'p1', 'oNEW'));
           expect(view.toArray()).toHaveLength(5);
         });
 
-        it('does not mutate the parent through union', () => {
-          const store = buildStore();
-          const view = store.match(namedNode('s1'), null, null, null, opts);
+        it('should not mutate the parent through union', () => {
           const union = view.union([q('s1', 'p1', 'oU')]);
           expect(union.size).toBe(6);
           expect(store.has(q('s1', 'p1', 'oU'))).toBe(false);
@@ -937,18 +923,14 @@ describe('Store', () => {
           expect(union.size).toBe(6);
         });
 
-        it('keeps a nested match() frozen at nesting time', () => {
-          const store = buildStore();
-          const view = store.match(namedNode('s1'), null, null, null, opts);
+        it('should keep a nested match() frozen at nesting time', () => {
           const sub = view.match(null, namedNode('p1'));
           store.addQuad(q('s1', 'p1', 'oNEW'));
           expect([...sub]).toHaveLength(5);
           expect(sub.has(q('s1', 'p1', 'oNEW'))).toBe(false);
         });
 
-        it('supports detach() before and after materialization', () => {
-          const store = buildStore();
-          const view = store.match(namedNode('s1'), null, null, null, opts);
+        it('should support detach() before and after materialization', () => {
           view.detach();
           expect(store._observers).toBe(null);
           store.addQuad(q('s1', 'p1', 'oNEW'));
@@ -964,25 +946,25 @@ describe('Store', () => {
       describe('forwarded', () => {
         const opts = { matchSemantics: 'forwarded' };
 
-        it('reflects parent additions made BEFORE iteration', () => {
-          const store = buildStore();
-          const view = store.match(namedNode('s1'), null, null, null, opts);
+        let store, view;
+        beforeEach(() => {
+          store = buildStore();
+          view = store.match(namedNode('s1'), null, null, null, opts);
+        });
+
+        it('should reflect parent additions made before iteration', () => {
           store.addQuad(q('s1', 'p1', 'oNEW'));
           expect([...view]).toHaveLength(6);
           expect(view.has(q('s1', 'p1', 'oNEW'))).toBe(true);
         });
 
-        it('reflects parent deletions made BEFORE iteration', () => {
-          const store = buildStore();
-          const view = store.match(namedNode('s1'), null, null, null, opts);
+        it('should reflect parent deletions made before iteration', () => {
           store.removeQuad(q('s1', 'p1', 'o0'));
           expect([...view]).toHaveLength(4);
           expect(view.has(q('s1', 'p1', 'o0'))).toBe(false);
         });
 
-        it('keeps the running iteration stable across a parent ADD DURING sync iteration', () => {
-          const store = buildStore();
-          const view = store.match(namedNode('s1'), null, null, null, opts);
+        it('should keep the running iteration stable across a parent add during sync iteration', () => {
           const seen = [];
           let mutated = false;
           for (const quad of view) {
@@ -998,9 +980,7 @@ describe('Store', () => {
           expect([...view]).toHaveLength(6);
         });
 
-        it('keeps the running iteration stable across a parent DELETE of an already-yielded quad', () => {
-          const store = buildStore();
-          const view = store.match(namedNode('s1'), null, null, null, opts);
+        it('should keep the running iteration stable across a parent delete of an already-yielded quad', () => {
           const seen = [];
           let mutated = false;
           for (const quad of view) {
@@ -1014,9 +994,7 @@ describe('Store', () => {
           expect([...view]).toHaveLength(4);
         });
 
-        it('keeps the running iteration stable across a parent mutation DURING async iteration', async () => {
-          const store = buildStore();
-          const view = store.match(namedNode('s1'), null, null, null, opts);
+        it('should keep the running iteration stable across a parent mutation during async iteration', async () => {
           const seen = [];
           await new Promise((resolve, reject) => {
             let mutated = false;
@@ -1034,24 +1012,18 @@ describe('Store', () => {
           expect([...view]).toHaveLength(4);
         });
 
-        it('reflects parent mutations made AFTER iteration', () => {
-          const store = buildStore();
-          const view = store.match(namedNode('s1'), null, null, null, opts);
+        it('should reflect parent mutations made after iteration', () => {
           expect([...view]).toHaveLength(5);
           store.addQuad(q('s1', 'p1', 'oNEW'));
           expect([...view]).toHaveLength(6);
         });
 
-        it('ignores non-matching parent mutations', () => {
-          const store = buildStore();
-          const view = store.match(namedNode('s1'), null, null, null, opts);
+        it('should ignore non-matching parent mutations', () => {
           store.addQuad(q('s2', 'p1', 'oNEW'));
           expect([...view]).toHaveLength(5);
         });
 
-        it('writes view additions and deletions through to the parent', () => {
-          const store = buildStore();
-          const view = store.match(namedNode('s1'), null, null, null, opts);
+        it('should write view additions and deletions through to the parent', () => {
           view.add(q('s1', 'p1', 'oOWN'));
           expect(store.has(q('s1', 'p1', 'oOWN'))).toBe(true);
           expect(view.has(q('s1', 'p1', 'oOWN'))).toBe(true);
@@ -1060,9 +1032,7 @@ describe('Store', () => {
           expect(view.has(q('s1', 'p1', 'o0'))).toBe(false);
         });
 
-        it('forwards addAll and deleteMatches to the parent', () => {
-          const store = buildStore();
-          const view = store.match(namedNode('s1'), null, null, null, opts);
+        it('should forward addAll and deleteMatches to the parent', () => {
           view.addAll([q('s1', 'p1', 'oA'), q('s1', 'p1', 'oB')]);
           expect(store.has(q('s1', 'p1', 'oA'))).toBe(true);
           expect(view.size).toBe(7);
@@ -1070,9 +1040,7 @@ describe('Store', () => {
           expect(store.has(q('s1', 'p1', 'oA'))).toBe(false);
         });
 
-        it('writes non-matching mutations through to the parent unrestricted', () => {
-          const store = buildStore();
-          const view = store.match(namedNode('s1'), null, null, null, opts);
+        it('should write non-matching mutations through to the parent unrestricted', () => {
           // A non-matching add mutates the parent but never appears in the view
           view.add(q('s3', 'p1', 'oNM'));
           expect(store.has(q('s3', 'p1', 'oNM'))).toBe(true);
@@ -1087,9 +1055,7 @@ describe('Store', () => {
           expect(view.size).toBe(5);
         });
 
-        it('defers materialization of an unread view across parent mutations', () => {
-          const store = buildStore();
-          const view = store.match(namedNode('s1'), null, null, null, opts);
+        it('should defer materialization of an unread view across parent mutations', () => {
           store.addQuad(q('s1', 'p1', 'oNEW'));
           store.removeQuad(q('s1', 'p1', 'o0'));
           // Nothing has been read from the view, so it has not materialized
@@ -1097,9 +1063,7 @@ describe('Store', () => {
           expect(values(view)).toEqual(['o1', 'o2', 'o3', 'o4', 'oNEW']);
         });
 
-        it('applies parent mutations to an already-materialized view', () => {
-          const store = buildStore();
-          const view = store.match(namedNode('s1'), null, null, null, opts);
+        it('should apply parent mutations to an already-materialized view', () => {
           // Materialize the view before any parent mutation
           expect(view.size).toBe(5);
           store.addQuad(q('s1', 'p1', 'oNEW'));
@@ -1109,36 +1073,28 @@ describe('Store', () => {
           expect(view.size).toBe(5);
         });
 
-        it('forwards a Store addAll (bypassing the index-merge fast path) when observed', () => {
-          const store = buildStore();
-          const view = store.match(namedNode('s1'), null, null, null, opts);
+        it('should forward a Store addAll (bypassing the index-merge fast path) when observed', () => {
           const extra = new Store([], { entityIndex: store._entityIndex });
           extra.addQuad(q('s1', 'p1', 'oM'));
           store.addAll(extra);
           expect(view.has(q('s1', 'p1', 'oM'))).toBe(true);
         });
 
-        it('exposes a live toArray/toStream/union', async () => {
-          const store = buildStore();
-          const view = store.match(namedNode('s1'), null, null, null, opts);
+        it('should expose a live toArray/toStream/union', async () => {
           store.addQuad(q('s1', 'p1', 'oNEW'));
           expect(view.toArray()).toHaveLength(6);
           await expect(arrayifyStream(view.toStream())).resolves.toHaveLength(6);
           expect(view.union(new Store([q('s1', 'p1', 'oU')])).size).toBe(7);
         });
 
-        it('does not mutate the parent through union', () => {
-          const store = buildStore();
-          const view = store.match(namedNode('s1'), null, null, null, opts);
+        it('should not mutate the parent through union', () => {
           const union = view.union([q('s1', 'p1', 'oU')]);
           expect(union.size).toBe(6);
           expect(store.has(q('s1', 'p1', 'oU'))).toBe(false);
           expect(view.has(q('s1', 'p1', 'oU'))).toBe(false);
         });
 
-        it('stops observing the parent after detach()', () => {
-          const store = buildStore();
-          const view = store.match(namedNode('s1'), null, null, null, opts);
+        it('should stop observing the parent after detach()', () => {
           expect(view.detach()).toBe(view);
           expect(store._observers).toBe(null);
           // The view is frozen to its contents at detach time
@@ -1153,9 +1109,7 @@ describe('Store', () => {
           expect(view.size).toBe(6);
         });
 
-        it('downgrades a nested match() to a snapshot of the view', () => {
-          const store = buildStore();
-          const view = store.match(namedNode('s1'), null, null, null, opts);
+        it('should downgrade a nested match() to a snapshot of the view', () => {
           const sub = view.match(null, namedNode('p1'));
           expect([...sub]).toHaveLength(5);
           // Later root mutations reach the outer view, but not the nested snapshot
@@ -1169,16 +1123,15 @@ describe('Store', () => {
           expect(view.has(q('s1', 'p1', 'oSUB'))).toBe(false);
         });
 
-        it('handles matching mutations in the default graph', () => {
-          const store = new Store([q('s1', 'p1', 'o0')]);
-          const view = store.match(null, null, null, new DefaultGraph(), opts);
+        it('should handle matching mutations in the default graph', () => {
+          store = new Store([q('s1', 'p1', 'o0')]);
+          view = store.match(null, null, null, new DefaultGraph(), opts);
           store.addQuad(q('s1', 'p1', 'o1'));
           expect([...view]).toHaveLength(2);
         });
 
-        it('treats an empty-string graph pattern as the default graph', () => {
-          const store = buildStore();
-          const view = store.match(null, null, null, '', opts);
+        it('should treat an empty-string graph pattern as the default graph', () => {
+          view = store.match(null, null, null, '', opts);
           expect([...view]).toHaveLength(6);
           // A named-graph quad does not match a default-graph pattern
           store.addQuad(q('s3', 'p1', 'oG', 'g1'));
@@ -1189,9 +1142,7 @@ describe('Store', () => {
           expect([...view]).toHaveLength(7);
         });
 
-        it('stays stable when a parent mutation lands as the source is exhausted', () => {
-          const store = buildStore();
-          const view = store.match(namedNode('s1'), null, null, null, opts);
+        it('should stay stable when a parent mutation lands as the source is exhausted', () => {
           const seen = [];
           for (const quad of view) {
             seen.push(quad.object.value);
@@ -1203,9 +1154,7 @@ describe('Store', () => {
           expect([...view]).toHaveLength(6);
         });
 
-        it('captures a baseline from an already-materialized view mid-iteration', () => {
-          const store = buildStore();
-          const view = store.match(namedNode('s1'), null, null, null, opts);
+        it('should capture a baseline from an already-materialized view mid-iteration', () => {
           // Force materialization of `_filtered` via a first matching mutation.
           store.addQuad(q('s1', 'p1', 'oNEW'));
           expect(view.size).toBe(6);
@@ -1223,10 +1172,10 @@ describe('Store', () => {
           expect([...view]).toHaveLength(7);
         });
 
-        it('reflects additions of a pattern term absent at match() time', () => {
-          const store = new Store();
+        it('should reflect additions of a pattern term absent at match() time', () => {
+          store = new Store();
           // The subject `s9` is not present when the view is created.
-          const view = store.match(namedNode('s9'), null, null, null, opts);
+          view = store.match(namedNode('s9'), null, null, null, opts);
           expect([...view]).toHaveLength(0);
           // A mutation while `s9` is still absent cannot match the view
           store.addQuad(q('sOther', 'p1', 'o1'));
@@ -1236,16 +1185,14 @@ describe('Store', () => {
           expect(view.has(q('s9', 'p1', 'o1'))).toBe(true);
         });
 
-        it('ignores a re-added quad that already exists', () => {
-          const store = buildStore();
-          const view = store.match(namedNode('s1'), null, null, null, opts);
+        it('should ignore a re-added quad that already exists', () => {
           // Re-adding an existing quad must not notify observers nor change size.
           store.addQuad(q('s1', 'p1', 'o0'));
           expect([...view]).toHaveLength(5);
         });
 
-        it('matches across all pattern positions and the default graph', () => {
-          const store = new Store([q('s1', 'p1', 'o1')]);
+        it('should match across all pattern positions and the default graph', () => {
+          store = new Store([q('s1', 'p1', 'o1')]);
           // Wildcard pattern: every position is a wildcard.
           const wildcard = store.match(null, null, null, null, opts);
           // Fully specified pattern including the default graph.
@@ -1257,10 +1204,10 @@ describe('Store', () => {
           expect([...exact]).toHaveLength(1);
         });
 
-        it('does not match mutations differing in any single position', () => {
-          const store = new Store([new Quad(
+        it('should not match mutations differing in any single position', () => {
+          store = new Store([new Quad(
             namedNode('s1'), namedNode('p1'), namedNode('o1'), namedNode('g1'))]);
-          const view = store.match(
+          view = store.match(
             namedNode('s1'), namedNode('p1'), namedNode('o1'), namedNode('g1'), opts);
           // Each of these differs from the pattern in exactly one position.
           store.addQuad(new Quad(namedNode('sX'), namedNode('p1'), namedNode('o1'), namedNode('g1')));
@@ -1271,11 +1218,11 @@ describe('Store', () => {
           expect([...view]).toHaveLength(1);
         });
 
-        it('releases iteration state when its stream is destroyed mid-read', done => {
-          const store = new Store();
+        it('should release iteration state when its stream is destroyed mid-read', done => {
+          store = new Store();
           for (let i = 0; i < 20; i++)
             store.addQuad(q('s1', 'p1', `o${i}`));
-          const view = store.match(namedNode('s1'), null, null, null, opts);
+          view = store.match(namedNode('s1'), null, null, null, opts);
           // A partial read leaves the internal iterator suspended
           expect(view.read()).not.toBeNull();
           expect(view._activeIterators).toBe(1);
@@ -1299,9 +1246,7 @@ describe('Store', () => {
           view.destroy();
         });
 
-        it('supports destroying its stream before any read', done => {
-          const store = buildStore();
-          const view = store.match(namedNode('s1'), null, null, null, opts);
+        it('should support destroying its stream before any read', done => {
           view.once('close', () => {
             // The dataset side of the view remains usable
             expect(view.size).toBe(5);
@@ -1310,9 +1255,7 @@ describe('Store', () => {
           view.destroy();
         });
 
-        it('keeps concurrent iterations stable', () => {
-          const store = buildStore();
-          const view = store.match(namedNode('s1'), null, null, null, opts);
+        it('should keep concurrent iterations stable', () => {
           const outer = [];
           const inner = [];
           for (const a of view) {
@@ -1328,12 +1271,12 @@ describe('Store', () => {
           expect(outer.sort()).toEqual(['o0', 'o1', 'o2', 'o3', 'o4']);
         });
 
-        it('keeps an overlapping iteration stable after a baseline freeze', () => {
-          const store = new Store();
+        it('should keep an overlapping iteration stable after a baseline freeze', () => {
+          store = new Store();
           // Spread the quads across predicate buckets, so deletions hit levels not yet iterated
           for (let i = 0; i < 5; i++)
             store.addQuad(q('s1', `p${i}`, 'o1'));
-          const view = store.match(namedNode('s1'), null, null, null, opts);
+          view = store.match(namedNode('s1'), null, null, null, opts);
           const outer = view[Symbol.iterator]();
           expect(outer.next().done).toBe(false);
           // This mutation freezes a baseline for the in-progress outer iteration

--- a/test/N3Store-test.js
+++ b/test/N3Store-test.js
@@ -945,6 +945,20 @@ describe('Store', () => {
           expect([...sub]).toHaveLength(5);
           expect(sub.has(q('s1', 'p1', 'oNEW'))).toBe(false);
         });
+
+        it('supports detach() before and after materialization', () => {
+          const store = buildStore();
+          const view = store.match(namedNode('s1'), null, null, null, opts);
+          view.detach();
+          expect(store._observers).toBe(null);
+          store.addQuad(q('s1', 'p1', 'oNEW'));
+          expect([...view]).toHaveLength(5);
+          // A view that has already materialized (removing its observer) can also detach
+          const other = store.match(namedNode('s1'), null, null, null, opts);
+          expect(other.size).toBe(6);
+          expect(other.detach().size).toBe(6);
+          expect(store._observers).toBe(null);
+        });
       });
 
       describe('forwarded', () => {
@@ -1103,6 +1117,23 @@ describe('Store', () => {
           expect(union.size).toBe(6);
           expect(store.has(q('s1', 'p1', 'oU'))).toBe(false);
           expect(view.has(q('s1', 'p1', 'oU'))).toBe(false);
+        });
+
+        it('stops observing the parent after detach()', () => {
+          const store = buildStore();
+          const view = store.match(namedNode('s1'), null, null, null, opts);
+          expect(view.detach()).toBe(view);
+          expect(store._observers).toBe(null);
+          // The view is frozen to its contents at detach time
+          store.addQuad(q('s1', 'p1', 'oNEW'));
+          expect([...view]).toHaveLength(5);
+          // Mutations now apply to the view only, not to the parent
+          view.add(q('s1', 'p1', 'oLOCAL'));
+          expect(view.has(q('s1', 'p1', 'oLOCAL'))).toBe(true);
+          expect(store.has(q('s1', 'p1', 'oLOCAL'))).toBe(false);
+          // `detach()` is idempotent
+          expect(view.detach()).toBe(view);
+          expect(view.size).toBe(6);
         });
 
         it('downgrades a nested match() to a snapshot of the view', () => {

--- a/test/N3Store-test.js
+++ b/test/N3Store-test.js
@@ -783,6 +783,16 @@ describe('Store', () => {
         expect(values(view)).not.toContain('oNEW');
       });
 
+      it('does not write union() contents through to a store with a forwarded default', () => {
+        const store = buildStore({ matchSemantics: 'forwarded' });
+        const view = store.match(namedNode('s1'), null, null, null, { matchSemantics: 'lazy' });
+        const union = view.union([q('s1', 'p1', 'oU')]);
+        expect(union.size).toBe(6);
+        expect(union.has(q('s1', 'p1', 'oU'))).toBe(true);
+        expect(store.size).toBe(6);
+        expect(store.has(q('s1', 'p1', 'oU'))).toBe(false);
+      });
+
       it('detaches a single observer while another remains attached', () => {
         const store = buildStore();
         // Two snapshot views observe the store concurrently.
@@ -884,6 +894,24 @@ describe('Store', () => {
           expect(view.toArray()).toHaveLength(5);
           await expect(arrayifyStream(view.toStream())).resolves.toHaveLength(5);
           expect(view.union(new Store([q('s1', 'p1', 'oU')])).size).toBe(6);
+        });
+
+        it('freezes on a matching mutation before a first toArray', () => {
+          const store = buildStore();
+          const view = store.match(namedNode('s1'), null, null, null, opts);
+          store.addQuad(q('s1', 'p1', 'oNEW'));
+          expect(view.toArray()).toHaveLength(5);
+        });
+
+        it('does not mutate the parent through union', () => {
+          const store = buildStore();
+          const view = store.match(namedNode('s1'), null, null, null, opts);
+          const union = view.union([q('s1', 'p1', 'oU')]);
+          expect(union.size).toBe(6);
+          expect(store.has(q('s1', 'p1', 'oU'))).toBe(false);
+          // The union result is independent of later parent mutations
+          store.addQuad(q('s1', 'p1', 'oNEW'));
+          expect(union.size).toBe(6);
         });
       });
 
@@ -1034,6 +1062,15 @@ describe('Store', () => {
           expect(view.toArray()).toHaveLength(6);
           await expect(arrayifyStream(view.toStream())).resolves.toHaveLength(6);
           expect(view.union(new Store([q('s1', 'p1', 'oU')])).size).toBe(7);
+        });
+
+        it('does not mutate the parent through union', () => {
+          const store = buildStore();
+          const view = store.match(namedNode('s1'), null, null, null, opts);
+          const union = view.union([q('s1', 'p1', 'oU')]);
+          expect(union.size).toBe(6);
+          expect(store.has(q('s1', 'p1', 'oU'))).toBe(false);
+          expect(view.has(q('s1', 'p1', 'oU'))).toBe(false);
         });
 
         it('handles matching mutations in the default graph', () => {

--- a/test/N3Store-test.js
+++ b/test/N3Store-test.js
@@ -761,6 +761,11 @@ describe('Store', () => {
           .toThrow('Unknown matchSemantics: bogus');
       });
 
+      it('throws on an unknown store-level matchSemantics value', () => {
+        expect(() => new Store([], { matchSemantics: 'bogus' }))
+          .toThrow('Unknown matchSemantics: bogus');
+      });
+
       it('uses the store-level default matchSemantics', () => {
         const store = buildStore({ matchSemantics: 'snapshot' });
         const view = store.match(namedNode('s1'), null, null);

--- a/test/N3Store-test.js
+++ b/test/N3Store-test.js
@@ -730,6 +730,399 @@ describe('Store', () => {
       });
     });
 
+    describe('match semantics', () => {
+      function q(s, p, o, g) {
+        return new Quad(new NamedNode(s), new NamedNode(p), new NamedNode(o), g ? new NamedNode(g) : undefined);
+      }
+      function values(view) {
+        return [...view].map(x => x.object.value).sort();
+      }
+
+      function buildStore(options) {
+        const s = new Store([], options);
+        for (let i = 0; i < 5; i++)
+          s.addQuad(q('s1', 'p1', `o${i}`));
+        s.addQuad(q('s2', 'p1', 'oX')); // a non-matching quad for an `s1` pattern
+        return s;
+      }
+
+      it('defaults to lazy semantics', () => {
+        const store = buildStore();
+        const view = store.match(namedNode('s1'), null, null);
+        store.addQuad(q('s1', 'p1', 'oNEW'));
+        // Lazy: parent mutation before the view's own mutation leaks in.
+        expect(values(view)).toContain('oNEW');
+        expect([...view]).toHaveLength(6);
+      });
+
+      it('throws on an unknown matchSemantics value', () => {
+        const store = buildStore();
+        expect(() => store.match(namedNode('s1'), null, null, null, { matchSemantics: 'bogus' }))
+          .toThrow('Unknown matchSemantics: bogus');
+      });
+
+      it('uses the store-level default matchSemantics', () => {
+        const store = buildStore({ matchSemantics: 'snapshot' });
+        const view = store.match(namedNode('s1'), null, null);
+        store.addQuad(q('s1', 'p1', 'oNEW'));
+        expect(values(view)).not.toContain('oNEW');
+        expect([...view]).toHaveLength(5);
+      });
+
+      it('lets a per-call matchSemantics override the store default', () => {
+        const store = buildStore({ matchSemantics: 'snapshot' });
+        const view = store.match(namedNode('s1'), null, null, null, { matchSemantics: 'forwarded' });
+        store.addQuad(q('s1', 'p1', 'oNEW'));
+        expect(values(view)).toContain('oNEW');
+      });
+
+      it('falls back to the store default when an options object omits matchSemantics', () => {
+        const store = buildStore({ matchSemantics: 'snapshot' });
+        const view = store.match(namedNode('s1'), null, null, null, {});
+        store.addQuad(q('s1', 'p1', 'oNEW'));
+        expect(values(view)).not.toContain('oNEW');
+      });
+
+      it('detaches a single observer while another remains attached', () => {
+        const store = buildStore();
+        // Two snapshot views observe the store concurrently.
+        const a = store.match(namedNode('s1'), null, null, null, { matchSemantics: 'snapshot' });
+        const b = store.match(namedNode('s1'), null, null, null, { matchSemantics: 'snapshot' });
+        // The first matching mutation materializes (and detaches) view `a`'s
+        // observer, while view `b`'s observer is still registered.
+        a.size; // eslint-disable-line no-unused-expressions
+        store.addQuad(q('s1', 'p1', 'oNEW'));
+        expect([...a]).toHaveLength(5);
+        expect([...b]).toHaveLength(5);
+        store.addQuad(q('s1', 'p1', 'oNEW2'));
+        expect([...b]).toHaveLength(5);
+      });
+
+      describe('snapshot', () => {
+        const opts = { matchSemantics: 'snapshot' };
+
+        it('ignores parent additions made BEFORE iteration', () => {
+          const store = buildStore();
+          const view = store.match(namedNode('s1'), null, null, null, opts);
+          store.addQuad(q('s1', 'p1', 'oNEW'));
+          expect([...view]).toHaveLength(5);
+          expect(view.size).toBe(5);
+          expect(view.has(q('s1', 'p1', 'oNEW'))).toBe(false);
+          expect(view.has(q('s1', 'p1', 'o0'))).toBe(true);
+        });
+
+        it('ignores parent deletions made BEFORE iteration', () => {
+          const store = buildStore();
+          const view = store.match(namedNode('s1'), null, null, null, opts);
+          store.removeQuad(q('s1', 'p1', 'o0'));
+          expect([...view]).toHaveLength(5);
+          expect(view.has(q('s1', 'p1', 'o0'))).toBe(true);
+        });
+
+        it('ignores a parent mutation that lands DURING sync iteration', () => {
+          const store = buildStore();
+          const view = store.match(namedNode('s1'), null, null, null, opts);
+          const seen = [];
+          let mutated = false;
+          for (const quad of view) {
+            seen.push(quad.object.value);
+            if (!mutated) {
+              mutated = true;
+              store.addQuad(q('s1', 'p1', 'oNEW'));
+              store.removeQuad(q('s1', 'p1', 'o4'));
+            }
+          }
+          expect(seen.sort()).toEqual(['o0', 'o1', 'o2', 'o3', 'o4']);
+        });
+
+        it('ignores a parent mutation that lands DURING async iteration', async () => {
+          const store = buildStore();
+          const view = store.match(namedNode('s1'), null, null, null, opts);
+          const seen = [];
+          await new Promise((resolve, reject) => {
+            let mutated = false;
+            view.on('data', d => {
+              seen.push(d.object.value);
+              if (!mutated) {
+                mutated = true;
+                store.addQuad(q('s1', 'p1', 'oNEW'));
+              }
+            });
+            view.on('end', resolve);
+            view.on('error', reject);
+          });
+          expect(seen).not.toContain('oNEW');
+          expect(seen.sort()).toEqual(['o0', 'o1', 'o2', 'o3', 'o4']);
+        });
+
+        it('ignores parent mutations made AFTER iteration', () => {
+          const store = buildStore();
+          const view = store.match(namedNode('s1'), null, null, null, opts);
+          expect([...view]).toHaveLength(5);
+          store.addQuad(q('s1', 'p1', 'oNEW'));
+          expect([...view]).toHaveLength(5);
+        });
+
+        it('ignores non-matching parent mutations', () => {
+          const store = buildStore();
+          const view = store.match(namedNode('s1'), null, null, null, opts);
+          store.addQuad(q('s2', 'p1', 'oNEW'));
+          expect([...view]).toHaveLength(5);
+        });
+
+        it('supports its own independent mutations', () => {
+          const store = buildStore();
+          const view = store.match(namedNode('s1'), null, null, null, opts);
+          view.add(q('s1', 'p1', 'oOWN'));
+          expect(view.has(q('s1', 'p1', 'oOWN'))).toBe(true);
+          // The parent is not affected by snapshot view mutations.
+          expect(store.has(q('s1', 'p1', 'oOWN'))).toBe(false);
+        });
+
+        it('exposes a stable toArray/toStream/union', async () => {
+          const store = buildStore();
+          const view = store.match(namedNode('s1'), null, null, null, opts);
+          expect(view.toArray()).toHaveLength(5);
+          await expect(arrayifyStream(view.toStream())).resolves.toHaveLength(5);
+          expect(view.union(new Store([q('s1', 'p1', 'oU')])).size).toBe(6);
+        });
+      });
+
+      describe('forwarded', () => {
+        const opts = { matchSemantics: 'forwarded' };
+
+        it('reflects parent additions made BEFORE iteration', () => {
+          const store = buildStore();
+          const view = store.match(namedNode('s1'), null, null, null, opts);
+          store.addQuad(q('s1', 'p1', 'oNEW'));
+          expect([...view]).toHaveLength(6);
+          expect(view.has(q('s1', 'p1', 'oNEW'))).toBe(true);
+        });
+
+        it('reflects parent deletions made BEFORE iteration', () => {
+          const store = buildStore();
+          const view = store.match(namedNode('s1'), null, null, null, opts);
+          store.removeQuad(q('s1', 'p1', 'o0'));
+          expect([...view]).toHaveLength(4);
+          expect(view.has(q('s1', 'p1', 'o0'))).toBe(false);
+        });
+
+        it('keeps the running iteration stable across a parent ADD DURING sync iteration', () => {
+          const store = buildStore();
+          const view = store.match(namedNode('s1'), null, null, null, opts);
+          const seen = [];
+          let mutated = false;
+          for (const quad of view) {
+            seen.push(quad.object.value);
+            if (!mutated) {
+              mutated = true;
+              store.addQuad(q('s1', 'p1', 'oNEW'));
+            }
+          }
+          // The in-progress pass is stable (no duplicates, no omissions)...
+          expect(seen.sort()).toEqual(['o0', 'o1', 'o2', 'o3', 'o4']);
+          // ...and the next pass reflects the forwarded state.
+          expect([...view]).toHaveLength(6);
+        });
+
+        it('keeps the running iteration stable across a parent DELETE of an already-yielded quad', () => {
+          const store = buildStore();
+          const view = store.match(namedNode('s1'), null, null, null, opts);
+          const seen = [];
+          let mutated = false;
+          for (const quad of view) {
+            seen.push(quad.object.value);
+            if (!mutated) {
+              mutated = true;
+              store.removeQuad(q('s1', 'p1', quad.object.value));
+            }
+          }
+          expect(seen.sort()).toEqual(['o0', 'o1', 'o2', 'o3', 'o4']);
+          expect([...view]).toHaveLength(4);
+        });
+
+        it('keeps the running iteration stable across a parent mutation DURING async iteration', async () => {
+          const store = buildStore();
+          const view = store.match(namedNode('s1'), null, null, null, opts);
+          const seen = [];
+          await new Promise((resolve, reject) => {
+            let mutated = false;
+            view.on('data', d => {
+              seen.push(d.object.value);
+              if (!mutated) {
+                mutated = true;
+                store.removeQuad(q('s1', 'p1', 'o3'));
+              }
+            });
+            view.on('end', resolve);
+            view.on('error', reject);
+          });
+          expect(seen.sort()).toEqual(['o0', 'o1', 'o2', 'o3', 'o4']);
+          expect([...view]).toHaveLength(4);
+        });
+
+        it('reflects parent mutations made AFTER iteration', () => {
+          const store = buildStore();
+          const view = store.match(namedNode('s1'), null, null, null, opts);
+          expect([...view]).toHaveLength(5);
+          store.addQuad(q('s1', 'p1', 'oNEW'));
+          expect([...view]).toHaveLength(6);
+        });
+
+        it('ignores non-matching parent mutations', () => {
+          const store = buildStore();
+          const view = store.match(namedNode('s1'), null, null, null, opts);
+          store.addQuad(q('s2', 'p1', 'oNEW'));
+          expect([...view]).toHaveLength(5);
+        });
+
+        it('writes view additions and deletions through to the parent', () => {
+          const store = buildStore();
+          const view = store.match(namedNode('s1'), null, null, null, opts);
+          view.add(q('s1', 'p1', 'oOWN'));
+          expect(store.has(q('s1', 'p1', 'oOWN'))).toBe(true);
+          expect(view.has(q('s1', 'p1', 'oOWN'))).toBe(true);
+          view.delete(q('s1', 'p1', 'o0'));
+          expect(store.has(q('s1', 'p1', 'o0'))).toBe(false);
+          expect(view.has(q('s1', 'p1', 'o0'))).toBe(false);
+        });
+
+        it('forwards addAll and deleteMatches to the parent', () => {
+          const store = buildStore();
+          const view = store.match(namedNode('s1'), null, null, null, opts);
+          view.addAll([q('s1', 'p1', 'oA'), q('s1', 'p1', 'oB')]);
+          expect(store.has(q('s1', 'p1', 'oA'))).toBe(true);
+          expect(view.size).toBe(7);
+          view.deleteMatches(namedNode('s1'), namedNode('p1'), namedNode('oA'));
+          expect(store.has(q('s1', 'p1', 'oA'))).toBe(false);
+        });
+
+        it('forwards a Store addAll (bypassing the index-merge fast path) when observed', () => {
+          const store = buildStore();
+          const view = store.match(namedNode('s1'), null, null, null, opts);
+          const extra = new Store([], { entityIndex: store._entityIndex });
+          extra.addQuad(q('s1', 'p1', 'oM'));
+          store.addAll(extra);
+          expect(view.has(q('s1', 'p1', 'oM'))).toBe(true);
+        });
+
+        it('exposes a live toArray/toStream/union', async () => {
+          const store = buildStore();
+          const view = store.match(namedNode('s1'), null, null, null, opts);
+          store.addQuad(q('s1', 'p1', 'oNEW'));
+          expect(view.toArray()).toHaveLength(6);
+          await expect(arrayifyStream(view.toStream())).resolves.toHaveLength(6);
+          expect(view.union(new Store([q('s1', 'p1', 'oU')])).size).toBe(7);
+        });
+
+        it('handles matching mutations in the default graph', () => {
+          const store = new Store([q('s1', 'p1', 'o0')]);
+          const view = store.match(null, null, null, new DefaultGraph(), opts);
+          store.addQuad(q('s1', 'p1', 'o1'));
+          expect([...view]).toHaveLength(2);
+        });
+
+        it('stays stable when a parent mutation lands as the source is exhausted', () => {
+          const store = buildStore();
+          const view = store.match(namedNode('s1'), null, null, null, opts);
+          const seen = [];
+          for (const quad of view) {
+            seen.push(quad.object.value);
+            // Mutate only while processing the final matching quad, so the
+            // source iterator is exhausted on the very next step.
+            if (seen.length === 5)
+              store.addQuad(q('s1', 'p1', 'oNEW'));
+          }
+          expect(seen.sort()).toEqual(['o0', 'o1', 'o2', 'o3', 'o4']);
+          expect([...view]).toHaveLength(6);
+        });
+
+        it('captures a baseline from an already-materialized view mid-iteration', () => {
+          const store = buildStore();
+          const view = store.match(namedNode('s1'), null, null, null, opts);
+          // Force materialization of `_filtered` via a first matching mutation.
+          store.addQuad(q('s1', 'p1', 'oNEW'));
+          expect(view.size).toBe(6);
+          // Now iterate the materialized view and mutate mid-iteration.
+          const seen = [];
+          let mutated = false;
+          for (const quad of view) {
+            seen.push(quad.object.value);
+            if (!mutated) {
+              mutated = true;
+              store.addQuad(q('s1', 'p1', 'oNEW2'));
+            }
+          }
+          expect(seen.sort()).toEqual(['o0', 'o1', 'o2', 'o3', 'o4', 'oNEW']);
+          expect([...view]).toHaveLength(7);
+        });
+
+        it('reflects additions of a pattern term absent at match() time', () => {
+          const store = new Store();
+          // The subject `s9` is not present when the view is created.
+          const view = store.match(namedNode('s9'), null, null, null, opts);
+          expect([...view]).toHaveLength(0);
+          store.addQuad(q('s9', 'p1', 'o1'));
+          expect([...view]).toHaveLength(1);
+          expect(view.has(q('s9', 'p1', 'o1'))).toBe(true);
+        });
+
+        it('ignores a re-added quad that already exists', () => {
+          const store = buildStore();
+          const view = store.match(namedNode('s1'), null, null, null, opts);
+          // Re-adding an existing quad must not notify observers nor change size.
+          store.addQuad(q('s1', 'p1', 'o0'));
+          expect([...view]).toHaveLength(5);
+        });
+
+        it('matches across all pattern positions and the default graph', () => {
+          const store = new Store([q('s1', 'p1', 'o1')]);
+          // Wildcard pattern: every position is a wildcard.
+          const wildcard = store.match(null, null, null, null, opts);
+          // Fully specified pattern including the default graph.
+          const exact = store.match(
+            namedNode('s1'), namedNode('p1'), namedNode('o1'), new DefaultGraph(), opts);
+          store.addQuad(q('s1', 'p1', 'o1')); // already exists, no change
+          store.addQuad(q('s1', 'p1', 'o2')); // matches wildcard, not exact (object differs)
+          expect([...wildcard]).toHaveLength(2);
+          expect([...exact]).toHaveLength(1);
+        });
+
+        it('does not match mutations differing in any single position', () => {
+          const store = new Store([new Quad(
+            namedNode('s1'), namedNode('p1'), namedNode('o1'), namedNode('g1'))]);
+          const view = store.match(
+            namedNode('s1'), namedNode('p1'), namedNode('o1'), namedNode('g1'), opts);
+          // Each of these differs from the pattern in exactly one position.
+          store.addQuad(new Quad(namedNode('sX'), namedNode('p1'), namedNode('o1'), namedNode('g1')));
+          store.addQuad(new Quad(namedNode('s1'), namedNode('pX'), namedNode('o1'), namedNode('g1')));
+          store.addQuad(new Quad(namedNode('s1'), namedNode('p1'), namedNode('oX'), namedNode('g1')));
+          store.addQuad(new Quad(namedNode('s1'), namedNode('p1'), namedNode('o1'), namedNode('gX')));
+          expect([...view]).toHaveLength(1);
+        });
+
+        it('keeps concurrent iterations stable', () => {
+          const store = buildStore();
+          const view = store.match(namedNode('s1'), null, null, null, opts);
+          const outer = [];
+          const inner = [];
+          for (const a of view) {
+            outer.push(a.object.value);
+            if (outer.length === 1) {
+              // Run a nested (concurrent) iteration to completion; its finally
+              // block decrements `_activeIterators` while the outer one is still
+              // active, then mutate to exercise the still-running outer iterator.
+              for (const b of view)
+                inner.push(b.object.value);
+              store.addQuad(q('s1', 'p1', 'oNEW'));
+            }
+          }
+          expect(inner).toHaveLength(5);
+          expect(outer.sort()).toEqual(['o0', 'o1', 'o2', 'o3', 'o4']);
+        });
+      });
+    });
+
     describe('getSubjects', () => {
       describe('with existing predicate, object and graph parameters', () => {
         it(

--- a/test/N3Store-test.js
+++ b/test/N3Store-test.js
@@ -1051,6 +1051,15 @@ describe('Store', () => {
           expect(store.has(q('s1', 'p1', 'oA'))).toBe(false);
         });
 
+        it('should write import() through to the parent', done => {
+          const events = view.import(new ArrayReader([q('s1', 'p1', 'oI')]));
+          events.on('end', () => {
+            expect(store.has(q('s1', 'p1', 'oI'))).toBe(true);
+            expect(view.has(q('s1', 'p1', 'oI'))).toBe(true);
+            done();
+          });
+        });
+
         it('should write non-matching mutations through to the parent unrestricted', () => {
           // A non-matching add mutates the parent but never appears in the view
           view.add(q('s3', 'p1', 'oNM'));

--- a/test/N3Store-test.js
+++ b/test/N3Store-test.js
@@ -931,6 +931,15 @@ describe('Store', () => {
           store.addQuad(q('s1', 'p1', 'oNEW'));
           expect(union.size).toBe(6);
         });
+
+        it('keeps a nested match() frozen at nesting time', () => {
+          const store = buildStore();
+          const view = store.match(namedNode('s1'), null, null, null, opts);
+          const sub = view.match(null, namedNode('p1'));
+          store.addQuad(q('s1', 'p1', 'oNEW'));
+          expect([...sub]).toHaveLength(5);
+          expect(sub.has(q('s1', 'p1', 'oNEW'))).toBe(false);
+        });
       });
 
       describe('forwarded', () => {
@@ -1089,6 +1098,22 @@ describe('Store', () => {
           expect(union.size).toBe(6);
           expect(store.has(q('s1', 'p1', 'oU'))).toBe(false);
           expect(view.has(q('s1', 'p1', 'oU'))).toBe(false);
+        });
+
+        it('downgrades a nested match() to a snapshot of the view', () => {
+          const store = buildStore();
+          const view = store.match(namedNode('s1'), null, null, null, opts);
+          const sub = view.match(null, namedNode('p1'));
+          expect([...sub]).toHaveLength(5);
+          // Later root mutations reach the outer view, but not the nested snapshot
+          store.addQuad(q('s1', 'p1', 'oNEW'));
+          expect(view.has(q('s1', 'p1', 'oNEW'))).toBe(true);
+          expect([...sub]).toHaveLength(5);
+          // Mutations on the sub-view reach neither the root store nor the outer view
+          sub.add(q('s1', 'p1', 'oSUB'));
+          expect(sub.has(q('s1', 'p1', 'oSUB'))).toBe(true);
+          expect(store.has(q('s1', 'p1', 'oSUB'))).toBe(false);
+          expect(view.has(q('s1', 'p1', 'oSUB'))).toBe(false);
         });
 
         it('handles matching mutations in the default graph', () => {

--- a/test/N3Store-test.js
+++ b/test/N3Store-test.js
@@ -788,8 +788,7 @@ describe('Store', () => {
         // Two snapshot views observe the store concurrently.
         const a = store.match(namedNode('s1'), null, null, null, { matchSemantics: 'snapshot' });
         const b = store.match(namedNode('s1'), null, null, null, { matchSemantics: 'snapshot' });
-        // The first matching mutation materializes (and detaches) view `a`'s
-        // observer, while view `b`'s observer is still registered.
+        // Materialize (and detach) view `a`'s observer while view `b`'s remains registered
         a.size; // eslint-disable-line no-unused-expressions
         store.addQuad(q('s1', 'p1', 'oNEW'));
         expect([...a]).toHaveLength(5);
@@ -1028,8 +1027,7 @@ describe('Store', () => {
           const seen = [];
           for (const quad of view) {
             seen.push(quad.object.value);
-            // Mutate only while processing the final matching quad, so the
-            // source iterator is exhausted on the very next step.
+            // Mutate while processing the final quad, so the source is exhausted on the next step
             if (seen.length === 5)
               store.addQuad(q('s1', 'p1', 'oNEW'));
           }
@@ -1109,9 +1107,7 @@ describe('Store', () => {
           for (const a of view) {
             outer.push(a.object.value);
             if (outer.length === 1) {
-              // Run a nested (concurrent) iteration to completion; its finally
-              // block decrements `_activeIterators` while the outer one is still
-              // active, then mutate to exercise the still-running outer iterator.
+              // Run a nested iteration to completion (dropping `_activeIterators` to 1), then mutate
               for (const b of view)
                 inner.push(b.object.value);
               store.addQuad(q('s1', 'p1', 'oNEW'));

--- a/test/N3Store-test.js
+++ b/test/N3Store-test.js
@@ -1070,6 +1070,23 @@ describe('Store', () => {
           expect(store.has(q('s1', 'p1', 'oA'))).toBe(false);
         });
 
+        it('writes non-matching mutations through to the parent unrestricted', () => {
+          const store = buildStore();
+          const view = store.match(namedNode('s1'), null, null, null, opts);
+          // A non-matching add mutates the parent but never appears in the view
+          view.add(q('s3', 'p1', 'oNM'));
+          expect(store.has(q('s3', 'p1', 'oNM'))).toBe(true);
+          expect(view.has(q('s3', 'p1', 'oNM'))).toBe(false);
+          // A non-matching addAll grows the parent, not the view
+          view.addAll([q('s3', 'p1', 'oNM2')]);
+          expect(store.has(q('s3', 'p1', 'oNM2'))).toBe(true);
+          expect(view.size).toBe(5);
+          // A deleteMatches wider than the pattern deletes parent quads outside the view
+          view.deleteMatches(namedNode('s2'), null, null);
+          expect(store.has(q('s2', 'p1', 'oX'))).toBe(false);
+          expect(view.size).toBe(5);
+        });
+
         it('defers materialization of an unread view across parent mutations', () => {
           const store = buildStore();
           const view = store.match(namedNode('s1'), null, null, null, opts);

--- a/test/N3Store-test.js
+++ b/test/N3Store-test.js
@@ -783,6 +783,24 @@ describe('Store', () => {
         expect(values(view)).not.toContain('oNEW');
       });
 
+      it('keeps internal match() calls lazy under a non-lazy store default', async () => {
+        for (const matchSemantics of ['snapshot', 'forwarded']) {
+          const store = buildStore({ matchSemantics });
+          store.deleteMatches(namedNode('s2'), null, null);
+          expect(store.size).toBe(5);
+          expect(store._observers).toBe(null);
+          await expect(arrayifyStream(store.toStream())).resolves.toHaveLength(5);
+          expect(store._observers).toBe(null);
+        }
+      });
+
+      it('keeps toStream() on a lazy view lazy under a forwarded store default', async () => {
+        const store = buildStore({ matchSemantics: 'forwarded' });
+        const view = store.match(namedNode('s1'), null, null, null, { matchSemantics: 'lazy' });
+        await expect(arrayifyStream(view.toStream())).resolves.toHaveLength(5);
+        expect(store._observers).toBe(null);
+      });
+
       it('does not write union() contents through to a store with a forwarded default', () => {
         const store = buildStore({ matchSemantics: 'forwarded' });
         const view = store.match(namedNode('s1'), null, null, null, { matchSemantics: 'lazy' });

--- a/test/N3Store-test.js
+++ b/test/N3Store-test.js
@@ -1098,6 +1098,19 @@ describe('Store', () => {
           expect([...view]).toHaveLength(2);
         });
 
+        it('treats an empty-string graph pattern as the default graph', () => {
+          const store = buildStore();
+          const view = store.match(null, null, null, '', opts);
+          expect([...view]).toHaveLength(6);
+          // A named-graph quad does not match a default-graph pattern
+          store.addQuad(q('s3', 'p1', 'oG', 'g1'));
+          expect([...view]).toHaveLength(6);
+          expect(view.has(q('s3', 'p1', 'oG', 'g1'))).toBe(false);
+          // A default-graph quad does match
+          store.addQuad(q('s3', 'p1', 'oD'));
+          expect([...view]).toHaveLength(7);
+        });
+
         it('stays stable when a parent mutation lands as the source is exhausted', () => {
           const store = buildStore();
           const view = store.match(namedNode('s1'), null, null, null, opts);

--- a/test/N3Store-test.js
+++ b/test/N3Store-test.js
@@ -840,6 +840,17 @@ describe('Store', () => {
         expect([...b]).toHaveLength(5);
       });
 
+      it('should stop observing when a snapshot with an absent pattern term materializes', () => {
+        const store = buildStore();
+        const view = store.match(namedNode('sNONE'), null, null, null, { matchSemantics: 'snapshot' });
+        expect(view.size).toBe(0);
+        // Materialization removes the observer also on the absent-term path
+        expect(store._observers).toBe(null);
+        // The view stays frozen to its (empty) contents
+        store.addQuad(q('sNONE', 'p1', 'o1'));
+        expect([...view]).toHaveLength(0);
+      });
+
       describe('snapshot', () => {
         const opts = { matchSemantics: 'snapshot' };
 

--- a/test/N3Store-test.js
+++ b/test/N3Store-test.js
@@ -740,6 +740,399 @@ describe('Store', () => {
       });
     });
 
+    describe('match semantics', () => {
+      function q(s, p, o, g) {
+        return new Quad(new NamedNode(s), new NamedNode(p), new NamedNode(o), g ? new NamedNode(g) : undefined);
+      }
+      function values(view) {
+        return [...view].map(x => x.object.value).sort();
+      }
+
+      function buildStore(options) {
+        const s = new Store([], options);
+        for (let i = 0; i < 5; i++)
+          s.addQuad(q('s1', 'p1', `o${i}`));
+        s.addQuad(q('s2', 'p1', 'oX')); // a non-matching quad for an `s1` pattern
+        return s;
+      }
+
+      it('defaults to lazy semantics', () => {
+        const store = buildStore();
+        const view = store.match(namedNode('s1'), null, null);
+        store.addQuad(q('s1', 'p1', 'oNEW'));
+        // Lazy: parent mutation before the view's own mutation leaks in.
+        expect(values(view)).toContain('oNEW');
+        expect([...view]).toHaveLength(6);
+      });
+
+      it('throws on an unknown matchSemantics value', () => {
+        const store = buildStore();
+        expect(() => store.match(namedNode('s1'), null, null, null, { matchSemantics: 'bogus' }))
+          .toThrow('Unknown matchSemantics: bogus');
+      });
+
+      it('uses the store-level default matchSemantics', () => {
+        const store = buildStore({ matchSemantics: 'snapshot' });
+        const view = store.match(namedNode('s1'), null, null);
+        store.addQuad(q('s1', 'p1', 'oNEW'));
+        expect(values(view)).not.toContain('oNEW');
+        expect([...view]).toHaveLength(5);
+      });
+
+      it('lets a per-call matchSemantics override the store default', () => {
+        const store = buildStore({ matchSemantics: 'snapshot' });
+        const view = store.match(namedNode('s1'), null, null, null, { matchSemantics: 'forwarded' });
+        store.addQuad(q('s1', 'p1', 'oNEW'));
+        expect(values(view)).toContain('oNEW');
+      });
+
+      it('falls back to the store default when an options object omits matchSemantics', () => {
+        const store = buildStore({ matchSemantics: 'snapshot' });
+        const view = store.match(namedNode('s1'), null, null, null, {});
+        store.addQuad(q('s1', 'p1', 'oNEW'));
+        expect(values(view)).not.toContain('oNEW');
+      });
+
+      it('detaches a single observer while another remains attached', () => {
+        const store = buildStore();
+        // Two snapshot views observe the store concurrently.
+        const a = store.match(namedNode('s1'), null, null, null, { matchSemantics: 'snapshot' });
+        const b = store.match(namedNode('s1'), null, null, null, { matchSemantics: 'snapshot' });
+        // The first matching mutation materializes (and detaches) view `a`'s
+        // observer, while view `b`'s observer is still registered.
+        a.size; // eslint-disable-line no-unused-expressions
+        store.addQuad(q('s1', 'p1', 'oNEW'));
+        expect([...a]).toHaveLength(5);
+        expect([...b]).toHaveLength(5);
+        store.addQuad(q('s1', 'p1', 'oNEW2'));
+        expect([...b]).toHaveLength(5);
+      });
+
+      describe('snapshot', () => {
+        const opts = { matchSemantics: 'snapshot' };
+
+        it('ignores parent additions made BEFORE iteration', () => {
+          const store = buildStore();
+          const view = store.match(namedNode('s1'), null, null, null, opts);
+          store.addQuad(q('s1', 'p1', 'oNEW'));
+          expect([...view]).toHaveLength(5);
+          expect(view.size).toBe(5);
+          expect(view.has(q('s1', 'p1', 'oNEW'))).toBe(false);
+          expect(view.has(q('s1', 'p1', 'o0'))).toBe(true);
+        });
+
+        it('ignores parent deletions made BEFORE iteration', () => {
+          const store = buildStore();
+          const view = store.match(namedNode('s1'), null, null, null, opts);
+          store.removeQuad(q('s1', 'p1', 'o0'));
+          expect([...view]).toHaveLength(5);
+          expect(view.has(q('s1', 'p1', 'o0'))).toBe(true);
+        });
+
+        it('ignores a parent mutation that lands DURING sync iteration', () => {
+          const store = buildStore();
+          const view = store.match(namedNode('s1'), null, null, null, opts);
+          const seen = [];
+          let mutated = false;
+          for (const quad of view) {
+            seen.push(quad.object.value);
+            if (!mutated) {
+              mutated = true;
+              store.addQuad(q('s1', 'p1', 'oNEW'));
+              store.removeQuad(q('s1', 'p1', 'o4'));
+            }
+          }
+          expect(seen.sort()).toEqual(['o0', 'o1', 'o2', 'o3', 'o4']);
+        });
+
+        it('ignores a parent mutation that lands DURING async iteration', async () => {
+          const store = buildStore();
+          const view = store.match(namedNode('s1'), null, null, null, opts);
+          const seen = [];
+          await new Promise((resolve, reject) => {
+            let mutated = false;
+            view.on('data', d => {
+              seen.push(d.object.value);
+              if (!mutated) {
+                mutated = true;
+                store.addQuad(q('s1', 'p1', 'oNEW'));
+              }
+            });
+            view.on('end', resolve);
+            view.on('error', reject);
+          });
+          expect(seen).not.toContain('oNEW');
+          expect(seen.sort()).toEqual(['o0', 'o1', 'o2', 'o3', 'o4']);
+        });
+
+        it('ignores parent mutations made AFTER iteration', () => {
+          const store = buildStore();
+          const view = store.match(namedNode('s1'), null, null, null, opts);
+          expect([...view]).toHaveLength(5);
+          store.addQuad(q('s1', 'p1', 'oNEW'));
+          expect([...view]).toHaveLength(5);
+        });
+
+        it('ignores non-matching parent mutations', () => {
+          const store = buildStore();
+          const view = store.match(namedNode('s1'), null, null, null, opts);
+          store.addQuad(q('s2', 'p1', 'oNEW'));
+          expect([...view]).toHaveLength(5);
+        });
+
+        it('supports its own independent mutations', () => {
+          const store = buildStore();
+          const view = store.match(namedNode('s1'), null, null, null, opts);
+          view.add(q('s1', 'p1', 'oOWN'));
+          expect(view.has(q('s1', 'p1', 'oOWN'))).toBe(true);
+          // The parent is not affected by snapshot view mutations.
+          expect(store.has(q('s1', 'p1', 'oOWN'))).toBe(false);
+        });
+
+        it('exposes a stable toArray/toStream/union', async () => {
+          const store = buildStore();
+          const view = store.match(namedNode('s1'), null, null, null, opts);
+          expect(view.toArray()).toHaveLength(5);
+          await expect(arrayifyStream(view.toStream())).resolves.toHaveLength(5);
+          expect(view.union(new Store([q('s1', 'p1', 'oU')])).size).toBe(6);
+        });
+      });
+
+      describe('forwarded', () => {
+        const opts = { matchSemantics: 'forwarded' };
+
+        it('reflects parent additions made BEFORE iteration', () => {
+          const store = buildStore();
+          const view = store.match(namedNode('s1'), null, null, null, opts);
+          store.addQuad(q('s1', 'p1', 'oNEW'));
+          expect([...view]).toHaveLength(6);
+          expect(view.has(q('s1', 'p1', 'oNEW'))).toBe(true);
+        });
+
+        it('reflects parent deletions made BEFORE iteration', () => {
+          const store = buildStore();
+          const view = store.match(namedNode('s1'), null, null, null, opts);
+          store.removeQuad(q('s1', 'p1', 'o0'));
+          expect([...view]).toHaveLength(4);
+          expect(view.has(q('s1', 'p1', 'o0'))).toBe(false);
+        });
+
+        it('keeps the running iteration stable across a parent ADD DURING sync iteration', () => {
+          const store = buildStore();
+          const view = store.match(namedNode('s1'), null, null, null, opts);
+          const seen = [];
+          let mutated = false;
+          for (const quad of view) {
+            seen.push(quad.object.value);
+            if (!mutated) {
+              mutated = true;
+              store.addQuad(q('s1', 'p1', 'oNEW'));
+            }
+          }
+          // The in-progress pass is stable (no duplicates, no omissions)...
+          expect(seen.sort()).toEqual(['o0', 'o1', 'o2', 'o3', 'o4']);
+          // ...and the next pass reflects the forwarded state.
+          expect([...view]).toHaveLength(6);
+        });
+
+        it('keeps the running iteration stable across a parent DELETE of an already-yielded quad', () => {
+          const store = buildStore();
+          const view = store.match(namedNode('s1'), null, null, null, opts);
+          const seen = [];
+          let mutated = false;
+          for (const quad of view) {
+            seen.push(quad.object.value);
+            if (!mutated) {
+              mutated = true;
+              store.removeQuad(q('s1', 'p1', quad.object.value));
+            }
+          }
+          expect(seen.sort()).toEqual(['o0', 'o1', 'o2', 'o3', 'o4']);
+          expect([...view]).toHaveLength(4);
+        });
+
+        it('keeps the running iteration stable across a parent mutation DURING async iteration', async () => {
+          const store = buildStore();
+          const view = store.match(namedNode('s1'), null, null, null, opts);
+          const seen = [];
+          await new Promise((resolve, reject) => {
+            let mutated = false;
+            view.on('data', d => {
+              seen.push(d.object.value);
+              if (!mutated) {
+                mutated = true;
+                store.removeQuad(q('s1', 'p1', 'o3'));
+              }
+            });
+            view.on('end', resolve);
+            view.on('error', reject);
+          });
+          expect(seen.sort()).toEqual(['o0', 'o1', 'o2', 'o3', 'o4']);
+          expect([...view]).toHaveLength(4);
+        });
+
+        it('reflects parent mutations made AFTER iteration', () => {
+          const store = buildStore();
+          const view = store.match(namedNode('s1'), null, null, null, opts);
+          expect([...view]).toHaveLength(5);
+          store.addQuad(q('s1', 'p1', 'oNEW'));
+          expect([...view]).toHaveLength(6);
+        });
+
+        it('ignores non-matching parent mutations', () => {
+          const store = buildStore();
+          const view = store.match(namedNode('s1'), null, null, null, opts);
+          store.addQuad(q('s2', 'p1', 'oNEW'));
+          expect([...view]).toHaveLength(5);
+        });
+
+        it('writes view additions and deletions through to the parent', () => {
+          const store = buildStore();
+          const view = store.match(namedNode('s1'), null, null, null, opts);
+          view.add(q('s1', 'p1', 'oOWN'));
+          expect(store.has(q('s1', 'p1', 'oOWN'))).toBe(true);
+          expect(view.has(q('s1', 'p1', 'oOWN'))).toBe(true);
+          view.delete(q('s1', 'p1', 'o0'));
+          expect(store.has(q('s1', 'p1', 'o0'))).toBe(false);
+          expect(view.has(q('s1', 'p1', 'o0'))).toBe(false);
+        });
+
+        it('forwards addAll and deleteMatches to the parent', () => {
+          const store = buildStore();
+          const view = store.match(namedNode('s1'), null, null, null, opts);
+          view.addAll([q('s1', 'p1', 'oA'), q('s1', 'p1', 'oB')]);
+          expect(store.has(q('s1', 'p1', 'oA'))).toBe(true);
+          expect(view.size).toBe(7);
+          view.deleteMatches(namedNode('s1'), namedNode('p1'), namedNode('oA'));
+          expect(store.has(q('s1', 'p1', 'oA'))).toBe(false);
+        });
+
+        it('forwards a Store addAll (bypassing the index-merge fast path) when observed', () => {
+          const store = buildStore();
+          const view = store.match(namedNode('s1'), null, null, null, opts);
+          const extra = new Store([], { entityIndex: store._entityIndex });
+          extra.addQuad(q('s1', 'p1', 'oM'));
+          store.addAll(extra);
+          expect(view.has(q('s1', 'p1', 'oM'))).toBe(true);
+        });
+
+        it('exposes a live toArray/toStream/union', async () => {
+          const store = buildStore();
+          const view = store.match(namedNode('s1'), null, null, null, opts);
+          store.addQuad(q('s1', 'p1', 'oNEW'));
+          expect(view.toArray()).toHaveLength(6);
+          await expect(arrayifyStream(view.toStream())).resolves.toHaveLength(6);
+          expect(view.union(new Store([q('s1', 'p1', 'oU')])).size).toBe(7);
+        });
+
+        it('handles matching mutations in the default graph', () => {
+          const store = new Store([q('s1', 'p1', 'o0')]);
+          const view = store.match(null, null, null, new DefaultGraph(), opts);
+          store.addQuad(q('s1', 'p1', 'o1'));
+          expect([...view]).toHaveLength(2);
+        });
+
+        it('stays stable when a parent mutation lands as the source is exhausted', () => {
+          const store = buildStore();
+          const view = store.match(namedNode('s1'), null, null, null, opts);
+          const seen = [];
+          for (const quad of view) {
+            seen.push(quad.object.value);
+            // Mutate only while processing the final matching quad, so the
+            // source iterator is exhausted on the very next step.
+            if (seen.length === 5)
+              store.addQuad(q('s1', 'p1', 'oNEW'));
+          }
+          expect(seen.sort()).toEqual(['o0', 'o1', 'o2', 'o3', 'o4']);
+          expect([...view]).toHaveLength(6);
+        });
+
+        it('captures a baseline from an already-materialized view mid-iteration', () => {
+          const store = buildStore();
+          const view = store.match(namedNode('s1'), null, null, null, opts);
+          // Force materialization of `_filtered` via a first matching mutation.
+          store.addQuad(q('s1', 'p1', 'oNEW'));
+          expect(view.size).toBe(6);
+          // Now iterate the materialized view and mutate mid-iteration.
+          const seen = [];
+          let mutated = false;
+          for (const quad of view) {
+            seen.push(quad.object.value);
+            if (!mutated) {
+              mutated = true;
+              store.addQuad(q('s1', 'p1', 'oNEW2'));
+            }
+          }
+          expect(seen.sort()).toEqual(['o0', 'o1', 'o2', 'o3', 'o4', 'oNEW']);
+          expect([...view]).toHaveLength(7);
+        });
+
+        it('reflects additions of a pattern term absent at match() time', () => {
+          const store = new Store();
+          // The subject `s9` is not present when the view is created.
+          const view = store.match(namedNode('s9'), null, null, null, opts);
+          expect([...view]).toHaveLength(0);
+          store.addQuad(q('s9', 'p1', 'o1'));
+          expect([...view]).toHaveLength(1);
+          expect(view.has(q('s9', 'p1', 'o1'))).toBe(true);
+        });
+
+        it('ignores a re-added quad that already exists', () => {
+          const store = buildStore();
+          const view = store.match(namedNode('s1'), null, null, null, opts);
+          // Re-adding an existing quad must not notify observers nor change size.
+          store.addQuad(q('s1', 'p1', 'o0'));
+          expect([...view]).toHaveLength(5);
+        });
+
+        it('matches across all pattern positions and the default graph', () => {
+          const store = new Store([q('s1', 'p1', 'o1')]);
+          // Wildcard pattern: every position is a wildcard.
+          const wildcard = store.match(null, null, null, null, opts);
+          // Fully specified pattern including the default graph.
+          const exact = store.match(
+            namedNode('s1'), namedNode('p1'), namedNode('o1'), new DefaultGraph(), opts);
+          store.addQuad(q('s1', 'p1', 'o1')); // already exists, no change
+          store.addQuad(q('s1', 'p1', 'o2')); // matches wildcard, not exact (object differs)
+          expect([...wildcard]).toHaveLength(2);
+          expect([...exact]).toHaveLength(1);
+        });
+
+        it('does not match mutations differing in any single position', () => {
+          const store = new Store([new Quad(
+            namedNode('s1'), namedNode('p1'), namedNode('o1'), namedNode('g1'))]);
+          const view = store.match(
+            namedNode('s1'), namedNode('p1'), namedNode('o1'), namedNode('g1'), opts);
+          // Each of these differs from the pattern in exactly one position.
+          store.addQuad(new Quad(namedNode('sX'), namedNode('p1'), namedNode('o1'), namedNode('g1')));
+          store.addQuad(new Quad(namedNode('s1'), namedNode('pX'), namedNode('o1'), namedNode('g1')));
+          store.addQuad(new Quad(namedNode('s1'), namedNode('p1'), namedNode('oX'), namedNode('g1')));
+          store.addQuad(new Quad(namedNode('s1'), namedNode('p1'), namedNode('o1'), namedNode('gX')));
+          expect([...view]).toHaveLength(1);
+        });
+
+        it('keeps concurrent iterations stable', () => {
+          const store = buildStore();
+          const view = store.match(namedNode('s1'), null, null, null, opts);
+          const outer = [];
+          const inner = [];
+          for (const a of view) {
+            outer.push(a.object.value);
+            if (outer.length === 1) {
+              // Run a nested (concurrent) iteration to completion; its finally
+              // block decrements `_activeIterators` while the outer one is still
+              // active, then mutate to exercise the still-running outer iterator.
+              for (const b of view)
+                inner.push(b.object.value);
+              store.addQuad(q('s1', 'p1', 'oNEW'));
+            }
+          }
+          expect(inner).toHaveLength(5);
+          expect(outer.sort()).toEqual(['o0', 'o1', 'o2', 'o3', 'o4']);
+        });
+      });
+    });
+
     describe('getSubjects', () => {
       describe('with existing predicate, object and graph parameters', () => {
         it(

--- a/test/N3Store-test.js
+++ b/test/N3Store-test.js
@@ -1204,11 +1204,12 @@ describe('Store', () => {
           expect([...view]).toHaveLength(5);
         });
 
-        it('should write view additions and deletions through to the parent', () => {
+        it('should write view additions and deletions through without materializing', () => {
           expect(view.add(q('s1', 'p1', 'oOWN'))).toBe(view);
+          expect(view.delete(q('s1', 'p1', 'o0'))).toBe(view);
+          expect(view._filtered).toBeFalsy();
           expect(store.has(q('s1', 'p1', 'oOWN'))).toBe(true);
           expect(view.has(q('s1', 'p1', 'oOWN'))).toBe(true);
-          expect(view.delete(q('s1', 'p1', 'o0'))).toBe(view);
           expect(store.has(q('s1', 'p1', 'o0'))).toBe(false);
           expect(view.has(q('s1', 'p1', 'o0'))).toBe(false);
         });

--- a/test/N3Store-test.js
+++ b/test/N3Store-test.js
@@ -756,7 +756,7 @@ describe('Store', () => {
         return s;
       }
 
-      it('defaults to lazy semantics', () => {
+      it('should default to lazy semantics', () => {
         const store = buildStore();
         const view = store.match(namedNode('s1'), null, null);
         store.addQuad(q('s1', 'p1', 'oNEW'));
@@ -765,18 +765,18 @@ describe('Store', () => {
         expect([...view]).toHaveLength(6);
       });
 
-      it('throws on an unknown matchSemantics value', () => {
+      it('should throw on an unknown matchSemantics value', () => {
         const store = buildStore();
         expect(() => store.match(namedNode('s1'), null, null, null, { matchSemantics: 'bogus' }))
           .toThrow('Unknown matchSemantics: bogus');
       });
 
-      it('throws on an unknown store-level matchSemantics value', () => {
+      it('should throw on an unknown store-level matchSemantics value', () => {
         expect(() => new Store([], { matchSemantics: 'bogus' }))
           .toThrow('Unknown matchSemantics: bogus');
       });
 
-      it('uses the store-level default matchSemantics', () => {
+      it('should use the store-level default matchSemantics', () => {
         const store = buildStore({ matchSemantics: 'snapshot' });
         const view = store.match(namedNode('s1'), null, null);
         store.addQuad(q('s1', 'p1', 'oNEW'));
@@ -784,21 +784,21 @@ describe('Store', () => {
         expect([...view]).toHaveLength(5);
       });
 
-      it('lets a per-call matchSemantics override the store default', () => {
+      it('should let a per-call matchSemantics override the store default', () => {
         const store = buildStore({ matchSemantics: 'snapshot' });
         const view = store.match(namedNode('s1'), null, null, null, { matchSemantics: 'forwarded' });
         store.addQuad(q('s1', 'p1', 'oNEW'));
         expect(values(view)).toContain('oNEW');
       });
 
-      it('falls back to the store default when an options object omits matchSemantics', () => {
+      it('should fall back to the store default when an options object omits matchSemantics', () => {
         const store = buildStore({ matchSemantics: 'snapshot' });
         const view = store.match(namedNode('s1'), null, null, null, {});
         store.addQuad(q('s1', 'p1', 'oNEW'));
         expect(values(view)).not.toContain('oNEW');
       });
 
-      it('keeps internal match() calls lazy under a non-lazy store default', async () => {
+      it('should keep internal match() calls lazy under a non-lazy store default', async () => {
         for (const matchSemantics of ['snapshot', 'forwarded']) {
           const store = buildStore({ matchSemantics });
           store.deleteMatches(namedNode('s2'), null, null);
@@ -809,14 +809,14 @@ describe('Store', () => {
         }
       });
 
-      it('keeps toStream() on a lazy view lazy under a forwarded store default', async () => {
+      it('should keep toStream() on a lazy view lazy under a forwarded store default', async () => {
         const store = buildStore({ matchSemantics: 'forwarded' });
         const view = store.match(namedNode('s1'), null, null, null, { matchSemantics: 'lazy' });
         await expect(arrayifyStream(view.toStream())).resolves.toHaveLength(5);
         expect(store._observers).toBe(null);
       });
 
-      it('does not write union() contents through to a store with a forwarded default', () => {
+      it('should not write union() contents through to a store with a forwarded default', () => {
         const store = buildStore({ matchSemantics: 'forwarded' });
         const view = store.match(namedNode('s1'), null, null, null, { matchSemantics: 'lazy' });
         const union = view.union([q('s1', 'p1', 'oU')]);
@@ -826,7 +826,7 @@ describe('Store', () => {
         expect(store.has(q('s1', 'p1', 'oU'))).toBe(false);
       });
 
-      it('detaches a single observer while another remains attached', () => {
+      it('should detach a single observer while another remains attached', () => {
         const store = buildStore();
         // Two snapshot views observe the store concurrently.
         const a = store.match(namedNode('s1'), null, null, null, { matchSemantics: 'snapshot' });
@@ -843,9 +843,13 @@ describe('Store', () => {
       describe('snapshot', () => {
         const opts = { matchSemantics: 'snapshot' };
 
-        it('ignores parent additions made BEFORE iteration', () => {
-          const store = buildStore();
-          const view = store.match(namedNode('s1'), null, null, null, opts);
+        let store, view;
+        beforeEach(() => {
+          store = buildStore();
+          view = store.match(namedNode('s1'), null, null, null, opts);
+        });
+
+        it('should ignore parent additions made before iteration', () => {
           store.addQuad(q('s1', 'p1', 'oNEW'));
           expect([...view]).toHaveLength(5);
           expect(view.size).toBe(5);
@@ -853,17 +857,13 @@ describe('Store', () => {
           expect(view.has(q('s1', 'p1', 'o0'))).toBe(true);
         });
 
-        it('ignores parent deletions made BEFORE iteration', () => {
-          const store = buildStore();
-          const view = store.match(namedNode('s1'), null, null, null, opts);
+        it('should ignore parent deletions made before iteration', () => {
           store.removeQuad(q('s1', 'p1', 'o0'));
           expect([...view]).toHaveLength(5);
           expect(view.has(q('s1', 'p1', 'o0'))).toBe(true);
         });
 
-        it('ignores a parent mutation that lands DURING sync iteration', () => {
-          const store = buildStore();
-          const view = store.match(namedNode('s1'), null, null, null, opts);
+        it('should ignore a parent mutation that lands during sync iteration', () => {
           const seen = [];
           let mutated = false;
           for (const quad of view) {
@@ -877,9 +877,7 @@ describe('Store', () => {
           expect(seen.sort()).toEqual(['o0', 'o1', 'o2', 'o3', 'o4']);
         });
 
-        it('ignores a parent mutation that lands DURING async iteration', async () => {
-          const store = buildStore();
-          const view = store.match(namedNode('s1'), null, null, null, opts);
+        it('should ignore a parent mutation that lands during async iteration', async () => {
           const seen = [];
           await new Promise((resolve, reject) => {
             let mutated = false;
@@ -897,48 +895,36 @@ describe('Store', () => {
           expect(seen.sort()).toEqual(['o0', 'o1', 'o2', 'o3', 'o4']);
         });
 
-        it('ignores parent mutations made AFTER iteration', () => {
-          const store = buildStore();
-          const view = store.match(namedNode('s1'), null, null, null, opts);
+        it('should ignore parent mutations made after iteration', () => {
           expect([...view]).toHaveLength(5);
           store.addQuad(q('s1', 'p1', 'oNEW'));
           expect([...view]).toHaveLength(5);
         });
 
-        it('ignores non-matching parent mutations', () => {
-          const store = buildStore();
-          const view = store.match(namedNode('s1'), null, null, null, opts);
+        it('should ignore non-matching parent mutations', () => {
           store.addQuad(q('s2', 'p1', 'oNEW'));
           expect([...view]).toHaveLength(5);
         });
 
-        it('supports its own independent mutations', () => {
-          const store = buildStore();
-          const view = store.match(namedNode('s1'), null, null, null, opts);
+        it('should support its own independent mutations', () => {
           view.add(q('s1', 'p1', 'oOWN'));
           expect(view.has(q('s1', 'p1', 'oOWN'))).toBe(true);
           // The parent is not affected by snapshot view mutations.
           expect(store.has(q('s1', 'p1', 'oOWN'))).toBe(false);
         });
 
-        it('exposes a stable toArray/toStream/union', async () => {
-          const store = buildStore();
-          const view = store.match(namedNode('s1'), null, null, null, opts);
+        it('should expose a stable toArray/toStream/union', async () => {
           expect(view.toArray()).toHaveLength(5);
           await expect(arrayifyStream(view.toStream())).resolves.toHaveLength(5);
           expect(view.union(new Store([q('s1', 'p1', 'oU')])).size).toBe(6);
         });
 
-        it('freezes on a matching mutation before a first toArray', () => {
-          const store = buildStore();
-          const view = store.match(namedNode('s1'), null, null, null, opts);
+        it('should freeze on a matching mutation before a first toArray', () => {
           store.addQuad(q('s1', 'p1', 'oNEW'));
           expect(view.toArray()).toHaveLength(5);
         });
 
-        it('does not mutate the parent through union', () => {
-          const store = buildStore();
-          const view = store.match(namedNode('s1'), null, null, null, opts);
+        it('should not mutate the parent through union', () => {
           const union = view.union([q('s1', 'p1', 'oU')]);
           expect(union.size).toBe(6);
           expect(store.has(q('s1', 'p1', 'oU'))).toBe(false);
@@ -947,18 +933,14 @@ describe('Store', () => {
           expect(union.size).toBe(6);
         });
 
-        it('keeps a nested match() frozen at nesting time', () => {
-          const store = buildStore();
-          const view = store.match(namedNode('s1'), null, null, null, opts);
+        it('should keep a nested match() frozen at nesting time', () => {
           const sub = view.match(null, namedNode('p1'));
           store.addQuad(q('s1', 'p1', 'oNEW'));
           expect([...sub]).toHaveLength(5);
           expect(sub.has(q('s1', 'p1', 'oNEW'))).toBe(false);
         });
 
-        it('supports detach() before and after materialization', () => {
-          const store = buildStore();
-          const view = store.match(namedNode('s1'), null, null, null, opts);
+        it('should support detach() before and after materialization', () => {
           view.detach();
           expect(store._observers).toBe(null);
           store.addQuad(q('s1', 'p1', 'oNEW'));
@@ -974,25 +956,25 @@ describe('Store', () => {
       describe('forwarded', () => {
         const opts = { matchSemantics: 'forwarded' };
 
-        it('reflects parent additions made BEFORE iteration', () => {
-          const store = buildStore();
-          const view = store.match(namedNode('s1'), null, null, null, opts);
+        let store, view;
+        beforeEach(() => {
+          store = buildStore();
+          view = store.match(namedNode('s1'), null, null, null, opts);
+        });
+
+        it('should reflect parent additions made before iteration', () => {
           store.addQuad(q('s1', 'p1', 'oNEW'));
           expect([...view]).toHaveLength(6);
           expect(view.has(q('s1', 'p1', 'oNEW'))).toBe(true);
         });
 
-        it('reflects parent deletions made BEFORE iteration', () => {
-          const store = buildStore();
-          const view = store.match(namedNode('s1'), null, null, null, opts);
+        it('should reflect parent deletions made before iteration', () => {
           store.removeQuad(q('s1', 'p1', 'o0'));
           expect([...view]).toHaveLength(4);
           expect(view.has(q('s1', 'p1', 'o0'))).toBe(false);
         });
 
-        it('keeps the running iteration stable across a parent ADD DURING sync iteration', () => {
-          const store = buildStore();
-          const view = store.match(namedNode('s1'), null, null, null, opts);
+        it('should keep the running iteration stable across a parent add during sync iteration', () => {
           const seen = [];
           let mutated = false;
           for (const quad of view) {
@@ -1008,9 +990,7 @@ describe('Store', () => {
           expect([...view]).toHaveLength(6);
         });
 
-        it('keeps the running iteration stable across a parent DELETE of an already-yielded quad', () => {
-          const store = buildStore();
-          const view = store.match(namedNode('s1'), null, null, null, opts);
+        it('should keep the running iteration stable across a parent delete of an already-yielded quad', () => {
           const seen = [];
           let mutated = false;
           for (const quad of view) {
@@ -1024,9 +1004,7 @@ describe('Store', () => {
           expect([...view]).toHaveLength(4);
         });
 
-        it('keeps the running iteration stable across a parent mutation DURING async iteration', async () => {
-          const store = buildStore();
-          const view = store.match(namedNode('s1'), null, null, null, opts);
+        it('should keep the running iteration stable across a parent mutation during async iteration', async () => {
           const seen = [];
           await new Promise((resolve, reject) => {
             let mutated = false;
@@ -1044,24 +1022,18 @@ describe('Store', () => {
           expect([...view]).toHaveLength(4);
         });
 
-        it('reflects parent mutations made AFTER iteration', () => {
-          const store = buildStore();
-          const view = store.match(namedNode('s1'), null, null, null, opts);
+        it('should reflect parent mutations made after iteration', () => {
           expect([...view]).toHaveLength(5);
           store.addQuad(q('s1', 'p1', 'oNEW'));
           expect([...view]).toHaveLength(6);
         });
 
-        it('ignores non-matching parent mutations', () => {
-          const store = buildStore();
-          const view = store.match(namedNode('s1'), null, null, null, opts);
+        it('should ignore non-matching parent mutations', () => {
           store.addQuad(q('s2', 'p1', 'oNEW'));
           expect([...view]).toHaveLength(5);
         });
 
-        it('writes view additions and deletions through to the parent', () => {
-          const store = buildStore();
-          const view = store.match(namedNode('s1'), null, null, null, opts);
+        it('should write view additions and deletions through to the parent', () => {
           view.add(q('s1', 'p1', 'oOWN'));
           expect(store.has(q('s1', 'p1', 'oOWN'))).toBe(true);
           expect(view.has(q('s1', 'p1', 'oOWN'))).toBe(true);
@@ -1070,9 +1042,7 @@ describe('Store', () => {
           expect(view.has(q('s1', 'p1', 'o0'))).toBe(false);
         });
 
-        it('forwards addAll and deleteMatches to the parent', () => {
-          const store = buildStore();
-          const view = store.match(namedNode('s1'), null, null, null, opts);
+        it('should forward addAll and deleteMatches to the parent', () => {
           view.addAll([q('s1', 'p1', 'oA'), q('s1', 'p1', 'oB')]);
           expect(store.has(q('s1', 'p1', 'oA'))).toBe(true);
           expect(view.size).toBe(7);
@@ -1080,9 +1050,7 @@ describe('Store', () => {
           expect(store.has(q('s1', 'p1', 'oA'))).toBe(false);
         });
 
-        it('writes non-matching mutations through to the parent unrestricted', () => {
-          const store = buildStore();
-          const view = store.match(namedNode('s1'), null, null, null, opts);
+        it('should write non-matching mutations through to the parent unrestricted', () => {
           // A non-matching add mutates the parent but never appears in the view
           view.add(q('s3', 'p1', 'oNM'));
           expect(store.has(q('s3', 'p1', 'oNM'))).toBe(true);
@@ -1097,9 +1065,7 @@ describe('Store', () => {
           expect(view.size).toBe(5);
         });
 
-        it('defers materialization of an unread view across parent mutations', () => {
-          const store = buildStore();
-          const view = store.match(namedNode('s1'), null, null, null, opts);
+        it('should defer materialization of an unread view across parent mutations', () => {
           store.addQuad(q('s1', 'p1', 'oNEW'));
           store.removeQuad(q('s1', 'p1', 'o0'));
           // Nothing has been read from the view, so it has not materialized
@@ -1107,9 +1073,7 @@ describe('Store', () => {
           expect(values(view)).toEqual(['o1', 'o2', 'o3', 'o4', 'oNEW']);
         });
 
-        it('applies parent mutations to an already-materialized view', () => {
-          const store = buildStore();
-          const view = store.match(namedNode('s1'), null, null, null, opts);
+        it('should apply parent mutations to an already-materialized view', () => {
           // Materialize the view before any parent mutation
           expect(view.size).toBe(5);
           store.addQuad(q('s1', 'p1', 'oNEW'));
@@ -1119,36 +1083,28 @@ describe('Store', () => {
           expect(view.size).toBe(5);
         });
 
-        it('forwards a Store addAll (bypassing the index-merge fast path) when observed', () => {
-          const store = buildStore();
-          const view = store.match(namedNode('s1'), null, null, null, opts);
+        it('should forward a Store addAll (bypassing the index-merge fast path) when observed', () => {
           const extra = new Store([], { entityIndex: store._entityIndex });
           extra.addQuad(q('s1', 'p1', 'oM'));
           store.addAll(extra);
           expect(view.has(q('s1', 'p1', 'oM'))).toBe(true);
         });
 
-        it('exposes a live toArray/toStream/union', async () => {
-          const store = buildStore();
-          const view = store.match(namedNode('s1'), null, null, null, opts);
+        it('should expose a live toArray/toStream/union', async () => {
           store.addQuad(q('s1', 'p1', 'oNEW'));
           expect(view.toArray()).toHaveLength(6);
           await expect(arrayifyStream(view.toStream())).resolves.toHaveLength(6);
           expect(view.union(new Store([q('s1', 'p1', 'oU')])).size).toBe(7);
         });
 
-        it('does not mutate the parent through union', () => {
-          const store = buildStore();
-          const view = store.match(namedNode('s1'), null, null, null, opts);
+        it('should not mutate the parent through union', () => {
           const union = view.union([q('s1', 'p1', 'oU')]);
           expect(union.size).toBe(6);
           expect(store.has(q('s1', 'p1', 'oU'))).toBe(false);
           expect(view.has(q('s1', 'p1', 'oU'))).toBe(false);
         });
 
-        it('stops observing the parent after detach()', () => {
-          const store = buildStore();
-          const view = store.match(namedNode('s1'), null, null, null, opts);
+        it('should stop observing the parent after detach()', () => {
           expect(view.detach()).toBe(view);
           expect(store._observers).toBe(null);
           // The view is frozen to its contents at detach time
@@ -1163,9 +1119,7 @@ describe('Store', () => {
           expect(view.size).toBe(6);
         });
 
-        it('downgrades a nested match() to a snapshot of the view', () => {
-          const store = buildStore();
-          const view = store.match(namedNode('s1'), null, null, null, opts);
+        it('should downgrade a nested match() to a snapshot of the view', () => {
           const sub = view.match(null, namedNode('p1'));
           expect([...sub]).toHaveLength(5);
           // Later root mutations reach the outer view, but not the nested snapshot
@@ -1179,16 +1133,15 @@ describe('Store', () => {
           expect(view.has(q('s1', 'p1', 'oSUB'))).toBe(false);
         });
 
-        it('handles matching mutations in the default graph', () => {
-          const store = new Store([q('s1', 'p1', 'o0')]);
-          const view = store.match(null, null, null, new DefaultGraph(), opts);
+        it('should handle matching mutations in the default graph', () => {
+          store = new Store([q('s1', 'p1', 'o0')]);
+          view = store.match(null, null, null, new DefaultGraph(), opts);
           store.addQuad(q('s1', 'p1', 'o1'));
           expect([...view]).toHaveLength(2);
         });
 
-        it('treats an empty-string graph pattern as the default graph', () => {
-          const store = buildStore();
-          const view = store.match(null, null, null, '', opts);
+        it('should treat an empty-string graph pattern as the default graph', () => {
+          view = store.match(null, null, null, '', opts);
           expect([...view]).toHaveLength(6);
           // A named-graph quad does not match a default-graph pattern
           store.addQuad(q('s3', 'p1', 'oG', 'g1'));
@@ -1199,9 +1152,7 @@ describe('Store', () => {
           expect([...view]).toHaveLength(7);
         });
 
-        it('stays stable when a parent mutation lands as the source is exhausted', () => {
-          const store = buildStore();
-          const view = store.match(namedNode('s1'), null, null, null, opts);
+        it('should stay stable when a parent mutation lands as the source is exhausted', () => {
           const seen = [];
           for (const quad of view) {
             seen.push(quad.object.value);
@@ -1213,9 +1164,7 @@ describe('Store', () => {
           expect([...view]).toHaveLength(6);
         });
 
-        it('captures a baseline from an already-materialized view mid-iteration', () => {
-          const store = buildStore();
-          const view = store.match(namedNode('s1'), null, null, null, opts);
+        it('should capture a baseline from an already-materialized view mid-iteration', () => {
           // Force materialization of `_filtered` via a first matching mutation.
           store.addQuad(q('s1', 'p1', 'oNEW'));
           expect(view.size).toBe(6);
@@ -1233,10 +1182,10 @@ describe('Store', () => {
           expect([...view]).toHaveLength(7);
         });
 
-        it('reflects additions of a pattern term absent at match() time', () => {
-          const store = new Store();
+        it('should reflect additions of a pattern term absent at match() time', () => {
+          store = new Store();
           // The subject `s9` is not present when the view is created.
-          const view = store.match(namedNode('s9'), null, null, null, opts);
+          view = store.match(namedNode('s9'), null, null, null, opts);
           expect([...view]).toHaveLength(0);
           // A mutation while `s9` is still absent cannot match the view
           store.addQuad(q('sOther', 'p1', 'o1'));
@@ -1246,16 +1195,14 @@ describe('Store', () => {
           expect(view.has(q('s9', 'p1', 'o1'))).toBe(true);
         });
 
-        it('ignores a re-added quad that already exists', () => {
-          const store = buildStore();
-          const view = store.match(namedNode('s1'), null, null, null, opts);
+        it('should ignore a re-added quad that already exists', () => {
           // Re-adding an existing quad must not notify observers nor change size.
           store.addQuad(q('s1', 'p1', 'o0'));
           expect([...view]).toHaveLength(5);
         });
 
-        it('matches across all pattern positions and the default graph', () => {
-          const store = new Store([q('s1', 'p1', 'o1')]);
+        it('should match across all pattern positions and the default graph', () => {
+          store = new Store([q('s1', 'p1', 'o1')]);
           // Wildcard pattern: every position is a wildcard.
           const wildcard = store.match(null, null, null, null, opts);
           // Fully specified pattern including the default graph.
@@ -1267,10 +1214,10 @@ describe('Store', () => {
           expect([...exact]).toHaveLength(1);
         });
 
-        it('does not match mutations differing in any single position', () => {
-          const store = new Store([new Quad(
+        it('should not match mutations differing in any single position', () => {
+          store = new Store([new Quad(
             namedNode('s1'), namedNode('p1'), namedNode('o1'), namedNode('g1'))]);
-          const view = store.match(
+          view = store.match(
             namedNode('s1'), namedNode('p1'), namedNode('o1'), namedNode('g1'), opts);
           // Each of these differs from the pattern in exactly one position.
           store.addQuad(new Quad(namedNode('sX'), namedNode('p1'), namedNode('o1'), namedNode('g1')));
@@ -1281,11 +1228,11 @@ describe('Store', () => {
           expect([...view]).toHaveLength(1);
         });
 
-        it('releases iteration state when its stream is destroyed mid-read', done => {
-          const store = new Store();
+        it('should release iteration state when its stream is destroyed mid-read', done => {
+          store = new Store();
           for (let i = 0; i < 20; i++)
             store.addQuad(q('s1', 'p1', `o${i}`));
-          const view = store.match(namedNode('s1'), null, null, null, opts);
+          view = store.match(namedNode('s1'), null, null, null, opts);
           // A partial read leaves the internal iterator suspended
           expect(view.read()).not.toBeNull();
           expect(view._activeIterators).toBe(1);
@@ -1309,9 +1256,7 @@ describe('Store', () => {
           view.destroy();
         });
 
-        it('supports destroying its stream before any read', done => {
-          const store = buildStore();
-          const view = store.match(namedNode('s1'), null, null, null, opts);
+        it('should support destroying its stream before any read', done => {
           view.once('close', () => {
             // The dataset side of the view remains usable
             expect(view.size).toBe(5);
@@ -1320,9 +1265,7 @@ describe('Store', () => {
           view.destroy();
         });
 
-        it('keeps concurrent iterations stable', () => {
-          const store = buildStore();
-          const view = store.match(namedNode('s1'), null, null, null, opts);
+        it('should keep concurrent iterations stable', () => {
           const outer = [];
           const inner = [];
           for (const a of view) {
@@ -1338,12 +1281,12 @@ describe('Store', () => {
           expect(outer.sort()).toEqual(['o0', 'o1', 'o2', 'o3', 'o4']);
         });
 
-        it('keeps an overlapping iteration stable after a baseline freeze', () => {
-          const store = new Store();
+        it('should keep an overlapping iteration stable after a baseline freeze', () => {
+          store = new Store();
           // Spread the quads across predicate buckets, so deletions hit levels not yet iterated
           for (let i = 0; i < 5; i++)
             store.addQuad(q('s1', `p${i}`, 'o1'));
-          const view = store.match(namedNode('s1'), null, null, null, opts);
+          view = store.match(namedNode('s1'), null, null, null, opts);
           const outer = view[Symbol.iterator]();
           expect(outer.next().done).toBe(false);
           // This mutation freezes a baseline for the in-progress outer iteration

--- a/test/N3Store-test.js
+++ b/test/N3Store-test.js
@@ -1284,6 +1284,38 @@ describe('Store', () => {
           expect(inner).toHaveLength(5);
           expect(outer.sort()).toEqual(['o0', 'o1', 'o2', 'o3', 'o4']);
         });
+
+        it('keeps an overlapping iteration stable after a baseline freeze', () => {
+          const store = new Store();
+          // Spread the quads across predicate buckets, so deletions hit levels not yet iterated
+          for (let i = 0; i < 5; i++)
+            store.addQuad(q('s1', `p${i}`, 'o1'));
+          const view = store.match(namedNode('s1'), null, null, null, opts);
+          const outer = view[Symbol.iterator]();
+          expect(outer.next().done).toBe(false);
+          // This mutation freezes a baseline for the in-progress outer iteration
+          store.addQuad(q('s1', 'pNEW', 'o1'));
+          // An iteration starting now must also stay stable across further matching mutations
+          const seen = [];
+          let mutated = false;
+          for (const quad of view) {
+            seen.push(quad.predicate.value);
+            if (!mutated) {
+              mutated = true;
+              store.removeQuad(q('s1', 'p3', 'o1'));
+              store.removeQuad(q('s1', 'p4', 'o1'));
+            }
+          }
+          expect(seen).toHaveLength(6);
+          expect(seen).toEqual(expect.arrayContaining(['p3', 'p4', 'pNEW']));
+          // The outer iteration still yields the quads from its own start
+          const rest = [];
+          for (let next = outer.next(); !next.done; next = outer.next())
+            rest.push(next.value.predicate.value);
+          expect(rest).toHaveLength(4);
+          expect(rest).toEqual(expect.arrayContaining(['p3', 'p4']));
+          expect(rest).not.toContain('pNEW');
+        });
       });
     });
 

--- a/test/N3Store-test.js
+++ b/test/N3Store-test.js
@@ -1080,6 +1080,23 @@ describe('Store', () => {
           expect(store.has(q('s1', 'p1', 'oA'))).toBe(false);
         });
 
+        it('writes non-matching mutations through to the parent unrestricted', () => {
+          const store = buildStore();
+          const view = store.match(namedNode('s1'), null, null, null, opts);
+          // A non-matching add mutates the parent but never appears in the view
+          view.add(q('s3', 'p1', 'oNM'));
+          expect(store.has(q('s3', 'p1', 'oNM'))).toBe(true);
+          expect(view.has(q('s3', 'p1', 'oNM'))).toBe(false);
+          // A non-matching addAll grows the parent, not the view
+          view.addAll([q('s3', 'p1', 'oNM2')]);
+          expect(store.has(q('s3', 'p1', 'oNM2'))).toBe(true);
+          expect(view.size).toBe(5);
+          // A deleteMatches wider than the pattern deletes parent quads outside the view
+          view.deleteMatches(namedNode('s2'), null, null);
+          expect(store.has(q('s2', 'p1', 'oX'))).toBe(false);
+          expect(view.size).toBe(5);
+        });
+
         it('defers materialization of an unread view across parent mutations', () => {
           const store = buildStore();
           const view = store.match(namedNode('s1'), null, null, null, opts);

--- a/test/N3Store-test.js
+++ b/test/N3Store-test.js
@@ -793,6 +793,24 @@ describe('Store', () => {
         expect(values(view)).not.toContain('oNEW');
       });
 
+      it('keeps internal match() calls lazy under a non-lazy store default', async () => {
+        for (const matchSemantics of ['snapshot', 'forwarded']) {
+          const store = buildStore({ matchSemantics });
+          store.deleteMatches(namedNode('s2'), null, null);
+          expect(store.size).toBe(5);
+          expect(store._observers).toBe(null);
+          await expect(arrayifyStream(store.toStream())).resolves.toHaveLength(5);
+          expect(store._observers).toBe(null);
+        }
+      });
+
+      it('keeps toStream() on a lazy view lazy under a forwarded store default', async () => {
+        const store = buildStore({ matchSemantics: 'forwarded' });
+        const view = store.match(namedNode('s1'), null, null, null, { matchSemantics: 'lazy' });
+        await expect(arrayifyStream(view.toStream())).resolves.toHaveLength(5);
+        expect(store._observers).toBe(null);
+      });
+
       it('does not write union() contents through to a store with a forwarded default', () => {
         const store = buildStore({ matchSemantics: 'forwarded' });
         const view = store.match(namedNode('s1'), null, null, null, { matchSemantics: 'lazy' });

--- a/test/N3Store-test.js
+++ b/test/N3Store-test.js
@@ -830,6 +830,18 @@ describe('Store', () => {
         expect([...b]).toHaveLength(5);
       });
 
+      it('should detach both observers when one mutation notifies two snapshot views', () => {
+        const store = buildStore();
+        // Two live snapshot views; a single matching mutation notifies both, and each
+        // observer unregisters itself mid-notification while the other is still pending.
+        const a = store.match(namedNode('s1'), null, null, null, { matchSemantics: 'snapshot' });
+        const b = store.match(namedNode('s1'), null, null, null, { matchSemantics: 'snapshot' });
+        store.addQuad(q('s1', 'p1', 'oNEW'));
+        expect(store._observers).toBe(null);
+        expect([...a]).toHaveLength(5);
+        expect([...b]).toHaveLength(5);
+      });
+
       it('should stop observing when a snapshot with an absent pattern term materializes', () => {
         const store = buildStore();
         const view = store.match(namedNode('sNONE'), null, null, null, { matchSemantics: 'snapshot' });

--- a/test/N3Store-test.js
+++ b/test/N3Store-test.js
@@ -840,6 +840,18 @@ describe('Store', () => {
         expect([...b]).toHaveLength(5);
       });
 
+      it('should detach both observers when one mutation notifies two snapshot views', () => {
+        const store = buildStore();
+        // Two live snapshot views; a single matching mutation notifies both, and each
+        // observer unregisters itself mid-notification while the other is still pending.
+        const a = store.match(namedNode('s1'), null, null, null, { matchSemantics: 'snapshot' });
+        const b = store.match(namedNode('s1'), null, null, null, { matchSemantics: 'snapshot' });
+        store.addQuad(q('s1', 'p1', 'oNEW'));
+        expect(store._observers).toBe(null);
+        expect([...a]).toHaveLength(5);
+        expect([...b]).toHaveLength(5);
+      });
+
       it('should stop observing when a snapshot with an absent pattern term materializes', () => {
         const store = buildStore();
         const view = store.match(namedNode('sNONE'), null, null, null, { matchSemantics: 'snapshot' });

--- a/test/N3Store-test.js
+++ b/test/N3Store-test.js
@@ -793,6 +793,16 @@ describe('Store', () => {
         expect(values(view)).not.toContain('oNEW');
       });
 
+      it('does not write union() contents through to a store with a forwarded default', () => {
+        const store = buildStore({ matchSemantics: 'forwarded' });
+        const view = store.match(namedNode('s1'), null, null, null, { matchSemantics: 'lazy' });
+        const union = view.union([q('s1', 'p1', 'oU')]);
+        expect(union.size).toBe(6);
+        expect(union.has(q('s1', 'p1', 'oU'))).toBe(true);
+        expect(store.size).toBe(6);
+        expect(store.has(q('s1', 'p1', 'oU'))).toBe(false);
+      });
+
       it('detaches a single observer while another remains attached', () => {
         const store = buildStore();
         // Two snapshot views observe the store concurrently.
@@ -894,6 +904,24 @@ describe('Store', () => {
           expect(view.toArray()).toHaveLength(5);
           await expect(arrayifyStream(view.toStream())).resolves.toHaveLength(5);
           expect(view.union(new Store([q('s1', 'p1', 'oU')])).size).toBe(6);
+        });
+
+        it('freezes on a matching mutation before a first toArray', () => {
+          const store = buildStore();
+          const view = store.match(namedNode('s1'), null, null, null, opts);
+          store.addQuad(q('s1', 'p1', 'oNEW'));
+          expect(view.toArray()).toHaveLength(5);
+        });
+
+        it('does not mutate the parent through union', () => {
+          const store = buildStore();
+          const view = store.match(namedNode('s1'), null, null, null, opts);
+          const union = view.union([q('s1', 'p1', 'oU')]);
+          expect(union.size).toBe(6);
+          expect(store.has(q('s1', 'p1', 'oU'))).toBe(false);
+          // The union result is independent of later parent mutations
+          store.addQuad(q('s1', 'p1', 'oNEW'));
+          expect(union.size).toBe(6);
         });
       });
 
@@ -1044,6 +1072,15 @@ describe('Store', () => {
           expect(view.toArray()).toHaveLength(6);
           await expect(arrayifyStream(view.toStream())).resolves.toHaveLength(6);
           expect(view.union(new Store([q('s1', 'p1', 'oU')])).size).toBe(7);
+        });
+
+        it('does not mutate the parent through union', () => {
+          const store = buildStore();
+          const view = store.match(namedNode('s1'), null, null, null, opts);
+          const union = view.union([q('s1', 'p1', 'oU')]);
+          expect(union.size).toBe(6);
+          expect(store.has(q('s1', 'p1', 'oU'))).toBe(false);
+          expect(view.has(q('s1', 'p1', 'oU'))).toBe(false);
         });
 
         it('handles matching mutations in the default graph', () => {

--- a/test/N3Store-test.js
+++ b/test/N3Store-test.js
@@ -741,6 +741,8 @@ describe('Store', () => {
     });
 
     describe('match semantics', () => {
+      const initialValues = ['o0', 'o1', 'o2', 'o3', 'o4'];
+
       function q(s, p, o, g) {
         return new Quad(new NamedNode(s), new NamedNode(p), new NamedNode(o), g ? new NamedNode(g) : undefined);
       }
@@ -748,10 +750,20 @@ describe('Store', () => {
         return [...view].map(x => x.object.value).sort();
       }
 
+      function valuesWithMutationAfterFirstQuad(view, mutate) {
+        const seen = [];
+        for (const quad of view) {
+          seen.push(quad.object.value);
+          if (seen.length === 1)
+            mutate(quad);
+        }
+        return seen.sort();
+      }
+
       function buildStore(options) {
         const store = new Store([], options);
-        for (let i = 0; i < 5; i++)
-          store.addQuad(q('s1', 'p1', `o${i}`));
+        for (const object of initialValues)
+          store.addQuad(q('s1', 'p1', object));
         store.addQuad(q('s2', 'p1', 'oX'));
         return store;
       }
@@ -897,9 +909,9 @@ describe('Store', () => {
           parent.add(q('s1', 'p1', 'oPARENT'));
           child.add(q('s1', 'p1', 'oCHILD'));
 
-          expect(values(parent)).toEqual(['o0', 'o1', 'o2', 'o3', 'o4', 'oPARENT']);
-          expect(values(child)).toEqual(['o0', 'o1', 'o2', 'o3', 'o4', 'oCHILD']);
-          expect(values(leaf)).toEqual(['o0', 'o1', 'o2', 'o3', 'o4', 'oCHILD']);
+          expect(values(parent)).toEqual([...initialValues, 'oPARENT']);
+          expect(values(child)).toEqual([...initialValues, 'oCHILD']);
+          expect(values(leaf)).toEqual([...initialValues, 'oCHILD']);
         });
 
         it('should preserve each snapshot boundary in a match chain', () => {
@@ -912,9 +924,9 @@ describe('Store', () => {
           parent.add(q('s1', 'p1', 'oPARENT'));
           child.add(q('s1', 'p1', 'oCHILD'));
 
-          expect(values(parent)).toEqual(['o0', 'o1', 'o2', 'o3', 'o4', 'oPARENT']);
-          expect(values(child)).toEqual(['o0', 'o1', 'o2', 'o3', 'o4', 'oCHILD']);
-          expect(values(leaf)).toEqual(['o0', 'o1', 'o2', 'o3', 'o4']);
+          expect(values(parent)).toEqual([...initialValues, 'oPARENT']);
+          expect(values(child)).toEqual([...initialValues, 'oCHILD']);
+          expect(values(leaf)).toEqual(initialValues);
         });
 
         it('should downgrade forwarded descendants to snapshots', () => {
@@ -927,9 +939,9 @@ describe('Store', () => {
           parent.add(q('s1', 'p1', 'oPARENT'));
           child.add(q('s1', 'p1', 'oCHILD'));
 
-          expect(values(parent)).toEqual(['o0', 'o1', 'o2', 'o3', 'o4', 'oPARENT', 'oROOT']);
-          expect(values(child)).toEqual(['o0', 'o1', 'o2', 'o3', 'o4', 'oCHILD']);
-          expect(values(leaf)).toEqual(['o0', 'o1', 'o2', 'o3', 'o4']);
+          expect(values(parent)).toEqual([...initialValues, 'oPARENT', 'oROOT']);
+          expect(values(child)).toEqual([...initialValues, 'oCHILD']);
+          expect(values(leaf)).toEqual(initialValues);
           expect(store.has(q('s1', 'p1', 'oPARENT'))).toBe(true);
           expect(store.has(q('s1', 'p1', 'oCHILD'))).toBe(false);
         });
@@ -959,17 +971,11 @@ describe('Store', () => {
         });
 
         it('should ignore a parent mutation that lands during sync iteration', () => {
-          const seen = [];
-          let mutated = false;
-          for (const quad of view) {
-            seen.push(quad.object.value);
-            if (!mutated) {
-              mutated = true;
-              store.addQuad(q('s1', 'p1', 'oNEW'));
-              store.removeQuad(q('s1', 'p1', 'o4'));
-            }
-          }
-          expect(seen.sort()).toEqual(['o0', 'o1', 'o2', 'o3', 'o4']);
+          const seen = valuesWithMutationAfterFirstQuad(view, () => {
+            store.addQuad(q('s1', 'p1', 'oNEW'));
+            store.removeQuad(q('s1', 'p1', 'o4'));
+          });
+          expect(seen).toEqual(initialValues);
         });
 
         it('should ignore a parent mutation that lands during async iteration', async () => {
@@ -987,7 +993,7 @@ describe('Store', () => {
             view.on('error', reject);
           });
           expect(seen).not.toContain('oNEW');
-          expect(seen.sort()).toEqual(['o0', 'o1', 'o2', 'o3', 'o4']);
+          expect(seen.sort()).toEqual(initialValues);
         });
 
         it('should ignore parent mutations made after iteration', () => {
@@ -1067,30 +1073,16 @@ describe('Store', () => {
         });
 
         it('should keep the running iteration stable across a parent add during sync iteration', () => {
-          const seen = [];
-          let mutated = false;
-          for (const quad of view) {
-            seen.push(quad.object.value);
-            if (!mutated) {
-              mutated = true;
-              store.addQuad(q('s1', 'p1', 'oNEW'));
-            }
-          }
-          expect(seen.sort()).toEqual(['o0', 'o1', 'o2', 'o3', 'o4']);
+          const seen = valuesWithMutationAfterFirstQuad(view,
+            () => store.addQuad(q('s1', 'p1', 'oNEW')));
+          expect(seen).toEqual(initialValues);
           expect([...view]).toHaveLength(6);
         });
 
         it('should keep the running iteration stable across a parent delete of an already-yielded quad', () => {
-          const seen = [];
-          let mutated = false;
-          for (const quad of view) {
-            seen.push(quad.object.value);
-            if (!mutated) {
-              mutated = true;
-              store.removeQuad(q('s1', 'p1', quad.object.value));
-            }
-          }
-          expect(seen.sort()).toEqual(['o0', 'o1', 'o2', 'o3', 'o4']);
+          const seen = valuesWithMutationAfterFirstQuad(view,
+            quad => store.removeQuad(q('s1', 'p1', quad.object.value)));
+          expect(seen).toEqual(initialValues);
           expect([...view]).toHaveLength(4);
         });
 
@@ -1108,7 +1100,7 @@ describe('Store', () => {
             view.on('end', resolve);
             view.on('error', reject);
           });
-          expect(seen.sort()).toEqual(['o0', 'o1', 'o2', 'o3', 'o4']);
+          expect(seen.sort()).toEqual(initialValues);
           expect([...view]).toHaveLength(4);
         });
 
@@ -1246,23 +1238,16 @@ describe('Store', () => {
             if (seen.length === 5)
               store.addQuad(q('s1', 'p1', 'oNEW'));
           }
-          expect(seen.sort()).toEqual(['o0', 'o1', 'o2', 'o3', 'o4']);
+          expect(seen.sort()).toEqual(initialValues);
           expect([...view]).toHaveLength(6);
         });
 
         it('should capture a baseline from an already-materialized view mid-iteration', () => {
           store.addQuad(q('s1', 'p1', 'oNEW'));
           expect(view.size).toBe(6);
-          const seen = [];
-          let mutated = false;
-          for (const quad of view) {
-            seen.push(quad.object.value);
-            if (!mutated) {
-              mutated = true;
-              store.addQuad(q('s1', 'p1', 'oNEW2'));
-            }
-          }
-          expect(seen.sort()).toEqual(['o0', 'o1', 'o2', 'o3', 'o4', 'oNEW']);
+          const seen = valuesWithMutationAfterFirstQuad(view,
+            () => store.addQuad(q('s1', 'p1', 'oNEW2')));
+          expect(seen).toEqual([...initialValues, 'oNEW']);
           expect([...view]).toHaveLength(7);
         });
 
@@ -1316,15 +1301,8 @@ describe('Store', () => {
           view.once('close', () => {
             expect(view._activeIterators).toBe(0);
             store.addQuad(q('s1', 'p1', 'oNEW'));
-            const seen = [];
-            let mutated = false;
-            for (const quad of view) {
-              seen.push(quad.object.value);
-              if (!mutated) {
-                mutated = true;
-                store.addQuad(q('s1', 'p1', 'oNEW2'));
-              }
-            }
+            const seen = valuesWithMutationAfterFirstQuad(view,
+              () => store.addQuad(q('s1', 'p1', 'oNEW2')));
             expect(seen).toHaveLength(21);
             done();
           });
@@ -1351,7 +1329,7 @@ describe('Store', () => {
             }
           }
           expect(inner).toHaveLength(5);
-          expect(outer.sort()).toEqual(['o0', 'o1', 'o2', 'o3', 'o4']);
+          expect(outer.sort()).toEqual(initialValues);
         });
 
         it('should keep an overlapping iteration stable after a baseline freeze', () => {

--- a/test/N3Store-test.js
+++ b/test/N3Store-test.js
@@ -1203,6 +1203,45 @@ describe('Store', () => {
           expect([...view]).toHaveLength(1);
         });
 
+        it('releases iteration state when its stream is destroyed mid-read', done => {
+          const store = new Store();
+          for (let i = 0; i < 20; i++)
+            store.addQuad(q('s1', 'p1', `o${i}`));
+          const view = store.match(namedNode('s1'), null, null, null, opts);
+          // A partial read leaves the internal iterator suspended
+          expect(view.read()).not.toBeNull();
+          expect(view._activeIterators).toBe(1);
+          view.once('close', () => {
+            expect(view._activeIterators).toBe(0);
+            // With no live iterators, this mutation must not freeze a baseline
+            store.addQuad(q('s1', 'p1', 'oNEW'));
+            // A later pass is still protected against mid-pass mutations
+            const seen = [];
+            let mutated = false;
+            for (const quad of view) {
+              seen.push(quad.object.value);
+              if (!mutated) {
+                mutated = true;
+                store.addQuad(q('s1', 'p1', 'oNEW2'));
+              }
+            }
+            expect(seen).toHaveLength(21);
+            done();
+          });
+          view.destroy();
+        });
+
+        it('supports destroying its stream before any read', done => {
+          const store = buildStore();
+          const view = store.match(namedNode('s1'), null, null, null, opts);
+          view.once('close', () => {
+            // The dataset side of the view remains usable
+            expect(view.size).toBe(5);
+            done();
+          });
+          view.destroy();
+        });
+
         it('keeps concurrent iterations stable', () => {
           const store = buildStore();
           const view = store.match(namedNode('s1'), null, null, null, opts);

--- a/test/N3Store-test.js
+++ b/test/N3Store-test.js
@@ -1108,6 +1108,19 @@ describe('Store', () => {
           expect([...view]).toHaveLength(2);
         });
 
+        it('treats an empty-string graph pattern as the default graph', () => {
+          const store = buildStore();
+          const view = store.match(null, null, null, '', opts);
+          expect([...view]).toHaveLength(6);
+          // A named-graph quad does not match a default-graph pattern
+          store.addQuad(q('s3', 'p1', 'oG', 'g1'));
+          expect([...view]).toHaveLength(6);
+          expect(view.has(q('s3', 'p1', 'oG', 'g1'))).toBe(false);
+          // A default-graph quad does match
+          store.addQuad(q('s3', 'p1', 'oD'));
+          expect([...view]).toHaveLength(7);
+        });
+
         it('stays stable when a parent mutation lands as the source is exhausted', () => {
           const store = buildStore();
           const view = store.match(namedNode('s1'), null, null, null, opts);

--- a/test/N3Store-test.js
+++ b/test/N3Store-test.js
@@ -782,7 +782,9 @@ describe('Store', () => {
       });
 
       it('should preserve match() arity', () => {
-        expect(buildStore().match).toHaveLength(4);
+        const store = buildStore();
+        expect(store.match).toHaveLength(4);
+        expect(store.match().match).toHaveLength(4);
       });
 
       it('should preserve a lazy iterator source after materialization', () => {
@@ -810,8 +812,43 @@ describe('Store', () => {
           expect(() => new Store([], { matchSemantics })).toThrow(message);
           expect(() => buildStore().match(
             namedNode('s1'), null, null, null, { matchSemantics })).toThrow(message);
+          const view = buildStore().match(namedNode('s1'));
+          expect(() => view.match(
+            null, namedNode('p1'), null, null, { matchSemantics })).toThrow(message);
         },
       );
+
+      it.each(['lazy', 'snapshot', 'forwarded'])(
+        'should accept an explicit inherited %s matchSemantics on a view',
+        matchSemantics => {
+          const store = buildStore();
+          const view = store.match(namedNode('s1'), null, null, null, { matchSemantics });
+          const child = view.match(null, namedNode('p1'), null, null, { matchSemantics });
+          expect([...child]).toHaveLength(5);
+        },
+      );
+
+      it('should inherit view semantics when options omit matchSemantics', () => {
+        const store = buildStore();
+        const view = store.match(namedNode('s1'), null, null, null, { matchSemantics: 'forwarded' });
+        const child = view.match(null, namedNode('p1'), null, null, {});
+        store.addQuad(q('s1', 'p1', 'oNEW'));
+        expect(child.has(q('s1', 'p1', 'oNEW'))).toBe(true);
+      });
+
+      it.each([
+        ['lazy', 'snapshot'],
+        ['snapshot', 'forwarded'],
+        ['forwarded', 'lazy'],
+      ])('should reject overriding view semantics from %s to %s', (inherited, requested) => {
+        const store = buildStore();
+        const view = store.match(namedNode('s1'), null, null, null, { matchSemantics: inherited });
+        const observerCount = store._observers && store._observers.size;
+        expect(() => view.match(null, namedNode('p1'), null, null, { matchSemantics: requested }))
+          .toThrow(`Cannot override matchSemantics on a view: inherited "${inherited}", received "${requested}"`);
+        expect(view._filtered).toBeUndefined();
+        expect(store._observers && store._observers.size).toBe(observerCount);
+      });
 
       it('should use the store-level default matchSemantics', () => {
         const store = buildStore({ matchSemantics: 'snapshot' });
@@ -996,21 +1033,90 @@ describe('Store', () => {
           expect(values(leaf)).toEqual(initialValues);
         });
 
-        it('should downgrade forwarded descendants to snapshots', () => {
-          const store = buildStore();
+        it('should forward recursively through a match chain', () => {
+          const store = new Store([
+            q('s1', 'p1', 'o1'),
+            q('s1', 'p2', 'o2'),
+            q('s2', 'p1', 'o3'),
+          ]);
           const parent = store.match(namedNode('s1'), null, null, null, { matchSemantics: 'forwarded' });
           const child = parent.match(null, namedNode('p1'));
           const leaf = child.match();
 
+          expect(parent._filtered).toBeUndefined();
+          expect(store._observers.size).toBe(3);
           store.addQuad(q('s1', 'p1', 'oROOT'));
-          parent.add(q('s1', 'p1', 'oPARENT'));
-          child.add(q('s1', 'p1', 'oCHILD'));
+          expect(leaf.add(q('s1', 'p1', 'oLEAF'))).toBe(leaf);
+          expect(leaf.delete(q('s1', 'p1', 'o1'))).toBe(leaf);
 
-          expect(values(parent)).toEqual([...initialValues, 'oPARENT', 'oROOT']);
-          expect(values(child)).toEqual([...initialValues, 'oCHILD']);
-          expect(values(leaf)).toEqual(initialValues);
-          expect(store.has(q('s1', 'p1', 'oPARENT'))).toBe(true);
-          expect(store.has(q('s1', 'p1', 'oCHILD'))).toBe(false);
+          expect(store.has(q('s1', 'p1', 'oLEAF'))).toBe(true);
+          expect(store.has(q('s1', 'p1', 'o1'))).toBe(false);
+          expect(values(parent).sort()).toEqual(['o2', 'oLEAF', 'oROOT']);
+          expect(values(child).sort()).toEqual(['oLEAF', 'oROOT']);
+          expect(values(leaf).sort()).toEqual(['oLEAF', 'oROOT']);
+          expect(store.size).toBe(4);
+        });
+
+        it('should keep a conflicting forwarded descendant empty', () => {
+          const store = buildStore();
+          const parent = store.match(namedNode('s1'), null, null, null, { matchSemantics: 'forwarded' });
+          const child = parent.match(namedNode('s2'));
+          const leaf = child.match(null, namedNode('p1'));
+
+          expect(store._observers.size).toBe(1);
+          expect([...child]).toHaveLength(0);
+          expect([...leaf]).toHaveLength(0);
+          expect(child.deleteMatches()).toBe(child);
+          expect(store.size).toBe(6);
+          store.addQuad(q('s2', 'p1', 'oNEW'));
+          expect([...child]).toHaveLength(0);
+          expect(() => child.add(q('s2', 'p1', 'oCHILD')))
+            .toThrow('Cannot add a quad that does not match the forwarded view pattern');
+          expect(store.has(q('s2', 'p1', 'oCHILD'))).toBe(false);
+        });
+
+        it('should intersect nested default graph patterns', () => {
+          const store = new Store([
+            q('s1', 'p1', 'o1'),
+            q('s1', 'p1', 'o2', 'g1'),
+          ]);
+          const parent = store.match(null, null, null, new DefaultGraph(), { matchSemantics: 'forwarded' });
+          const child = parent.match(null, null, null, '');
+          const conflicting = child.match(null, null, null, namedNode('g1'));
+
+          expect([...child]).toEqual([q('s1', 'p1', 'o1')]);
+          expect([...conflicting]).toHaveLength(0);
+          expect(store._observers.size).toBe(2);
+          expect(child.add(q('s2', 'p1', 'o2'))).toBe(child);
+          expect(store.has(q('s2', 'p1', 'o2'))).toBe(true);
+        });
+
+        it('should scope recursive deleteMatches to every ancestor pattern', () => {
+          const store = new Store([
+            q('s1', 'p1', 'o1'),
+            q('s1', 'p2', 'o2'),
+            q('s2', 'p1', 'o3'),
+          ]);
+          const parent = store.match(namedNode('s1'), null, null, null, { matchSemantics: 'forwarded' });
+          const child = parent.match(null, namedNode('p1'));
+
+          expect(() => child.add(q('s1', 'p2', 'oNEW')))
+            .toThrow('Cannot add a quad that does not match the forwarded view pattern');
+          expect(child.deleteMatches()).toBe(child);
+          expect(store.has(q('s1', 'p1', 'o1'))).toBe(false);
+          expect(store.has(q('s1', 'p2', 'o2'))).toBe(true);
+          expect(store.has(q('s2', 'p1', 'o3'))).toBe(true);
+        });
+
+        it('should keep a nested forwarded iterator stable across a root mutation', () => {
+          const store = new Store([q('s1', 'p1', 'o1'), q('s1', 'p1', 'o2')]);
+          const parent = store.match(namedNode('s1'), null, null, null, { matchSemantics: 'forwarded' });
+          const child = parent.match(null, namedNode('p1'));
+          const iterator = child[Symbol.iterator]();
+          const first = iterator.next().value;
+          store.removeQuad(q('s1', 'p1', first.object.value === 'o1' ? 'o2' : 'o1'));
+          expect(values([first, ...iterator])).toEqual(['o1', 'o2']);
+          expect([...child]).toHaveLength(1);
         });
       });
 
@@ -1214,12 +1320,20 @@ describe('Store', () => {
           expect(view.has(q('s1', 'p1', 'o0'))).toBe(false);
         });
 
-        it('should forward addAll and deleteMatches to the parent', () => {
-          expect(view.addAll([q('s1', 'p1', 'oA'), q('s1', 'p1', 'oB')])).toBe(view);
-          expect(store.has(q('s1', 'p1', 'oA'))).toBe(true);
+        it('should forward addAll incrementally and deleteMatches to the parent', () => {
+          const first = q('s1', 'p1', 'oA'), second = q('s1', 'p1', 'oB');
+          function* additions() {
+            yield first;
+            if (store.has(first))
+              yield second;
+          }
+
+          expect(view.addAll(additions())).toBe(view);
+          expect(store.has(first)).toBe(true);
+          expect(store.has(second)).toBe(true);
           expect(view.size).toBe(7);
-          expect(view.deleteMatches(namedNode('s1'), namedNode('p1'), namedNode('oA'))).toBe(view);
-          expect(store.has(q('s1', 'p1', 'oA'))).toBe(false);
+          expect(view.deleteMatches(first.subject, first.predicate, first.object)).toBe(view);
+          expect(store.has(first)).toBe(false);
         });
 
         it('should write import() through to the parent', done => {
@@ -1231,16 +1345,36 @@ describe('Store', () => {
           });
         });
 
-        it('should write non-matching mutations through to the parent unrestricted', () => {
-          view.add(q('s3', 'p1', 'oNM'));
-          expect(store.has(q('s3', 'p1', 'oNM'))).toBe(true);
-          expect(view.has(q('s3', 'p1', 'oNM'))).toBe(false);
-          view.addAll([q('s3', 'p1', 'oNM2')]);
-          expect(store.has(q('s3', 'p1', 'oNM2'))).toBe(true);
-          expect(view.size).toBe(5);
-          view.deleteMatches(namedNode('s2'), null, null);
-          expect(store.has(q('s2', 'p1', 'oX'))).toBe(false);
-          expect(view.size).toBe(5);
+        it('should reject additions outside the view pattern', () => {
+          const matching = q('s1', 'p1', 'oA'), nonMatching = q('s2', 'p1', 'oB');
+          const message = 'Cannot add a quad that does not match the forwarded view pattern';
+
+          expect(() => view.add(nonMatching)).toThrow(message);
+          expect(store.has(nonMatching)).toBe(false);
+          expect(() => view.addAll([matching, nonMatching])).toThrow(message);
+          expect(store.has(matching)).toBe(true);
+          expect(store.has(nonMatching)).toBe(false);
+        });
+
+        it('should constrain deletions to the view pattern', () => {
+          const outside = q('s2', 'p1', 'oX');
+          expect(view.delete(outside)).toBe(view);
+          expect(store.has(outside)).toBe(true);
+          expect(view.deleteMatches(namedNode('s2'))).toBe(view);
+          expect(store.has(outside)).toBe(true);
+          expect(view.deleteMatches()).toBe(view);
+          expect([...view]).toHaveLength(0);
+          expect(store.has(outside)).toBe(true);
+        });
+
+        it('should emit an error when import contains a quad outside the view pattern', async () => {
+          const nonMatching = q('s2', 'p1', 'oI');
+          const stream = new ArrayReader([nonMatching]);
+          const error = new Promise(resolve => stream.on('error', resolve));
+          expect(view.import(stream)).toBe(stream);
+          await expect(error).resolves.toHaveProperty(
+            'message', 'Cannot add a quad that does not match the forwarded view pattern');
+          expect(store.has(nonMatching)).toBe(false);
         });
 
         it('should defer materialization of an unread view across parent mutations', () => {
@@ -1321,16 +1455,25 @@ describe('Store', () => {
           expect(values(view)).toEqual(['o1', 'o2']);
         });
 
-        it('should downgrade a nested match() to a snapshot of the view', () => {
+        it('should keep a materialized nested match() forwarded to the root', () => {
           const sub = view.match(null, namedNode('p1'));
-          expect([...sub]).toHaveLength(5);
+          expect(sub.size).toBe(5);
           store.addQuad(q('s1', 'p1', 'oNEW'));
           expect(view.has(q('s1', 'p1', 'oNEW'))).toBe(true);
-          expect([...sub]).toHaveLength(5);
-          sub.add(q('s1', 'p1', 'oSUB'));
-          expect(sub.has(q('s1', 'p1', 'oSUB'))).toBe(true);
-          expect(store.has(q('s1', 'p1', 'oSUB'))).toBe(false);
-          expect(view.has(q('s1', 'p1', 'oSUB'))).toBe(false);
+          expect([...sub]).toHaveLength(6);
+          expect(sub.add(q('s1', 'p1', 'oSUB'))).toBe(sub);
+          expect(store.has(q('s1', 'p1', 'oSUB'))).toBe(true);
+          expect(view.has(q('s1', 'p1', 'oSUB'))).toBe(true);
+        });
+
+        it('should detach nested forwarded views independently', () => {
+          const sub = view.match(null, namedNode('p1'));
+          view.detach();
+          store.addQuad(q('s1', 'p1', 'oROOT'));
+          expect(view.has(q('s1', 'p1', 'oROOT'))).toBe(false);
+          expect(sub.has(q('s1', 'p1', 'oROOT'))).toBe(true);
+          expect(sub.detach()).toBe(sub);
+          expect(store._observers).toBe(null);
         });
 
         it('should handle matching mutations in the default graph', () => {
@@ -1343,10 +1486,12 @@ describe('Store', () => {
         it('should treat an empty-string graph pattern as the default graph', () => {
           view = store.match(null, null, null, '', opts);
           expect([...view]).toHaveLength(6);
+          expect(view.add(q('s3', 'p1', 'oD'))).toBe(view);
+          expect(() => view.add(q('s3', 'p1', 'oG', 'g1')))
+            .toThrow('Cannot add a quad that does not match the forwarded view pattern');
           store.addQuad(q('s3', 'p1', 'oG', 'g1'));
-          expect([...view]).toHaveLength(6);
+          expect([...view]).toHaveLength(7);
           expect(view.has(q('s3', 'p1', 'oG', 'g1'))).toBe(false);
-          store.addQuad(q('s3', 'p1', 'oD'));
           expect([...view]).toHaveLength(7);
         });
 
@@ -1391,6 +1536,7 @@ describe('Store', () => {
           const wildcard = store.match(null, null, null, null, opts);
           const exact = store.match(
             namedNode('s1'), namedNode('p1'), namedNode('o1'), new DefaultGraph(), opts);
+          expect(exact.add(q('s1', 'p1', 'o1'))).toBe(exact);
           store.addQuad(q('s1', 'p1', 'o1')); // already exists, no change
           store.addQuad(q('s1', 'p1', 'o2')); // matches wildcard, not exact (object differs)
           expect([...wildcard]).toHaveLength(2);

--- a/test/N3Store-test.js
+++ b/test/N3Store-test.js
@@ -979,6 +979,29 @@ describe('Store', () => {
         expect([...view]).toHaveLength(0);
       });
 
+      it.each(['snapshot', 'forwarded'])(
+        'should keep a %s toStream() stable across parent mutations',
+        async matchSemantics => {
+          const quads = Array.from({ length: 40 }, (_, i) => q(`s${i}`, 'p1', `o${i}`));
+          const store = new Store(quads);
+          const view = store.match(null, null, null, null, { matchSemantics });
+          const stream = view.toStream();
+          let first = true;
+          stream.on('data', () => {
+            if (first) {
+              first = false;
+              store.delete(quads[39]);
+              store.add(q('sNEW', 'p1', 'oNEW'));
+            }
+          });
+          expect(values(await arrayifyStream(stream))).toEqual(values(quads));
+          expect(view._activeIterators).toBe(0);
+          expect(view._baselines).toBe(null);
+          expect(view.has(quads[39])).toBe(matchSemantics === 'snapshot');
+          view.detach();
+        },
+      );
+
       describe('transitive matches', () => {
         it.each(['lazy', 'snapshot', 'forwarded'])(
           'should intersect patterns through a %s match chain',
@@ -1320,6 +1343,66 @@ describe('Store', () => {
           expect(view.has(q('s1', 'p1', 'o0'))).toBe(false);
         });
 
+        it.each(['every', 'some', 'filter', 'map', 'forEach'])(
+          'should forward mutations through the dataset passed to %s callbacks',
+          method => {
+            const original = q('s1', 'p1', 'o1');
+            const replacement = q('s1', 'p1', 'oNEW');
+            const outside = q('s2', 'p1', 'oOUT');
+            store = new Store([original]);
+            view = store.match(namedNode('s1'), null, null, null, opts);
+            const callback = jest.fn((quad, dataset) => {
+              expect(dataset).toBe(view);
+              dataset.delete(quad);
+              dataset.add(replacement);
+              expect(() => dataset.add(outside))
+                .toThrow('Cannot add a quad that does not match the forwarded view pattern');
+              return quad;
+            });
+
+            const result = view[method](callback);
+            expect(callback).toHaveBeenCalledTimes(1);
+            expect(store.has(original)).toBe(false);
+            expect(store.has(replacement)).toBe(true);
+            expect(store.has(outside)).toBe(false);
+            expect([...view]).toEqual([replacement]);
+            const expected = {
+              every: true, some: true, filter: [original], map: [original], forEach: undefined,
+            };
+            expect(result instanceof Store ? [...result] : result).toEqual(expected[method]);
+          },
+        );
+
+        it('should forward mutations through the dataset passed to reduce callbacks', () => {
+          const original = q('s1', 'p1', 'o1');
+          const replacement = q('s1', 'p1', 'oNEW');
+          store = new Store([original]);
+          view = store.match(namedNode('s1'), null, null, null, opts);
+          expect(view.reduce((count, quad, dataset) => {
+            expect(dataset).toBe(view);
+            dataset.delete(quad);
+            dataset.add(replacement);
+            return count + 1;
+          }, 0)).toBe(1);
+          expect(store.has(original)).toBe(false);
+          expect(store.has(replacement)).toBe(true);
+          expect([...view]).toEqual([replacement]);
+        });
+
+        it.each(['every', 'some', 'forEach'])(
+          'should preserve quad pattern arguments for %s callbacks',
+          method => {
+            const selected = q('s1', 'p1', 'o3');
+            const callback = jest.fn((quad, dataset) => {
+              expect(dataset).toBe(view);
+              return true;
+            });
+            view[method](callback, selected.subject, selected.predicate, selected.object, selected.graph);
+            expect(callback).toHaveBeenCalledTimes(1);
+            expect(callback).toHaveBeenCalledWith(selected, view);
+          },
+        );
+
         it('should forward addAll incrementally and deleteMatches to the parent', () => {
           const first = q('s1', 'p1', 'oA'), second = q('s1', 'p1', 'oB');
           function* additions() {
@@ -1424,6 +1507,43 @@ describe('Store', () => {
           await expect(arrayifyStream(view.toStream())).resolves.toHaveLength(6);
           expect(view.union(new Store([q('s1', 'p1', 'oU')])).size).toBe(7);
         });
+
+        it('should give each toStream() an independent iteration', async () => {
+          const first = view.toStream();
+          const firstQuad = first.read();
+          expect(firstQuad).not.toBeNull();
+          store.add(q('s1', 'p1', 'oNEW'));
+          const second = view.toStream();
+          const [remaining, current] = await Promise.all([
+            arrayifyStream(first), arrayifyStream(second),
+          ]);
+          expect(values([firstQuad, ...remaining])).toEqual(initialValues);
+          expect(values(current)).toEqual([...initialValues, 'oNEW']);
+          expect(values(await arrayifyStream(view))).toEqual([...initialValues, 'oNEW']);
+          expect(view._activeIterators).toBe(0);
+          expect(view._baselines).toBe(null);
+        });
+
+        it.each([undefined, new Error('cancel stream')])(
+          'should release toStream() iteration state on destroy (%p)',
+          async error => {
+            const stream = view.toStream();
+            expect(stream.read()).not.toBeNull();
+            store.add(q('s1', 'p1', 'oNEW'));
+            expect(view._activeIterators).toBe(1);
+            const onError = jest.fn();
+            stream.on('error', onError);
+            await new Promise(resolve => {
+              stream.once('close', resolve);
+              stream.destroy(error);
+            });
+            expect(view._activeIterators).toBe(0);
+            expect(view._baselines).toBe(null);
+            expect(view.destroyed).toBe(false);
+            expect(values(view)).toEqual([...initialValues, 'oNEW']);
+            expect(onError.mock.calls).toEqual(error ? [[error]] : []);
+          },
+        );
 
         it('should not mutate the parent through union', () => {
           const union = view.union([q('s1', 'p1', 'oU')]);
@@ -1595,6 +1715,33 @@ describe('Store', () => {
           }
           expect(inner).toHaveLength(5);
           expect(outer.sort()).toEqual(initialValues);
+        });
+
+        it('should release completed baselines while an older iteration remains open', () => {
+          const outer = view[Symbol.iterator]();
+          const peer = view[Symbol.iterator]();
+          const first = outer.next().value;
+          expect(peer.next().value).toEqual(first);
+          const extra = q('s1', 'p1', 'oTEMP');
+          store.add(extra);
+          peer.return();
+          expect(view._baselines.size).toBe(1);
+          store.delete(extra);
+
+          for (let i = 0; i < 20; i++) {
+            const inner = view[Symbol.iterator]();
+            const firstInner = inner.next().value;
+            store.add(extra);
+            expect(view._baselines.size).toBe(2);
+            expect(values([firstInner, ...inner])).toEqual(initialValues);
+            expect(view._baselines.size).toBe(1);
+            store.delete(extra);
+          }
+
+          expect(view._activeIterators).toBe(1);
+          expect(values([first, ...outer])).toEqual(initialValues);
+          expect(view._activeIterators).toBe(0);
+          expect(view._baselines).toBe(null);
         });
 
         it('should keep an overlapping iteration stable after a baseline freeze', () => {

--- a/test/N3Store-test.js
+++ b/test/N3Store-test.js
@@ -1061,6 +1061,15 @@ describe('Store', () => {
           expect(store.has(q('s1', 'p1', 'oA'))).toBe(false);
         });
 
+        it('should write import() through to the parent', done => {
+          const events = view.import(new ArrayReader([q('s1', 'p1', 'oI')]));
+          events.on('end', () => {
+            expect(store.has(q('s1', 'p1', 'oI'))).toBe(true);
+            expect(view.has(q('s1', 'p1', 'oI'))).toBe(true);
+            done();
+          });
+        });
+
         it('should write non-matching mutations through to the parent unrestricted', () => {
           // A non-matching add mutates the parent but never appears in the view
           view.add(q('s3', 'p1', 'oNM'));

--- a/test/N3Store-test.js
+++ b/test/N3Store-test.js
@@ -955,6 +955,20 @@ describe('Store', () => {
           expect([...sub]).toHaveLength(5);
           expect(sub.has(q('s1', 'p1', 'oNEW'))).toBe(false);
         });
+
+        it('supports detach() before and after materialization', () => {
+          const store = buildStore();
+          const view = store.match(namedNode('s1'), null, null, null, opts);
+          view.detach();
+          expect(store._observers).toBe(null);
+          store.addQuad(q('s1', 'p1', 'oNEW'));
+          expect([...view]).toHaveLength(5);
+          // A view that has already materialized (removing its observer) can also detach
+          const other = store.match(namedNode('s1'), null, null, null, opts);
+          expect(other.size).toBe(6);
+          expect(other.detach().size).toBe(6);
+          expect(store._observers).toBe(null);
+        });
       });
 
       describe('forwarded', () => {
@@ -1113,6 +1127,23 @@ describe('Store', () => {
           expect(union.size).toBe(6);
           expect(store.has(q('s1', 'p1', 'oU'))).toBe(false);
           expect(view.has(q('s1', 'p1', 'oU'))).toBe(false);
+        });
+
+        it('stops observing the parent after detach()', () => {
+          const store = buildStore();
+          const view = store.match(namedNode('s1'), null, null, null, opts);
+          expect(view.detach()).toBe(view);
+          expect(store._observers).toBe(null);
+          // The view is frozen to its contents at detach time
+          store.addQuad(q('s1', 'p1', 'oNEW'));
+          expect([...view]).toHaveLength(5);
+          // Mutations now apply to the view only, not to the parent
+          view.add(q('s1', 'p1', 'oLOCAL'));
+          expect(view.has(q('s1', 'p1', 'oLOCAL'))).toBe(true);
+          expect(store.has(q('s1', 'p1', 'oLOCAL'))).toBe(false);
+          // `detach()` is idempotent
+          expect(view.detach()).toBe(view);
+          expect(view.size).toBe(6);
         });
 
         it('downgrades a nested match() to a snapshot of the view', () => {

--- a/test/N3Store-test.js
+++ b/test/N3Store-test.js
@@ -798,8 +798,7 @@ describe('Store', () => {
         // Two snapshot views observe the store concurrently.
         const a = store.match(namedNode('s1'), null, null, null, { matchSemantics: 'snapshot' });
         const b = store.match(namedNode('s1'), null, null, null, { matchSemantics: 'snapshot' });
-        // The first matching mutation materializes (and detaches) view `a`'s
-        // observer, while view `b`'s observer is still registered.
+        // Materialize (and detach) view `a`'s observer while view `b`'s remains registered
         a.size; // eslint-disable-line no-unused-expressions
         store.addQuad(q('s1', 'p1', 'oNEW'));
         expect([...a]).toHaveLength(5);
@@ -1038,8 +1037,7 @@ describe('Store', () => {
           const seen = [];
           for (const quad of view) {
             seen.push(quad.object.value);
-            // Mutate only while processing the final matching quad, so the
-            // source iterator is exhausted on the very next step.
+            // Mutate while processing the final quad, so the source is exhausted on the next step
             if (seen.length === 5)
               store.addQuad(q('s1', 'p1', 'oNEW'));
           }
@@ -1119,9 +1117,7 @@ describe('Store', () => {
           for (const a of view) {
             outer.push(a.object.value);
             if (outer.length === 1) {
-              // Run a nested (concurrent) iteration to completion; its finally
-              // block decrements `_activeIterators` while the outer one is still
-              // active, then mutate to exercise the still-running outer iterator.
+              // Run a nested iteration to completion (dropping `_activeIterators` to 1), then mutate
               for (const b of view)
                 inner.push(b.object.value);
               store.addQuad(q('s1', 'p1', 'oNEW'));

--- a/test/N3Store-test.js
+++ b/test/N3Store-test.js
@@ -760,6 +760,11 @@ describe('Store', () => {
         return seen.sort();
       }
 
+      function removeOtherSubject(store, first) {
+        store.removeQuad(first.subject.value === 's1' ?
+          q('s2', 'p1', 'o2') : q('s1', 'p1', 'o1'));
+      }
+
       function buildStore(options) {
         const store = new Store([], options);
         for (const object of initialValues)
@@ -776,6 +781,20 @@ describe('Store', () => {
         expect([...view]).toHaveLength(6);
       });
 
+      it('should preserve match() arity', () => {
+        expect(buildStore().match).toHaveLength(4);
+      });
+
+      it('should preserve a lazy iterator source after materialization', () => {
+        const store = buildStore();
+        const view = store.match(namedNode('s1'), null, null);
+        const iterator = view[Symbol.iterator]();
+        expect(view.size).toBe(5);
+        store.addQuad(q('s1', 'p1', 'oNEW'));
+        expect(values(iterator)).toEqual([...initialValues, 'oNEW']);
+        expect(values(view)).toEqual(initialValues);
+      });
+
       it('should detach a lazy view as a snapshot', () => {
         const view = buildStore().match(namedNode('s1'), null, null).detach();
         const nested = view.match(null, namedNode('p1'));
@@ -784,16 +803,15 @@ describe('Store', () => {
         expect([...nested]).toHaveLength(5);
       });
 
-      it('should throw on an unknown matchSemantics value', () => {
-        const store = buildStore();
-        expect(() => store.match(namedNode('s1'), null, null, null, { matchSemantics: 'bogus' }))
-          .toThrow('Unknown matchSemantics: bogus');
-      });
-
-      it('should throw on an unknown store-level matchSemantics value', () => {
-        expect(() => new Store([], { matchSemantics: 'bogus' }))
-          .toThrow('Unknown matchSemantics: bogus');
-      });
+      it.each(['bogus', '', false, 0, null])(
+        'should reject an invalid matchSemantics value (%p)',
+        matchSemantics => {
+          const message = `Unknown matchSemantics: ${matchSemantics}`;
+          expect(() => new Store([], { matchSemantics })).toThrow(message);
+          expect(() => buildStore().match(
+            namedNode('s1'), null, null, null, { matchSemantics })).toThrow(message);
+        },
+      );
 
       it('should use the store-level default matchSemantics', () => {
         const store = buildStore({ matchSemantics: 'snapshot' });
@@ -845,11 +863,13 @@ describe('Store', () => {
         expect(store.has(q('s1', 'p1', 'oU'))).toBe(false);
       });
 
-      it('should detach a single observer while another remains attached', () => {
+      it('should leave other snapshots observed when one materializes', () => {
         const store = buildStore();
         const a = store.match(namedNode('s1'), null, null, null, { matchSemantics: 'snapshot' });
         const b = store.match(namedNode('s1'), null, null, null, { matchSemantics: 'snapshot' });
-        a.size; // eslint-disable-line no-unused-expressions
+        expect(store._observers.size).toBe(2);
+        expect(a.size).toBe(5);
+        expect(store._observers.size).toBe(1);
         store.addQuad(q('s1', 'p1', 'oNEW'));
         expect([...a]).toHaveLength(5);
         expect([...b]).toHaveLength(5);
@@ -867,12 +887,58 @@ describe('Store', () => {
         expect([...b]).toHaveLength(5);
       });
 
-      it('should stop observing when a snapshot with an absent pattern term materializes', () => {
+      it.each(['snapshot', 'forwarded'])(
+        'should keep a %s iterator stable when deletion removes an index branch',
+        matchSemantics => {
+          const store = new Store([q('s1', 'p1', 'o1'), q('s2', 'p1', 'o2')]);
+          const view = store.match(null, null, null, null, { matchSemantics });
+          const iterator = view[Symbol.iterator]();
+          const first = iterator.next().value;
+          removeOtherSubject(store, first);
+          expect(values([first, ...iterator])).toEqual(['o1', 'o2']);
+        },
+      );
+
+      it('should keep an iterator stable when deletion removes a nested index branch', () => {
+        const store = new Store([q('s1', 'p1', 'o1'), q('s1', 'p2', 'o2')]);
+        const view = store.match(null, null, null, null, { matchSemantics: 'snapshot' });
+        const iterator = view[Symbol.iterator]();
+        const first = iterator.next().value;
+        store.removeQuad(first.predicate.value === 'p1' ?
+          q('s1', 'p2', 'o2') : q('s1', 'p1', 'o1'));
+        expect(values([first, ...iterator])).toEqual(['o1', 'o2']);
+      });
+
+      it.each(['snapshot', 'forwarded'])(
+        'should keep a %s iterator stable across a reentrant factory mutation',
+        matchSemantics => {
+          const state = { mutate: false, store: null };
+          const factory = {
+            ...DataFactory,
+            defaultGraph() {
+              const graph = DataFactory.defaultGraph();
+              if (state.mutate) {
+                state.mutate = false;
+                state.store.removeQuad(q('s1', 'p1', 'o1'));
+              }
+              return graph;
+            },
+          };
+          const store = new Store([q('s1', 'p1', 'o1'), q('s2', 'p1', 'o2')], { factory });
+          state.store = store;
+          const view = store.match(null, null, null, null, { matchSemantics });
+          state.mutate = true;
+          expect([...view].map(({ subject, object }) =>
+            `${subject.value}:${object.value}`).sort()).toEqual(['s1:o1', 's2:o2']);
+          expect(store.has(q('s1', 'p1', 'o1'))).toBe(false);
+        },
+      );
+
+      it('should snapshot an absent pattern term before its first matching mutation', () => {
         const store = buildStore();
         const view = store.match(namedNode('sNONE'), null, null, null, { matchSemantics: 'snapshot' });
-        expect(view.size).toBe(0);
-        expect(store._observers).toBe(null);
         store.addQuad(q('sNONE', 'p1', 'o1'));
+        expect(store._observers).toBe(null);
         expect([...view]).toHaveLength(0);
       });
 
@@ -896,6 +962,7 @@ describe('Store', () => {
             expect([...byPredicate]).toHaveLength(3);
             expect([...byObject]).toHaveLength(2);
             expect([...byGraph]).toEqual([q('s1', 'p1', 'o1')]);
+            expect([...bySubject.match(namedNode('s2'))]).toHaveLength(0);
           },
         );
 
@@ -964,6 +1031,12 @@ describe('Store', () => {
           expect(view.has(q('s1', 'p1', 'o0'))).toBe(true);
         });
 
+        it('should ignore parent additions between iterator creation and first read', () => {
+          const iterator = view[Symbol.iterator]();
+          store.addQuad(q('s1', 'p1', 'oNEW'));
+          expect(values(iterator)).toEqual(initialValues);
+        });
+
         it('should ignore parent deletions made before iteration', () => {
           store.removeQuad(q('s1', 'p1', 'o0'));
           expect([...view]).toHaveLength(5);
@@ -976,6 +1049,16 @@ describe('Store', () => {
             store.removeQuad(q('s1', 'p1', 'o4'));
           });
           expect(seen).toEqual(initialValues);
+        });
+
+        it('should keep an active iterator stable when materialized', () => {
+          store = new Store([q('s1', 'p1', 'o1'), q('s2', 'p1', 'o2')]);
+          view = store.match(null, null, null, null, opts);
+          const seen = valuesWithMutationAfterFirstQuad(view, first => {
+            expect(view.size).toBe(2);
+            removeOtherSubject(store, first);
+          });
+          expect(seen).toEqual(['o1', 'o2']);
         });
 
         it('should ignore a parent mutation that lands during async iteration', async () => {
@@ -1064,6 +1147,12 @@ describe('Store', () => {
           store.addQuad(q('s1', 'p1', 'oNEW'));
           expect([...view]).toHaveLength(6);
           expect(view.has(q('s1', 'p1', 'oNEW'))).toBe(true);
+        });
+
+        it('should reflect parent additions between iterator creation and first read', () => {
+          const iterator = view[Symbol.iterator]();
+          store.addQuad(q('s1', 'p1', 'oNEW'));
+          expect(values(iterator)).toEqual([...initialValues, 'oNEW']);
         });
 
         it('should reflect parent deletions made before iteration', () => {
@@ -1169,6 +1258,24 @@ describe('Store', () => {
           expect(view.size).toBe(5);
         });
 
+        it('should keep an active iterator stable when materialized', () => {
+          store = new Store([
+            q('s1', 'p1', 'o2'),
+            q('s2', 'p1', 'o1'),
+            q('s1', 'p1', 'o1'),
+            q('s2', 'p1', 'o2'),
+          ]);
+          view = store.match(null, namedNode('p1'), null, null, opts);
+          const iterator = view[Symbol.iterator]();
+          const seen = [iterator.next().value, iterator.next().value];
+          expect(view.size).toBe(4);
+          store.addQuad(q('s3', 'p1', 'o3'));
+          seen.push(...iterator);
+          expect(seen.map(({ subject, object }) => `${subject.value}:${object.value}`).sort()).toEqual([
+            's1:o1', 's1:o2', 's2:o1', 's2:o2',
+          ]);
+        });
+
         it('should forward a Store addAll (bypassing the index-merge fast path) when observed', () => {
           const extra = new Store([], { entityIndex: store._entityIndex });
           extra.addQuad(q('s1', 'p1', 'oM'));
@@ -1200,6 +1307,17 @@ describe('Store', () => {
           expect(store.has(q('s1', 'p1', 'oLOCAL'))).toBe(false);
           expect(view.detach()).toBe(view);
           expect(view.size).toBe(6);
+        });
+
+        it('should keep an active iterator stable when detached', () => {
+          store = new Store([q('s1', 'p1', 'o1'), q('s2', 'p1', 'o2')]);
+          view = store.match(null, null, null, null, opts);
+          const seen = valuesWithMutationAfterFirstQuad(view, first => {
+            view.detach();
+            removeOtherSubject(store, first);
+          });
+          expect(seen).toEqual(['o1', 'o2']);
+          expect(values(view)).toEqual(['o1', 'o2']);
         });
 
         it('should downgrade a nested match() to a snapshot of the view', () => {

--- a/test/N3Store-test.js
+++ b/test/N3Store-test.js
@@ -1006,6 +1006,28 @@ describe('Store', () => {
           expect(store.has(q('s1', 'p1', 'oA'))).toBe(false);
         });
 
+        it('defers materialization of an unread view across parent mutations', () => {
+          const store = buildStore();
+          const view = store.match(namedNode('s1'), null, null, null, opts);
+          store.addQuad(q('s1', 'p1', 'oNEW'));
+          store.removeQuad(q('s1', 'p1', 'o0'));
+          // Nothing has been read from the view, so it has not materialized
+          expect(view._filtered).toBeFalsy();
+          expect(values(view)).toEqual(['o1', 'o2', 'o3', 'o4', 'oNEW']);
+        });
+
+        it('applies parent mutations to an already-materialized view', () => {
+          const store = buildStore();
+          const view = store.match(namedNode('s1'), null, null, null, opts);
+          // Materialize the view before any parent mutation
+          expect(view.size).toBe(5);
+          store.addQuad(q('s1', 'p1', 'oNEW'));
+          store.removeQuad(q('s1', 'p1', 'o0'));
+          expect(view.has(q('s1', 'p1', 'oNEW'))).toBe(true);
+          expect(view.has(q('s1', 'p1', 'o0'))).toBe(false);
+          expect(view.size).toBe(5);
+        });
+
         it('forwards a Store addAll (bypassing the index-merge fast path) when observed', () => {
           const store = buildStore();
           const view = store.match(namedNode('s1'), null, null, null, opts);
@@ -1070,6 +1092,9 @@ describe('Store', () => {
           // The subject `s9` is not present when the view is created.
           const view = store.match(namedNode('s9'), null, null, null, opts);
           expect([...view]).toHaveLength(0);
+          // A mutation while `s9` is still absent cannot match the view
+          store.addQuad(q('sOther', 'p1', 'o1'));
+          expect([...view]).toHaveLength(0);
           store.addQuad(q('s9', 'p1', 'o1'));
           expect([...view]).toHaveLength(1);
           expect(view.has(q('s9', 'p1', 'o1'))).toBe(true);
@@ -1106,6 +1131,7 @@ describe('Store', () => {
           store.addQuad(new Quad(namedNode('s1'), namedNode('pX'), namedNode('o1'), namedNode('g1')));
           store.addQuad(new Quad(namedNode('s1'), namedNode('p1'), namedNode('oX'), namedNode('g1')));
           store.addQuad(new Quad(namedNode('s1'), namedNode('p1'), namedNode('o1'), namedNode('gX')));
+          store.addQuad(new Quad(namedNode('s1'), namedNode('p1'), namedNode('o1'), namedNode('gY')));
           expect([...view]).toHaveLength(1);
         });
 

--- a/test/N3Store-test.js
+++ b/test/N3Store-test.js
@@ -941,6 +941,15 @@ describe('Store', () => {
           store.addQuad(q('s1', 'p1', 'oNEW'));
           expect(union.size).toBe(6);
         });
+
+        it('keeps a nested match() frozen at nesting time', () => {
+          const store = buildStore();
+          const view = store.match(namedNode('s1'), null, null, null, opts);
+          const sub = view.match(null, namedNode('p1'));
+          store.addQuad(q('s1', 'p1', 'oNEW'));
+          expect([...sub]).toHaveLength(5);
+          expect(sub.has(q('s1', 'p1', 'oNEW'))).toBe(false);
+        });
       });
 
       describe('forwarded', () => {
@@ -1099,6 +1108,22 @@ describe('Store', () => {
           expect(union.size).toBe(6);
           expect(store.has(q('s1', 'p1', 'oU'))).toBe(false);
           expect(view.has(q('s1', 'p1', 'oU'))).toBe(false);
+        });
+
+        it('downgrades a nested match() to a snapshot of the view', () => {
+          const store = buildStore();
+          const view = store.match(namedNode('s1'), null, null, null, opts);
+          const sub = view.match(null, namedNode('p1'));
+          expect([...sub]).toHaveLength(5);
+          // Later root mutations reach the outer view, but not the nested snapshot
+          store.addQuad(q('s1', 'p1', 'oNEW'));
+          expect(view.has(q('s1', 'p1', 'oNEW'))).toBe(true);
+          expect([...sub]).toHaveLength(5);
+          // Mutations on the sub-view reach neither the root store nor the outer view
+          sub.add(q('s1', 'p1', 'oSUB'));
+          expect(sub.has(q('s1', 'p1', 'oSUB'))).toBe(true);
+          expect(store.has(q('s1', 'p1', 'oSUB'))).toBe(false);
+          expect(view.has(q('s1', 'p1', 'oSUB'))).toBe(false);
         });
 
         it('handles matching mutations in the default graph', () => {

--- a/test/N3Store-test.js
+++ b/test/N3Store-test.js
@@ -1124,19 +1124,19 @@ describe('Store', () => {
         });
 
         it('should write view additions and deletions through to the parent', () => {
-          view.add(q('s1', 'p1', 'oOWN'));
+          expect(view.add(q('s1', 'p1', 'oOWN'))).toBe(view);
           expect(store.has(q('s1', 'p1', 'oOWN'))).toBe(true);
           expect(view.has(q('s1', 'p1', 'oOWN'))).toBe(true);
-          view.delete(q('s1', 'p1', 'o0'));
+          expect(view.delete(q('s1', 'p1', 'o0'))).toBe(view);
           expect(store.has(q('s1', 'p1', 'o0'))).toBe(false);
           expect(view.has(q('s1', 'p1', 'o0'))).toBe(false);
         });
 
         it('should forward addAll and deleteMatches to the parent', () => {
-          view.addAll([q('s1', 'p1', 'oA'), q('s1', 'p1', 'oB')]);
+          expect(view.addAll([q('s1', 'p1', 'oA'), q('s1', 'p1', 'oB')])).toBe(view);
           expect(store.has(q('s1', 'p1', 'oA'))).toBe(true);
           expect(view.size).toBe(7);
-          view.deleteMatches(namedNode('s1'), namedNode('p1'), namedNode('oA'));
+          expect(view.deleteMatches(namedNode('s1'), namedNode('p1'), namedNode('oA'))).toBe(view);
           expect(store.has(q('s1', 'p1', 'oA'))).toBe(false);
         });
 

--- a/test/N3Store-test.js
+++ b/test/N3Store-test.js
@@ -749,20 +749,27 @@ describe('Store', () => {
       }
 
       function buildStore(options) {
-        const s = new Store([], options);
+        const store = new Store([], options);
         for (let i = 0; i < 5; i++)
-          s.addQuad(q('s1', 'p1', `o${i}`));
-        s.addQuad(q('s2', 'p1', 'oX')); // a non-matching quad for an `s1` pattern
-        return s;
+          store.addQuad(q('s1', 'p1', `o${i}`));
+        store.addQuad(q('s2', 'p1', 'oX'));
+        return store;
       }
 
       it('should default to lazy semantics', () => {
         const store = buildStore();
         const view = store.match(namedNode('s1'), null, null);
         store.addQuad(q('s1', 'p1', 'oNEW'));
-        // Lazy: parent mutation before the view's own mutation leaks in.
         expect(values(view)).toContain('oNEW');
         expect([...view]).toHaveLength(6);
+      });
+
+      it('should detach a lazy view as a snapshot', () => {
+        const view = buildStore().match(namedNode('s1'), null, null).detach();
+        const nested = view.match(null, namedNode('p1'));
+        view.add(q('s1', 'p1', 'oNEW'));
+        expect([...view]).toHaveLength(6);
+        expect([...nested]).toHaveLength(5);
       });
 
       it('should throw on an unknown matchSemantics value', () => {
@@ -828,10 +835,8 @@ describe('Store', () => {
 
       it('should detach a single observer while another remains attached', () => {
         const store = buildStore();
-        // Two snapshot views observe the store concurrently.
         const a = store.match(namedNode('s1'), null, null, null, { matchSemantics: 'snapshot' });
         const b = store.match(namedNode('s1'), null, null, null, { matchSemantics: 'snapshot' });
-        // Materialize (and detach) view `a`'s observer while view `b`'s remains registered
         a.size; // eslint-disable-line no-unused-expressions
         store.addQuad(q('s1', 'p1', 'oNEW'));
         expect([...a]).toHaveLength(5);
@@ -842,8 +847,6 @@ describe('Store', () => {
 
       it('should detach both observers when one mutation notifies two snapshot views', () => {
         const store = buildStore();
-        // Two live snapshot views; a single matching mutation notifies both, and each
-        // observer unregisters itself mid-notification while the other is still pending.
         const a = store.match(namedNode('s1'), null, null, null, { matchSemantics: 'snapshot' });
         const b = store.match(namedNode('s1'), null, null, null, { matchSemantics: 'snapshot' });
         store.addQuad(q('s1', 'p1', 'oNEW'));
@@ -856,11 +859,80 @@ describe('Store', () => {
         const store = buildStore();
         const view = store.match(namedNode('sNONE'), null, null, null, { matchSemantics: 'snapshot' });
         expect(view.size).toBe(0);
-        // Materialization removes the observer also on the absent-term path
         expect(store._observers).toBe(null);
-        // The view stays frozen to its (empty) contents
         store.addQuad(q('sNONE', 'p1', 'o1'));
         expect([...view]).toHaveLength(0);
+      });
+
+      describe('transitive matches', () => {
+        it.each(['lazy', 'snapshot', 'forwarded'])(
+          'should intersect patterns through a %s match chain',
+          matchSemantics => {
+            const store = new Store([
+              q('s1', 'p1', 'o1'),
+              q('s1', 'p1', 'o2'),
+              q('s1', 'p2', 'o1'),
+              q('s2', 'p1', 'o1'),
+              q('s1', 'p1', 'o1', 'g1'),
+            ]);
+            const bySubject = store.match(namedNode('s1'), null, null, null, { matchSemantics });
+            const byPredicate = bySubject.match(null, namedNode('p1'));
+            const byObject = byPredicate.match(null, null, namedNode('o1'));
+            const byGraph = byObject.match(null, null, null, new DefaultGraph());
+
+            expect([...bySubject]).toHaveLength(4);
+            expect([...byPredicate]).toHaveLength(3);
+            expect([...byObject]).toHaveLength(2);
+            expect([...byGraph]).toEqual([q('s1', 'p1', 'o1')]);
+          },
+        );
+
+        it('should keep a lazy leaf live to its immediate parent', () => {
+          const store = buildStore();
+          const parent = store.match(namedNode('s1'), null, null);
+          const child = parent.match(null, namedNode('p1'));
+          const leaf = child.match();
+
+          store.addQuad(q('s1', 'p1', 'oROOT'));
+          parent.add(q('s1', 'p1', 'oPARENT'));
+          child.add(q('s1', 'p1', 'oCHILD'));
+
+          expect(values(parent)).toEqual(['o0', 'o1', 'o2', 'o3', 'o4', 'oPARENT']);
+          expect(values(child)).toEqual(['o0', 'o1', 'o2', 'o3', 'o4', 'oCHILD']);
+          expect(values(leaf)).toEqual(['o0', 'o1', 'o2', 'o3', 'o4', 'oCHILD']);
+        });
+
+        it('should preserve each snapshot boundary in a match chain', () => {
+          const store = buildStore();
+          const parent = store.match(namedNode('s1'), null, null, null, { matchSemantics: 'snapshot' });
+          const child = parent.match(null, namedNode('p1'));
+          const leaf = child.match();
+
+          store.addQuad(q('s1', 'p1', 'oROOT'));
+          parent.add(q('s1', 'p1', 'oPARENT'));
+          child.add(q('s1', 'p1', 'oCHILD'));
+
+          expect(values(parent)).toEqual(['o0', 'o1', 'o2', 'o3', 'o4', 'oPARENT']);
+          expect(values(child)).toEqual(['o0', 'o1', 'o2', 'o3', 'o4', 'oCHILD']);
+          expect(values(leaf)).toEqual(['o0', 'o1', 'o2', 'o3', 'o4']);
+        });
+
+        it('should downgrade forwarded descendants to snapshots', () => {
+          const store = buildStore();
+          const parent = store.match(namedNode('s1'), null, null, null, { matchSemantics: 'forwarded' });
+          const child = parent.match(null, namedNode('p1'));
+          const leaf = child.match();
+
+          store.addQuad(q('s1', 'p1', 'oROOT'));
+          parent.add(q('s1', 'p1', 'oPARENT'));
+          child.add(q('s1', 'p1', 'oCHILD'));
+
+          expect(values(parent)).toEqual(['o0', 'o1', 'o2', 'o3', 'o4', 'oPARENT', 'oROOT']);
+          expect(values(child)).toEqual(['o0', 'o1', 'o2', 'o3', 'o4', 'oCHILD']);
+          expect(values(leaf)).toEqual(['o0', 'o1', 'o2', 'o3', 'o4']);
+          expect(store.has(q('s1', 'p1', 'oPARENT'))).toBe(true);
+          expect(store.has(q('s1', 'p1', 'oCHILD'))).toBe(false);
+        });
       });
 
       describe('snapshot', () => {
@@ -932,7 +1004,6 @@ describe('Store', () => {
         it('should support its own independent mutations', () => {
           view.add(q('s1', 'p1', 'oOWN'));
           expect(view.has(q('s1', 'p1', 'oOWN'))).toBe(true);
-          // The parent is not affected by snapshot view mutations.
           expect(store.has(q('s1', 'p1', 'oOWN'))).toBe(false);
         });
 
@@ -951,7 +1022,6 @@ describe('Store', () => {
           const union = view.union([q('s1', 'p1', 'oU')]);
           expect(union.size).toBe(6);
           expect(store.has(q('s1', 'p1', 'oU'))).toBe(false);
-          // The union result is independent of later parent mutations
           store.addQuad(q('s1', 'p1', 'oNEW'));
           expect(union.size).toBe(6);
         });
@@ -968,7 +1038,6 @@ describe('Store', () => {
           expect(store._observers).toBe(null);
           store.addQuad(q('s1', 'p1', 'oNEW'));
           expect([...view]).toHaveLength(5);
-          // A view that has already materialized (removing its observer) can also detach
           const other = store.match(namedNode('s1'), null, null, null, opts);
           expect(other.size).toBe(6);
           expect(other.detach().size).toBe(6);
@@ -1007,9 +1076,7 @@ describe('Store', () => {
               store.addQuad(q('s1', 'p1', 'oNEW'));
             }
           }
-          // The in-progress pass is stable (no duplicates, no omissions)...
           expect(seen.sort()).toEqual(['o0', 'o1', 'o2', 'o3', 'o4']);
-          // ...and the next pass reflects the forwarded state.
           expect([...view]).toHaveLength(6);
         });
 
@@ -1083,15 +1150,12 @@ describe('Store', () => {
         });
 
         it('should write non-matching mutations through to the parent unrestricted', () => {
-          // A non-matching add mutates the parent but never appears in the view
           view.add(q('s3', 'p1', 'oNM'));
           expect(store.has(q('s3', 'p1', 'oNM'))).toBe(true);
           expect(view.has(q('s3', 'p1', 'oNM'))).toBe(false);
-          // A non-matching addAll grows the parent, not the view
           view.addAll([q('s3', 'p1', 'oNM2')]);
           expect(store.has(q('s3', 'p1', 'oNM2'))).toBe(true);
           expect(view.size).toBe(5);
-          // A deleteMatches wider than the pattern deletes parent quads outside the view
           view.deleteMatches(namedNode('s2'), null, null);
           expect(store.has(q('s2', 'p1', 'oX'))).toBe(false);
           expect(view.size).toBe(5);
@@ -1100,13 +1164,11 @@ describe('Store', () => {
         it('should defer materialization of an unread view across parent mutations', () => {
           store.addQuad(q('s1', 'p1', 'oNEW'));
           store.removeQuad(q('s1', 'p1', 'o0'));
-          // Nothing has been read from the view, so it has not materialized
           expect(view._filtered).toBeFalsy();
           expect(values(view)).toEqual(['o1', 'o2', 'o3', 'o4', 'oNEW']);
         });
 
         it('should apply parent mutations to an already-materialized view', () => {
-          // Materialize the view before any parent mutation
           expect(view.size).toBe(5);
           store.addQuad(q('s1', 'p1', 'oNEW'));
           store.removeQuad(q('s1', 'p1', 'o0'));
@@ -1139,14 +1201,11 @@ describe('Store', () => {
         it('should stop observing the parent after detach()', () => {
           expect(view.detach()).toBe(view);
           expect(store._observers).toBe(null);
-          // The view is frozen to its contents at detach time
           store.addQuad(q('s1', 'p1', 'oNEW'));
           expect([...view]).toHaveLength(5);
-          // Mutations now apply to the view only, not to the parent
           view.add(q('s1', 'p1', 'oLOCAL'));
           expect(view.has(q('s1', 'p1', 'oLOCAL'))).toBe(true);
           expect(store.has(q('s1', 'p1', 'oLOCAL'))).toBe(false);
-          // `detach()` is idempotent
           expect(view.detach()).toBe(view);
           expect(view.size).toBe(6);
         });
@@ -1154,11 +1213,9 @@ describe('Store', () => {
         it('should downgrade a nested match() to a snapshot of the view', () => {
           const sub = view.match(null, namedNode('p1'));
           expect([...sub]).toHaveLength(5);
-          // Later root mutations reach the outer view, but not the nested snapshot
           store.addQuad(q('s1', 'p1', 'oNEW'));
           expect(view.has(q('s1', 'p1', 'oNEW'))).toBe(true);
           expect([...sub]).toHaveLength(5);
-          // Mutations on the sub-view reach neither the root store nor the outer view
           sub.add(q('s1', 'p1', 'oSUB'));
           expect(sub.has(q('s1', 'p1', 'oSUB'))).toBe(true);
           expect(store.has(q('s1', 'p1', 'oSUB'))).toBe(false);
@@ -1175,11 +1232,9 @@ describe('Store', () => {
         it('should treat an empty-string graph pattern as the default graph', () => {
           view = store.match(null, null, null, '', opts);
           expect([...view]).toHaveLength(6);
-          // A named-graph quad does not match a default-graph pattern
           store.addQuad(q('s3', 'p1', 'oG', 'g1'));
           expect([...view]).toHaveLength(6);
           expect(view.has(q('s3', 'p1', 'oG', 'g1'))).toBe(false);
-          // A default-graph quad does match
           store.addQuad(q('s3', 'p1', 'oD'));
           expect([...view]).toHaveLength(7);
         });
@@ -1188,7 +1243,6 @@ describe('Store', () => {
           const seen = [];
           for (const quad of view) {
             seen.push(quad.object.value);
-            // Mutate while processing the final quad, so the source is exhausted on the next step
             if (seen.length === 5)
               store.addQuad(q('s1', 'p1', 'oNEW'));
           }
@@ -1197,10 +1251,8 @@ describe('Store', () => {
         });
 
         it('should capture a baseline from an already-materialized view mid-iteration', () => {
-          // Force materialization of `_filtered` via a first matching mutation.
           store.addQuad(q('s1', 'p1', 'oNEW'));
           expect(view.size).toBe(6);
-          // Now iterate the materialized view and mutate mid-iteration.
           const seen = [];
           let mutated = false;
           for (const quad of view) {
@@ -1216,10 +1268,8 @@ describe('Store', () => {
 
         it('should reflect additions of a pattern term absent at match() time', () => {
           store = new Store();
-          // The subject `s9` is not present when the view is created.
           view = store.match(namedNode('s9'), null, null, null, opts);
           expect([...view]).toHaveLength(0);
-          // A mutation while `s9` is still absent cannot match the view
           store.addQuad(q('sOther', 'p1', 'o1'));
           expect([...view]).toHaveLength(0);
           store.addQuad(q('s9', 'p1', 'o1'));
@@ -1228,16 +1278,13 @@ describe('Store', () => {
         });
 
         it('should ignore a re-added quad that already exists', () => {
-          // Re-adding an existing quad must not notify observers nor change size.
           store.addQuad(q('s1', 'p1', 'o0'));
           expect([...view]).toHaveLength(5);
         });
 
         it('should match across all pattern positions and the default graph', () => {
           store = new Store([q('s1', 'p1', 'o1')]);
-          // Wildcard pattern: every position is a wildcard.
           const wildcard = store.match(null, null, null, null, opts);
-          // Fully specified pattern including the default graph.
           const exact = store.match(
             namedNode('s1'), namedNode('p1'), namedNode('o1'), new DefaultGraph(), opts);
           store.addQuad(q('s1', 'p1', 'o1')); // already exists, no change
@@ -1251,7 +1298,6 @@ describe('Store', () => {
             namedNode('s1'), namedNode('p1'), namedNode('o1'), namedNode('g1'))]);
           view = store.match(
             namedNode('s1'), namedNode('p1'), namedNode('o1'), namedNode('g1'), opts);
-          // Each of these differs from the pattern in exactly one position.
           store.addQuad(new Quad(namedNode('sX'), namedNode('p1'), namedNode('o1'), namedNode('g1')));
           store.addQuad(new Quad(namedNode('s1'), namedNode('pX'), namedNode('o1'), namedNode('g1')));
           store.addQuad(new Quad(namedNode('s1'), namedNode('p1'), namedNode('oX'), namedNode('g1')));
@@ -1265,14 +1311,11 @@ describe('Store', () => {
           for (let i = 0; i < 20; i++)
             store.addQuad(q('s1', 'p1', `o${i}`));
           view = store.match(namedNode('s1'), null, null, null, opts);
-          // A partial read leaves the internal iterator suspended
           expect(view.read()).not.toBeNull();
           expect(view._activeIterators).toBe(1);
           view.once('close', () => {
             expect(view._activeIterators).toBe(0);
-            // With no live iterators, this mutation must not freeze a baseline
             store.addQuad(q('s1', 'p1', 'oNEW'));
-            // A later pass is still protected against mid-pass mutations
             const seen = [];
             let mutated = false;
             for (const quad of view) {
@@ -1290,7 +1333,6 @@ describe('Store', () => {
 
         it('should support destroying its stream before any read', done => {
           view.once('close', () => {
-            // The dataset side of the view remains usable
             expect(view.size).toBe(5);
             done();
           });
@@ -1303,7 +1345,6 @@ describe('Store', () => {
           for (const a of view) {
             outer.push(a.object.value);
             if (outer.length === 1) {
-              // Run a nested iteration to completion (dropping `_activeIterators` to 1), then mutate
               for (const b of view)
                 inner.push(b.object.value);
               store.addQuad(q('s1', 'p1', 'oNEW'));
@@ -1315,15 +1356,12 @@ describe('Store', () => {
 
         it('should keep an overlapping iteration stable after a baseline freeze', () => {
           store = new Store();
-          // Spread the quads across predicate buckets, so deletions hit levels not yet iterated
           for (let i = 0; i < 5; i++)
             store.addQuad(q('s1', `p${i}`, 'o1'));
           view = store.match(namedNode('s1'), null, null, null, opts);
           const outer = view[Symbol.iterator]();
           expect(outer.next().done).toBe(false);
-          // This mutation freezes a baseline for the in-progress outer iteration
           store.addQuad(q('s1', 'pNEW', 'o1'));
-          // An iteration starting now must also stay stable across further matching mutations
           const seen = [];
           let mutated = false;
           for (const quad of view) {
@@ -1336,7 +1374,6 @@ describe('Store', () => {
           }
           expect(seen).toHaveLength(6);
           expect(seen).toEqual(expect.arrayContaining(['p3', 'p4', 'pNEW']));
-          // The outer iteration still yields the quads from its own start
           const rest = [];
           for (let next = outer.next(); !next.done; next = outer.next())
             rest.push(next.value.predicate.value);

--- a/test/N3Store-test.js
+++ b/test/N3Store-test.js
@@ -771,6 +771,11 @@ describe('Store', () => {
           .toThrow('Unknown matchSemantics: bogus');
       });
 
+      it('throws on an unknown store-level matchSemantics value', () => {
+        expect(() => new Store([], { matchSemantics: 'bogus' }))
+          .toThrow('Unknown matchSemantics: bogus');
+      });
+
       it('uses the store-level default matchSemantics', () => {
         const store = buildStore({ matchSemantics: 'snapshot' });
         const view = store.match(namedNode('s1'), null, null);


### PR DESCRIPTION
## What

Resolves #595: make the semantics of the dataset returned by `Store#match()` configurable via a `matchSemantics` option, both per call and as a store-wide default:

```js
store.match(s, p, o, g, { matchSemantics: 'snapshot' });
new Store([], { matchSemantics: 'forwarded' });
```

- **`lazy`** (default, unchanged) — current behaviour: the view delegates live to the parent until the first operation that materialises it (a mutation, or a materialising read such as `size` or `has`).
- **`snapshot`** — the view reflects the parent at `match()` time; later parent mutations never affect it.
- **`forwarded`** — the view always reflects the parent. Matching mutations are forwarded in, and pattern-constrained view mutations are written through. Nested forwarded matches stay connected to the root with all ancestor patterns applied.

The diff-based mode from #595 is intentionally not implemented (left as future work).

## Default unchanged — open question

The default stays `lazy`. Making `snapshot` the default would be a breaking change and is an open question in #595; I'd recommend it for a future major, but this PR does not enact it.

## API decisions

- **`detach()`** (new method): releases a non-lazy view from its parent — without it, a `forwarded` view observes the parent forever and is retained by it. It deliberately materialises once (a documented deviation from "no eager copying"). Naming is open: `detach` vs `unobserve` vs `close` (`close`/`destroy` were avoided for their stream connotations on this Readable).
- **Sub-views inherit their parent's semantics.** Supplying the same `matchSemantics` explicitly is allowed; a different valid value throws an error naming both modes, and an unknown value uses the normal validation error. Changing modes at a view boundary would make snapshot timing, materialisation, and the write target ambiguous; callers can create a separate view from the root when they need another mode.
- **Forwarding is recursive and pattern-constrained.** Nested forwarded views observe and write to the root using the intersection of every ancestor pattern. `add` and `addAll` stop and throw on a non-matching quad; as with the store's existing sequential `addAll`, earlier additions remain. `import` reports a stream error, `delete` treats a non-member as a no-op, and `deleteMatches` cannot remove quads outside the view. Conflicting nested patterns produce a permanently empty view.
- **Detachment is per view.** Detaching a parent does not silently detach descendants that were already returned to the caller.

## Notes (not visible from the diff)

- Non-`lazy` views attach a pre-mutation observer. An unmatched mutation only performs a pattern check; a matching mutation materialises or updates the view as needed. A `forwarded` view that is never read is never materialised. Pattern term ids are cached after first resolution. A provably empty nested view does not attach an observer.
- Mutation *during* an in-progress iteration (sync iterator or async stream): every pass stays stable as of when it started. A matching mutation freezes a baseline for the active iteration generation, and open iterations switch to that baseline. Baselines are released when the last iteration closes (or the stream is destroyed).
- Store-level `matchSemantics` is validated at construction. Internal `match()` calls (`Store#deleteMatches`, `Store#toStream`, and view fallbacks) always use `lazy`, so a non-lazy store default cannot leak observers through them. An `''` graph pattern means the default graph, matching `getQuads`.
- The checked-in scenario benchmark is `perf/N3StoreMatchSemantics-perf.js`; comparative base/head measurements are below.

## Performance impact

The feature was benchmarked between exact revisions `a624b55` (base) and `a41e11e` (feature implementation) on an Apple M1 with 16 GB RAM, macOS/Darwin 25.6.0, and Node.js 22.21.1. Both revisions were built in isolated directories against the same dependencies.

The comparative harness used ABBA ordering (base, PR, PR, base) for each sample, forced GC between samples, and reported the median paired ratio. Two independent runs used a 128 × 128 store (16,384 quads) with:

- 16 full match/iteration passes (262,144 yielded quads);
- 16,384 view constructions;
- 65,536 parent mutations; and
- 128 open views for observer fan-out (about 8.4 million pattern checks per sample).

| Comparison | Relative cost |
| --- | ---: |
| PR default mutation path vs base, no observers | parity; no repeatable regression |
| PR default `lazy` view construction vs base | **1.09×** (+9%) in both runs |
| PR default `lazy` match + full iteration vs base | **1.02–1.04×** (+2–4%) |
| PR `snapshot` view construction vs PR `lazy` | **1.16–1.19×** (+16–19%) |
| PR `snapshot` match + full iteration vs PR `lazy` | **1.24–1.25×** (+24–25%) |
| PR `forwarded` match + full iteration vs PR `lazy` | **1.13–1.30×** (+13–30%) |
| PR observer fan-out vs PR with no observers | `snapshot`: **1.6–2.3×**; `forwarded`: **1.7–1.8×** |

The iterator-safety cleanup (`3b0db3a`) was also compared directly with `a41e11e` using the same paired method and a higher iteration workload. Median ratios were 0.98× for default iteration, 0.98× for snapshot iteration, 1.04× for forwarded iteration, 0.97× for default view construction, and 0.92× for observer fan-out. These differences were within run-to-run noise; no repeatable cleanup regression was found.

The final recursive-forwarding and pattern-safety change (`889f35d`) was compared directly with the preceding PR tip (`8fae640`) using the same ABBA method, with 9 measured rounds after 4 warm-ups on a 64 × 64 store. Default match iteration was 1.00×, forwarded iteration was 0.99×, and existing top-level observer fan-out was 0.99×. Matching `addAll` through a forwarded view measured 1.02× and 1.03× in two runs, reflecting the new validation but remaining within the harness's noise threshold. Recursive-child cases were compared with equivalent manually flattened root views at the preceding tip—rather than its behaviorally different snapshot children—and measured 1.05× for matching writes and 0.84× for mutation fan-out; the paired samples crossed parity in both cases, so neither is claimed as a repeatable regression or improvement.

The default-path cost is concentrated in constructing a view (validation and view state); normal parent mutations retain the allocation-free null guard. The non-default costs are opt-in: stable iteration adds generation bookkeeping, while mutation fan-out scales with the number of attached views. These figures are microbenchmarks and should be read as relative costs on this machine, not universal throughput numbers.

To run the checked-in scenario benchmark:

```sh
npm run build
node perf/N3StoreMatchSemantics-perf.js 128
```

Closes #595
