### PR TITLE
fix: use prefixes for local names with interior dots

### DIFF
--- a/src/N3Writer.js
+++ b/src/N3Writer.js
@@ -299,7 +299,7 @@ export default class N3Writer {
       }
       IRIlist = escapeRegex(IRIlist, /[\]\/\(\)\*\+\?\.\\\$]/g, '\\$&');
       this._prefixRegex = new RegExp(`^(?:${prefixList})[^\/]*$|` +
-                                     `^(${IRIlist})([_a-zA-Z0-9][\\-_a-zA-Z0-9]*)$`);
+                                     `^(${IRIlist})([_a-zA-Z0-9](?:\\.?[\\-_a-zA-Z0-9])*)$`);
     }
     // End a prefix block with a newline
     this._write(hasPrefixes ? '\n' : '', done);

--- a/test/N3StreamWriter-test.js
+++ b/test/N3StreamWriter-test.js
@@ -44,6 +44,14 @@ describe('StreamWriter', () => {
                       'a:3a b:3a b:a3.\n'),
     );
 
+    it(
+      'should use prefixes for local names with dots',
+      shouldSerialize({ prefixes: { a: 'http://a.org/' } },
+                      ['http://a.org/v1.0', 'http://a.org/a.b.c', 'http://a.org/d.'],
+                      '@prefix a: <http://a.org/>.\n\n' +
+                      'a:v1.0 a:a.b.c <http://a.org/d.>.\n'),
+    );
+
     it('should take over prefixes from the input stream', done => {
       const inputStream = new Readable(),
           writer = new StreamWriter(),

--- a/test/N3Writer-test.js
+++ b/test/N3Writer-test.js
@@ -288,6 +288,30 @@ describe('Writer', () => {
     );
 
     it(
+      'should use prefixes for local names with dots',
+      shouldSerialize({ prefixes: { a: 'http://a.org/', b: 'http://a.org/b#' } },
+                      ['http://a.org/v1.0', 'http://a.org/b#a.b.c', 'http://a.org/a-1.b-2'],
+                      ['http://a.org/vocab.', 'http://a.org/b#.a', 'http://a.org/b#a..b'],
+                      '@prefix a: <http://a.org/>.\n' +
+                      '@prefix b: <http://a.org/b#>.\n\n' +
+                      'a:v1.0 b:a.b.c a:a-1.b-2.\n' +
+                      '<http://a.org/vocab.> <http://a.org/b#.a> <http://a.org/b#a..b>.\n'),
+    );
+
+    it('should round-trip prefixed names with dots through the parser', async () => {
+      const writer = new Writer({ prefixes: { a: 'http://a.org/' } });
+      const quad = new Quad(new NamedNode('http://a.org/v1.0'),
+                            new NamedNode('http://a.org/p'),
+                            new NamedNode('http://a.org/a.b.c'));
+      writer.addQuad(quad);
+      const output = await new Promise(resolve => {
+        writer.end((error, result) => resolve(result));
+      });
+      expect(output).toBe('@prefix a: <http://a.org/>.\n\na:v1.0 a:p a:a.b.c.\n');
+      expect(new Parser().parse(output)).toStrictEqual([quad]);
+    });
+
+    it(
       'should expand prefixes when possible',
       shouldSerialize({ prefixes: { a: 'http://a.org/', b: 'http://a.org/b#' } },
                       ['a:bc', 'b:ef', 'c:bhi'],


### PR DESCRIPTION
The writer's prefix matcher rejected any dot in the local part, so IRIs like `http://a.org/v1.0` were always written in full even with a matching prefix. Turtle's `PN_LOCAL` allows interior dots, so the matcher now accepts them (`a:v1.0`, `a:a.b.c`) while local names with leading or trailing dots still fall back to full IRIs. Each step of the new pattern consumes at least one non-dot character, so there is no backtracking blow-up (checked against pathological inputs).

Two deliberate limits: consecutive interior dots (`a..b`) are legal `PN_LOCAL` but keep the full-IRI fallback to keep the pattern simple — the fallback is always correct output. And the slash question raised in the thread is out of scope: a raw `/` is not valid in a prefixed local name (that is `PN_LOCAL_ESC` territory) and extending the matcher that way carries the regex-performance risk already noted there.

Closes #372

cc @jeswr
