### PR TITLE
chore(tests): enable jest/expect-expect

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -316,9 +316,15 @@ export default [
         ],
       }],
 
-      // Still disabled: N3Store-test.js asserts in `describe` bodies and
-      // `beforeAll` hooks while building up its shared mutable stores;
-      // enabling this requires restructuring those suites.
+      // The `0` entries below override rules that `jest.configs['flat/recommended']`
+      // (spread into the preceding `test/**` config object) enables as `error`;
+      // in flat config, the later entry for the same files wins.
+      //
+      // `jest/no-standalone-expect` stays off — independently of
+      // `jest/expect-expect` above — because N3Store-test.js has ~40
+      // standalone `expect`s in `describe` bodies and `beforeAll` hooks
+      // while building up its shared mutable stores; enabling it requires
+      // restructuring those suites.
       'jest/no-standalone-expect': 0,
       'jest/no-done-callback': 0,
       'jest/no-identical-title': 0,

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -295,8 +295,31 @@ export default [
     },
     rules: {
       // jest rule overrides (was in the root .eslintrc)
+      // The test suites assert through shared helpers that either return the
+      // test body (`it('…', shouldParse(…))`) or call `expect` internally.
+      'jest/expect-expect': [2, {
+        assertFunctionNames: [
+          'expect',
+          'forResultStream',
+          'shouldCallbackComments',
+          'shouldEmitComments',
+          'shouldEmitPrefixes',
+          'shouldIncludeAll',
+          'shouldNotEmitCommentsWhenNotEnabled',
+          'shouldNotParse',
+          'shouldNotParseWithComments',
+          'shouldNotTokenize',
+          'shouldParse',
+          'shouldParseWithCommentsEnabled',
+          'shouldSerialize',
+          'shouldTokenize',
+        ],
+      }],
+
+      // Still disabled: N3Store-test.js asserts in `describe` bodies and
+      // `beforeAll` hooks while building up its shared mutable stores;
+      // enabling this requires restructuring those suites.
       'jest/no-standalone-expect': 0,
-      'jest/expect-expect': 0,
       'jest/no-done-callback': 0,
       'jest/no-identical-title': 0,
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -316,15 +316,6 @@ export default [
         ],
       }],
 
-      // The `0` entries below override rules that `jest.configs['flat/recommended']`
-      // (spread into the preceding `test/**` config object) enables as `error`;
-      // in flat config, the later entry for the same files wins.
-      //
-      // `jest/no-standalone-expect` stays off — independently of
-      // `jest/expect-expect` above — because N3Store-test.js has ~40
-      // standalone `expect`s in `describe` bodies and `beforeAll` hooks
-      // while building up its shared mutable stores; enabling it requires
-      // restructuring those suites.
       'jest/no-standalone-expect': 0,
       'jest/no-done-callback': 0,
 

--- a/test/N3Lexer-test.js
+++ b/test/N3Lexer-test.js
@@ -1106,7 +1106,7 @@ describe('Lexer', () => {
     );
 
     it('does not call setEncoding if not available', () => {
-      new Lexer().tokenize({ on: function () {} });
+      expect(() => new Lexer().tokenize({ on: function () {} })).not.toThrow();
     });
 
     it('should tokenize an TripleTerm start', shouldTokenize('<<(',

--- a/test/N3Parser-test.js
+++ b/test/N3Parser-test.js
@@ -1322,7 +1322,7 @@ describe('Parser', () => {
     );
 
     it('should not error if there is no triple callback', () => {
-      new Parser().parse('');
+      expect(() => new Parser().parse('')).not.toThrow();
     });
 
     it('should return prefixes through a callback', done => {

--- a/test/N3Writer-test.js
+++ b/test/N3Writer-test.js
@@ -371,7 +371,11 @@ describe('Writer', () => {
         write: function () {},
         end: function () { throw new Error('error'); },
       });
-      writer.end(done);
+      writer.end(error => {
+        // A failing stream end is swallowed; done is still called without error
+        expect(error).toBeUndefined();
+        done();
+      });
     });
 
     it('sends output through end when no stream argument is given', done => {


### PR DESCRIPTION
Enables `jest/expect-expect` in the test ESLint config, listing the suites' shared assertion helpers (`shouldParse`, `shouldTokenize`, `shouldSerialize`, …) in `assertFunctionNames`. The rule surfaced three tests that asserted nothing; they now assert the behaviour their titles describe (no-throw for the lexer/parser cases, and that a failing output-stream `end` is swallowed so the writer's `done` callback is called without an error).

`jest/no-standalone-expect` stays disabled for now: N3Store-test.js asserts in `describe` bodies and `beforeAll` hooks while building up shared mutable stores, and enabling it means restructuring those suites — better as its own change.

Refs #453

cc @jeswr