### PR TITLE
docs: add a recipe for parsing from Web Streams

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,30 @@ function SlowConsumer() {
 A dedicated `prefix` event signals every prefix with `prefix` and `term` arguments.
 A dedicated `comment` event can be enabled by setting `comments: true` in the N3.StreamParser constructor.
 
+### From a Web Stream to quads
+
+N3.js consumes [Node.js streams](http://nodejs.org/api/stream.html) natively,
+but sources such as `fetch` produce [Web Streams](https://developer.mozilla.org/en-US/docs/Web/API/Streams_API).
+On Node.js 17 or higher, convert such a stream into a Node.js stream:
+
+```JavaScript
+const streamParser = new N3.StreamParser(),
+      { Readable } = require('stream');
+Readable.fromWeb(response.body).pipe(streamParser);
+```
+
+In browsers (or anywhere without Node.js streams),
+write the chunks to the parser directly,
+since `N3.StreamParser` exposes a standard writable stream interface:
+
+```JavaScript
+const streamParser = new N3.StreamParser(),
+      reader = response.body.pipeThrough(new TextDecoderStream()).getReader();
+for (let result; !(result = await reader.read()).done;)
+  streamParser.write(result.value);
+streamParser.end();
+```
+
 ## Writing
 
 ### From quads to a string

--- a/README.md
+++ b/README.md
@@ -223,9 +223,12 @@ since `N3.StreamParser` exposes a standard writable stream interface:
 ```JavaScript
 const streamParser = new N3.StreamParser(),
       reader = response.body.pipeThrough(new TextDecoderStream()).getReader();
-for (let result; !(result = await reader.read()).done;)
-  streamParser.write(result.value);
-streamParser.end();
+(async () => {
+  for (let result; !(result = await reader.read()).done;)
+    if (!streamParser.write(result.value))
+      await new Promise(resolve => streamParser.once('drain', resolve));
+  streamParser.end();
+})();
 ```
 
 ## Writing


### PR DESCRIPTION
The parser only consumes Node.js streams, which regularly trips up users receiving Web Streams from `fetch` (see #359). Per the discussion there, this documents the two interop directions in the README instead of adding native Web Streams support: `Readable.fromWeb` on Node.js ≥ 17, and writing decoded chunks straight to `N3.StreamParser`'s writable side elsewhere.

Both snippets were execution-verified against the published package (4/4 quads parsed from a sample Turtle document).

Closes #359

cc @jeswr