### PR TITLE
fix: write empty named nodes as <>

### DIFF
--- a/src/N3Writer.js
+++ b/src/N3Writer.js
@@ -85,7 +85,9 @@ export default class N3Writer {
   _writeQuad(subject, predicate, object, graph, done) {
     try {
       // Write the graph's label if it has changed
-      if (!graph.equals(this._graph)) {
+      // (the id-based fast path of `equals` would conflate
+      // the empty named node `<>` with the default graph)
+      if (!graph.equals(this._graph) || graph.termType !== this._graph.termType) {
         // Close the previous graph and start the new one
         this._write((this._subject === null ? '' : (this._inDefaultGraph ? '.\n' : '\n}\n')) +
                     (DEFAULTGRAPH.equals(graph) ? '' : `${this._encodeIriOrBlank(graph)} {\n`));
@@ -125,7 +127,7 @@ export default class N3Writer {
     return  `${this._encodeSubject(subject)} ${
             this._encodeIriOrBlank(predicate)} ${
             this._encodeObject(object)
-            }${graph && graph.value ? ` ${this._encodeIriOrBlank(graph)} .\n` : ' .\n'}`;
+            }${graph && !isDefaultGraph(graph) ? ` ${this._encodeIriOrBlank(graph)} .\n` : ' .\n'}`;
   }
 
   // ### `quadsToString` serializes an array of quads as a string

--- a/test/N3Writer-test.js
+++ b/test/N3Writer-test.js
@@ -37,6 +37,20 @@ describe('Writer', () => {
       ).toBe('<a> <b> <c> <g> .\n');
     });
 
+    it('should serialize a quad with an empty named node as graph', () => {
+      const writer = new Writer();
+      expect(
+        writer.quadToString(new NamedNode('a'), new NamedNode('b'), new NamedNode('c'), new NamedNode('')),
+      ).toBe('<a> <b> <c> <> .\n');
+    });
+
+    it('should serialize a triple with empty named nodes', () => {
+      const writer = new Writer();
+      expect(
+        writer.quadToString(new NamedNode(''), new NamedNode(''), new NamedNode('')),
+      ).toBe('<> <> <> .\n');
+    });
+
     it('should serialize an array of triples', () => {
       const writer = new Writer();
       const triples = [new Quad(new NamedNode('a'), new NamedNode('b'), new NamedNode('c')),
@@ -355,6 +369,53 @@ describe('Writer', () => {
     );
 
     it(
+      'should serialize an empty named node as subject',
+      shouldSerialize([new NamedNode(''), 'def', 'ghi'],
+                      '<> <def> <ghi>.\n'),
+    );
+
+    it(
+      'should serialize an empty named node as predicate',
+      shouldSerialize(['abc', new NamedNode(''), 'ghi'],
+                      '<abc> <> <ghi>.\n'),
+    );
+
+    it(
+      'should serialize an empty named node as object',
+      shouldSerialize(['abc', 'def', new NamedNode('')],
+                      '<abc> <def> <>.\n'),
+    );
+
+    it(
+      'should serialize an empty named node as graph',
+      shouldSerialize(['abc', 'def', 'ghi', new NamedNode('')],
+                      '<> {\n<abc> <def> <ghi>\n}\n'),
+    );
+
+    it(
+      'should not merge an empty named graph into the default graph',
+      shouldSerialize(['abc', 'def', 'ghi', ''],
+                      ['jkl', 'mno', 'pqr', new NamedNode('')],
+                      ['stu', 'vwx', 'yz',  ''],
+                      '<abc> <def> <ghi>.\n' +
+                      '<> {\n<jkl> <mno> <pqr>\n}\n' +
+                      '<stu> <vwx> <yz>.\n'),
+    );
+
+    it('round-trips a triple with an empty named node', done => {
+      const input = '<> <http://ex.org/p> <http://ex.org/o>.\n';
+      const quads = new Parser().parse(input);
+      expect(quads[0].subject).toEqual(new NamedNode(''));
+      const writer = new Writer();
+      writer.addQuads(quads);
+      writer.end((error, output) => {
+        expect(output).toBe(input);
+        expect(new Parser().parse(output)).toEqual(quads);
+        done(error);
+      });
+    });
+
+    it(
       'should output 8-bit unicode characters as escape sequences',
       shouldSerialize(['\ud835\udc00', '\ud835\udc00', '"\ud835\udc00"^^\ud835\udc00', '\ud835\udc00'],
                       '<\\U0001d400> {\n<\\U0001d400> <\\U0001d400> "\\U0001d400"^^<\\U0001d400>\n}\n'),
@@ -460,6 +521,19 @@ describe('Writer', () => {
         new NamedNode('http://example.org/foo/cdeFgh/ijk')));
       writer.end((error, output) => {
         expect(output).toBe('<> <#b> <cdeFgh/ijk>.\n');
+        done(error);
+      });
+    });
+
+    it('uses a base IRI to relativize a graph to the empty IRI', done => {
+      const writer = new Writer({ baseIRI: 'http://example.org/foo/' });
+      writer.addQuad(new Quad(
+        new NamedNode('http://example.org/foo/a'),
+        new NamedNode('http://example.org/foo/b'),
+        new NamedNode('http://example.org/foo/c'),
+        new NamedNode('http://example.org/foo/')));
+      writer.end((error, output) => {
+        expect(output).toBe('<> {\n<a> <b> <c>\n}\n');
         done(error);
       });
     });


### PR DESCRIPTION
A quad in graph `NamedNode('')` was silently merged into the default graph (the id-based fast path of `equals` treats the two as equal), and `quadToString` dropped such a graph via a `graph.value` truthiness check. Both now serialize the graph as `<>`, matching the existing behaviour for empty named nodes in the other three positions, so output stays valid Turtle/TriG and round-trips.

Refs #246 — this covers only the writer layer; the store still conflates `NamedNode('')` with the default graph (both use `''` as internal id), which is left for a separate change.

cc @jeswr