### PR TITLE
docs: note prefix/comment event ordering on StreamParser

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,14 @@ function SlowConsumer() {
 A dedicated `prefix` event signals every prefix with `prefix` and `term` arguments.
 A dedicated `comment` event can be enabled by setting `comments: true` in the N3.StreamParser constructor.
 
+Note that `prefix` and `comment` events are emitted as soon as they are parsed,
+whereas quads can remain buffered until the consumer is ready to read them.
+The order of these events relative to `data` events is therefore
+not guaranteed to match the position of prefixes and comments in the document.
+If their position matters,
+use `N3.Parser` with the `onQuad`, `onPrefix` and `onComment` callbacks instead,
+which are invoked in document order.
+
 ## Writing
 
 ### From quads to a string

--- a/src/N3StreamParser.js
+++ b/src/N3StreamParser.js
@@ -1,6 +1,4 @@
 // **N3StreamParser** parses a text stream into a quad stream.
-// Because quads can remain buffered until the consumer reads them,
-// `prefix` and `comment` events are not synchronized with `data` events.
 import { Transform } from 'readable-stream';
 import N3Parser from './N3Parser';
 

--- a/src/N3StreamParser.js
+++ b/src/N3StreamParser.js
@@ -1,4 +1,6 @@
 // **N3StreamParser** parses a text stream into a quad stream.
+// Because quads can remain buffered until the consumer reads them,
+// `prefix` and `comment` events are not synchronized with `data` events.
 import { Transform } from 'readable-stream';
 import N3Parser from './N3Parser';
 


### PR DESCRIPTION
On `N3.StreamParser`, `prefix` and `comment` events are emitted as soon as they are parsed, while quads can remain buffered in the Transform's readable queue, so their order relative to `data` events need not match the document. Verified empirically: with the README's SlowConsumer pattern, a later prefix and trailing comment were observed before earlier quads were delivered. This adds a warning paragraph to the README pointing users who need document-order positioning to `N3.Parser` with `onQuad`/`onPrefix`/`onComment`, whose callbacks were verified to fire in document order.

Closes #440

cc @jeswr
