### PR TITLE
fix: parse literal subjects and predicates in N3 mode

### DIFF
--- a/src/N3Parser.js
+++ b/src/N3Parser.js
@@ -302,6 +302,18 @@ export default class N3Parser {
       // Additional semicolons can be safely ignored
       return this._predicate !== null ? this._readPredicate :
              this._error('Expected predicate but got ;', token);
+    case 'literal':
+      if (!this._n3Mode)
+        return this._error('Unexpected literal', token);
+
+      if (token.prefix.length === 0) {
+        this._literalValue = token.value;
+        return this._completePredicateLiteral;
+      }
+      else
+        this._predicate = this._factory.literal(token.value, this._factory.namedNode(token.prefix));
+
+      break;
     case '[':
       if (this._n3Mode) {
         // Start a new quad with a new blank node as subject
@@ -603,6 +615,8 @@ export default class N3Parser {
       const term = this._factory.literal(this._literalValue, { language: this._literalLanguage, direction: token.value });
       if (component === 'subject')
         this._subject = term;
+      else if (component === 'predicate')
+        this._predicate = term;
       else
         this._object = term;
       this._literalLanguage = undefined;
@@ -611,19 +625,46 @@ export default class N3Parser {
 
     if (component === 'subject')
       return token === null ? this._readPredicateOrNamedGraph : this._readPredicateOrNamedGraph(token);
+    if (component === 'predicate')
+      return token === null ? this._readObject : this._readObject(token);
     return this._completeObjectLiteralPost(token, listItem);
   }
 
   // Completes a literal in subject position
   _completeSubjectLiteral(token) {
     const completed = this._completeLiteral(token, 'subject');
+    if (!completed)
+      return;
+
     this._subject = completed.literal;
 
     // Postpone completion if the literal is only partially completed (such as lang+dir).
     if (completed.readCb)
       return completed.readCb.bind(this, false);
 
-    return this._readPredicateOrNamedGraph;
+    // If the token was consumed as a datatype, continue with the predicate;
+    // otherwise, consume the token now
+    return completed.token === null ?
+           this._readPredicateOrNamedGraph : this._readPredicateOrNamedGraph(completed.token);
+  }
+
+  // Completes a literal in predicate position
+  _completePredicateLiteral(token) {
+    const completed = this._completeLiteral(token, 'predicate');
+    if (!completed)
+      return;
+
+    this._predicate = completed.literal;
+    this._validAnnotation = true;
+
+    // Postpone completion if the literal is only partially completed (such as lang+dir).
+    if (completed.readCb)
+      return completed.readCb.bind(this, false);
+
+    // If the token was consumed as a datatype, continue with the object;
+    // otherwise, consume the token now
+    return completed.token === null ?
+           this._readObject : this._readObject(completed.token);
   }
 
   // Completes a literal in object position

--- a/src/N3Parser.js
+++ b/src/N3Parser.js
@@ -630,41 +630,40 @@ export default class N3Parser {
     return this._completeObjectLiteralPost(token, listItem);
   }
 
-  // Completes a literal in subject position
-  _completeSubjectLiteral(token) {
-    const completed = this._completeLiteral(token, 'subject');
+  // Completes a literal in subject or predicate position
+  _completeTermLiteral(token, component) {
+    const completed = this._completeLiteral(token, component);
     if (!completed)
       return;
 
-    this._subject = completed.literal;
+    let next;
+    if (component === 'subject') {
+      this._subject = completed.literal;
+      next = this._readPredicateOrNamedGraph;
+    }
+    else {
+      this._predicate = completed.literal;
+      this._validAnnotation = true;
+      next = this._readObject;
+    }
 
     // Postpone completion if the literal is only partially completed (such as lang+dir).
     if (completed.readCb)
       return completed.readCb.bind(this, false);
 
-    // If the token was consumed as a datatype, continue with the predicate;
+    // If the token was consumed as a datatype, continue with the next component;
     // otherwise, consume the token now
-    return completed.token === null ?
-           this._readPredicateOrNamedGraph : this._readPredicateOrNamedGraph(completed.token);
+    return completed.token === null ? next : next.call(this, completed.token);
+  }
+
+  // Completes a literal in subject position
+  _completeSubjectLiteral(token) {
+    return this._completeTermLiteral(token, 'subject');
   }
 
   // Completes a literal in predicate position
   _completePredicateLiteral(token) {
-    const completed = this._completeLiteral(token, 'predicate');
-    if (!completed)
-      return;
-
-    this._predicate = completed.literal;
-    this._validAnnotation = true;
-
-    // Postpone completion if the literal is only partially completed (such as lang+dir).
-    if (completed.readCb)
-      return completed.readCb.bind(this, false);
-
-    // If the token was consumed as a datatype, continue with the object;
-    // otherwise, consume the token now
-    return completed.token === null ?
-           this._readObject : this._readObject(completed.token);
+    return this._completeTermLiteral(token, 'predicate');
   }
 
   // Completes a literal in object position

--- a/test/N3Parser-test.js
+++ b/test/N3Parser-test.js
@@ -2115,6 +2115,12 @@ describe('Parser', () => {
         'Unexpected literal on line 1.'),
     );
 
+    it(
+      'should not parse a literal as predicate',
+      shouldNotParse(parser, '<a> "1" <b>.',
+        'Unexpected literal on line 1.'),
+    );
+
     it('should parse a triple term', shouldParse(parser, '<a> <b> <<(<a> <b> <c>)>>.',
         ['a', 'b', ['a', 'b', 'c']]));
 
@@ -2215,6 +2221,16 @@ describe('Parser', () => {
     it(
       'should not parse @forAll',
       shouldNotParse(parser, '@forAll <x>.', 'Unexpected "@forAll" on line 1.'),
+    );
+
+    it(
+      'should not parse a literal as subject',
+      shouldNotParse(parser, '"1" <a> <b>.', 'Unexpected literal on line 1.'),
+    );
+
+    it(
+      'should not parse a literal as predicate',
+      shouldNotParse(parser, '<a> "1" <b>.', 'Unexpected literal on line 1.'),
     );
 
     it('should parse a triple term', shouldParse(parser, '<a> <b> <<(<a> <b> <c>)>>.',
@@ -2920,6 +2936,101 @@ describe('Parser', () => {
             ['a', 'b', '_:b0'],
             ['"bonjour"@fr--ltr', 'sameAs', '"hello"@en--rtl', '_:b0'],
         ),
+    );
+
+    it(
+      'should parse an integer literal as subject',
+      shouldParse(parser, '1 <a> <b>.',
+          ['"1"^^http://www.w3.org/2001/XMLSchema#integer', 'a', 'b']),
+    );
+
+    it(
+      'should parse a string literal as subject',
+      shouldParse(parser, '"1" <a> <b>.',
+          ['"1"', 'a', 'b']),
+    );
+
+    it(
+      'should parse a string literal as subject of a formula',
+      shouldParse(parser, '<a> <b> {"1" <c> "2"}.',
+          ['a', 'b', '_:b0'],
+          ['"1"', 'c', '"2"', '_:b0'],
+      ),
+    );
+
+    it(
+      'should parse a string literal as subject of a formula in a blank node',
+      shouldParse(parser, '<a> <b> [ <c> {"1" <d> "2"} ].',
+          ['a', 'b', '_:b0'],
+          ['_:b0', 'c', '_:b1'],
+          ['"1"', 'd', '"2"', '_:b1'],
+      ),
+    );
+
+    it(
+      'should parse a string literal as subject list element',
+      shouldParse(parser, '("1") <a> <b>.',
+          ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', '"1"'],
+          ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil'],
+          ['_:b0', 'a', 'b'],
+      ),
+    );
+
+    it(
+      'should parse a string literal as object list element',
+      shouldParse(parser, '<a> <b> ("1").',
+          ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', '"1"'],
+          ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil'],
+          ['a', 'b', '_:b0'],
+      ),
+    );
+
+    it(
+      'should not parse a string literal as subject with an undefined datatype prefix',
+      shouldNotParse(parser, '"1"^^p:x <a> <b>.',
+        'Undefined prefix "p:" on line 1.'),
+    );
+
+    it(
+      'should parse an integer literal as predicate',
+      shouldParse(parser, '<a> 1 <b>.',
+          ['a', '"1"^^http://www.w3.org/2001/XMLSchema#integer', 'b']),
+    );
+
+    it(
+      'should parse a string literal as predicate',
+      shouldParse(parser, '<a> "1" <b>.',
+          ['a', '"1"', 'b']),
+    );
+
+    it(
+      'should parse a string literal as object',
+      shouldParse(parser, '<a> <b> "1".',
+          ['a', 'b', '"1"']),
+    );
+
+    it(
+      'should parse a literal with datatype as predicate',
+      shouldParse(parser, '<a> "1"^^<c> <b>.',
+          ['a', '"1"^^http://example.org/c', 'b']),
+    );
+
+    it(
+      'should parse a literal with language as predicate',
+      shouldParse(parser, '<a> "one"@en <b>.',
+          ['a', '"one"@en', 'b']),
+    );
+
+    it(
+      'should parse a literal with language and direction as predicate',
+      shouldParse(parser, '<a> "one"@en--ltr <b>.',
+          ['a', '"one"@en--ltr', 'b']),
+    );
+
+    it(
+      'should not parse a string literal as predicate with an undefined datatype prefix',
+      shouldNotParse(parser, '<a> "1"^^p:x <b>.',
+        'Undefined prefix "p:" on line 1.'),
     );
 
     it(


### PR DESCRIPTION
In `text/n3` mode, `_completeSubjectLiteral` dropped the look-ahead token when it was not a datatype or language tag, so a plain string literal as subject (`"1" <a> <b>.`) swallowed the predicate and failed one token later with `Expected entity but got .`. Literals in predicate position were rejected outright, although the N3 grammar allows a literal as a path item in both positions.

`_completeSubjectLiteral` now consumes the look-ahead token (as `_completeObjectLiteralPost` already did) and gains the same `!completed` guard as its object counterpart — previously an error while completing a subject literal (e.g. an undefined datatype prefix) crashed with a `TypeError` in callback mode instead of reporting the parse error. `_readPredicate` accepts literals (incl. datatype, language, and direction) in N3 mode only.

Turtle/TriG still reject literal subjects and predicates (negative tests added); the predicate error message changes from `Expected entity but got literal` to `Unexpected literal`, matching subject position. Tests include the six cases from the issue thread plus the formula cases.

Closes #328

cc @jeswr
