### PR TITLE
feat: let extractLists tolerate lists with extra arcs

### DIFF
--- a/src/N3Store.js
+++ b/src/N3Store.js
@@ -758,20 +758,26 @@ export default class N3Store {
 
   // ### `extractLists` finds and removes all list triples
   // and returns the items per list.
-  extractLists({ remove = false, ignoreErrors = false } = {}) {
+  // With `allowExtraArcs`, lists whose nodes carry arcs other than
+  // rdf:first/rdf:rest are returned as well,
+  // but left intact when `remove` is set.
+  extractLists({ remove = false, ignoreErrors = false, allowExtraArcs = false } = {}) {
     const lists = {}; // has scalar keys so could be a simple Object
     const onError = ignoreErrors ? (() => true) :
                   ((node, message) => { throw new Error(`${node.value} ${message}`); });
 
     // Traverse each list from its tail
     const tails = this.getQuads(null, namespaces.rdf.rest, namespaces.rdf.nil, null);
-    const toRemove = remove ? [...tails] : [];
+    const toRemove = [];
     tails.forEach(tailQuad => {
       const items = [];             // the members found as objects of rdf:first quads
       let malformed = false;      // signals whether the current list is malformed
+      let extraArcs = false;      // signals whether the current list has extra arcs
       let head;                   // the head of the list (_:b1 in above example)
       let headPos;                // set to subject or object when head is set
       const graph = tailQuad.graph; // make sure list is in exactly one graph
+      const removeStart = toRemove.length; // where this list's quads start in toRemove
+      toRemove.push(tailQuad);
 
       // Traverse the list from tail to end
       let current = tailQuad.subject;
@@ -805,8 +811,12 @@ export default class N3Store {
           }
 
           // alien triple
-          else if (objectQuads.length)
-            malformed = onError(current, 'can\'t be subject and object');
+          else if (objectQuads.length) {
+            if (allowExtraArcs)
+              extraArcs = true;
+            else
+              malformed = onError(current, `has non-list arc ${quad.predicate.value}`);
+          }
           else {
             head = quad; // e.g. { (1 2 3) :p :o }
             headPos = 'subject';
@@ -843,9 +853,14 @@ export default class N3Store {
       // Don't remove any quads if the list is malformed
       if (malformed)
         remove = false;
-      // Store the list under the value of its head
-      else if (head)
-        lists[head[headPos].value] = items;
+      else {
+        // Store the list under the value of its head
+        if (head)
+          lists[head[headPos].value] = items;
+        // Leave lists with extra arcs fully intact
+        if (extraArcs)
+          toRemove.length = removeStart;
+      }
     });
 
     // Remove list quads if requested

--- a/src/N3Store.js
+++ b/src/N3Store.js
@@ -760,7 +760,8 @@ export default class N3Store {
   // and returns the items per list.
   // With `allowExtraArcs`, lists whose nodes carry arcs other than
   // rdf:first/rdf:rest are returned as well,
-  // but left intact when `remove` is set.
+  // but left intact when `remove` is set. Ambiguous unreferenced list heads
+  // with multiple non-list arcs remain errors.
   extractLists({ remove = false, ignoreErrors = false, allowExtraArcs = false } = {}) {
     const lists = {}; // has scalar keys so could be a simple Object
     const onError = ignoreErrors ? (() => true) :
@@ -776,8 +777,7 @@ export default class N3Store {
       let head;                   // the head of the list (_:b1 in above example)
       let headPos;                // set to subject or object when head is set
       const graph = tailQuad.graph; // make sure list is in exactly one graph
-      const removeStart = toRemove.length; // where this list's quads start in toRemove
-      toRemove.push(tailQuad);
+      const listQuads = [];       // rdf:first/rdf:rest quads of this list
 
       // Traverse the list from tail to end
       let current = tailQuad.subject;
@@ -799,7 +799,9 @@ export default class N3Store {
             if (first)
               malformed = onError(current, 'has multiple rdf:first arcs');
             else
-              toRemove.push(first = quad);
+              first = quad;
+            if (remove && first === quad)
+              listQuads.push(quad);
           }
 
           // one rdf:rest
@@ -807,7 +809,9 @@ export default class N3Store {
             if (rest)
               malformed = onError(current, 'has multiple rdf:rest arcs');
             else
-              toRemove.push(rest = quad);
+              rest = quad;
+            if (remove && rest === quad)
+              listQuads.push(quad);
           }
 
           // alien triple
@@ -857,9 +861,9 @@ export default class N3Store {
         // Store the list under the value of its head
         if (head)
           lists[head[headPos].value] = items;
-        // Leave lists with extra arcs fully intact
-        if (extraArcs)
-          toRemove.length = removeStart;
+        // Leave lists with extra arcs fully intact; otherwise queue this list once.
+        if (remove && !extraArcs)
+          toRemove.push(...listQuads);
       }
     });
 

--- a/test/N3Store-test.js
+++ b/test/N3Store-test.js
@@ -1,5 +1,6 @@
 import {
   Store,
+  Parser,
   termFromId, termToId,
   EntityIndex,
   DataFactory,
@@ -1902,7 +1903,110 @@ describe('Store', () => {
     ).toBe(true);
 
     it('extractLists throws an error', () => {
-      expect(() => store.extractLists()).toThrow('b4 can\'t be subject and object');
+      expect(() => store.extractLists()).toThrow('b4 has non-list arc http://a.example/foo');
+    });
+
+    it(
+      'extractLists with allowExtraArcs returns no lists and does not delete triples',
+      () => {
+        const size = store.size;
+        expect(listsToJSON(store.extractLists({ allowExtraArcs: true, remove: true }))).toEqual({});
+        expect(store.size).toBe(size);
+      },
+    );
+  });
+
+  // Fixture of https://github.com/rdfjs/N3.js/issues/546
+  describe('A Store containing an rdf:Collection with an extra arc on its head', () => {
+    const ex = 'http://example.org/', foaf = 'http://xmlns.com/foaf/0.1/';
+    const rdfList = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#List';
+    const listDocument = `
+      @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+      @prefix foaf: <${foaf}> .
+      @prefix : <${ex}> .
+
+      :alice foaf:name  "Alice" .
+      :bob   foaf:name  "Bob" .
+      :cal   foaf:knows :1 .
+
+      :1 rdf:first :alice ; rdf:rest :2 .
+      :2 rdf:first :bob   ; rdf:rest rdf:nil .
+
+      :1 a rdf:List .`;
+    const listQuads = [
+      [`${ex}alice`, `${foaf}name`, '"Alice"'],
+      [`${ex}bob`, `${foaf}name`, '"Bob"'],
+      [`${ex}cal`, `${foaf}knows`, `${ex}1`],
+      [`${ex}1`, namespaces.rdf.first, `${ex}alice`],
+      [`${ex}1`, namespaces.rdf.rest, `${ex}2`],
+      [`${ex}2`, namespaces.rdf.first, `${ex}bob`],
+      [`${ex}2`, namespaces.rdf.rest, namespaces.rdf.nil],
+      [`${ex}1`, namespaces.rdf.type, rdfList],
+    ];
+    const listItemsJSON = {
+      [`${ex}1`]: [
+        { termType: 'NamedNode', value: `${ex}alice` },
+        { termType: 'NamedNode', value: `${ex}bob` },
+      ],
+    };
+
+    describe('extractLists without allowExtraArcs', () => {
+      const store = new Store(new Parser().parse(listDocument));
+      it('throws an error naming the extra arc', () => {
+        expect(() => store.extractLists())
+          .toThrow(`${ex}1 has non-list arc ${namespaces.rdf.type}`);
+      });
+    });
+
+    describe('extractLists with ignoreErrors but without allowExtraArcs', () => {
+      const store = new Store(new Parser().parse(listDocument));
+      const lists = store.extractLists({ ignoreErrors: true, remove: true });
+      it('should generate an empty list of Collections', () => {
+        expect(listsToJSON(lists)).toEqual({});
+      });
+      it('should not delete triples', shouldIncludeAll(store.getQuads(), ...listQuads));
+    });
+
+    describe('extractLists with allowExtraArcs without remove', () => {
+      const store = new Store(new Parser().parse(listDocument));
+      const lists = store.extractLists({ allowExtraArcs: true });
+      it('should generate a list of Collections', () => {
+        expect(listsToJSON(lists)).toEqual(listItemsJSON);
+      });
+      it('should not delete triples', shouldIncludeAll(store.getQuads(), ...listQuads));
+    });
+
+    describe('extractLists with allowExtraArcs and remove', () => {
+      const store = new Store(new Parser().parse(listDocument));
+      // Add a second list without extra arcs, which should still be removed
+      store.addQuad(new NamedNode(`${ex}cal`), new NamedNode(`${foaf}knows`), new NamedNode(`${ex}3`));
+      store.addQuad(new NamedNode(`${ex}3`), new NamedNode(namespaces.rdf.first), new NamedNode(`${ex}alice`));
+      store.addQuad(new NamedNode(`${ex}3`), new NamedNode(namespaces.rdf.rest), new NamedNode(namespaces.rdf.nil));
+      const lists = store.extractLists({ allowExtraArcs: true, remove: true });
+      it('should generate a list of Collections with both lists', () => {
+        expect(listsToJSON(lists)).toEqual({
+          ...listItemsJSON,
+          [`${ex}3`]: [{ termType: 'NamedNode', value: `${ex}alice` }],
+        });
+      });
+      it(
+        'should leave the list with extra arcs intact but remove the other list',
+        shouldIncludeAll(store.getQuads(), ...listQuads, [`${ex}cal`, `${foaf}knows`, `${ex}3`]),
+      );
+    });
+
+    describe('extractLists with allowExtraArcs and ignoreErrors', () => {
+      const store = new Store(new Parser().parse(listDocument));
+      // Add a malformed list, which should still disable removal altogether
+      store.addQuad(store.createBlankNode(), new NamedNode(namespaces.rdf.rest), new NamedNode(namespaces.rdf.nil));
+      const size = store.size;
+      const lists = store.extractLists({ allowExtraArcs: true, ignoreErrors: true, remove: true });
+      it('should generate a list of Collections without the malformed list', () => {
+        expect(listsToJSON(lists)).toEqual(listItemsJSON);
+      });
+      it('should not delete triples', () => {
+        expect(store.size).toBe(size);
+      });
     });
   });
 


### PR DESCRIPTION
`extractLists()` currently declares a list malformed as soon as one of its nodes carries any arc besides `rdf:first`/`rdf:rest` (e.g. `:1 a rdf:List`), which is common in real-world ontologies.

This adds an opt-in `allowExtraArcs` option: such lists are returned in the mapping, but their quads are never pushed to the removal set, so with `remove: true` they are left fully intact (like malformed lists today) and nothing dangles. The default stays strict on purpose: the result typically feeds the writer's `lists` option, and silently dropping extra arcs there would make round-tripping lossy — with the option enabled, callers accept that remaining `rdf:first`/`rdf:rest` quads coexist with the returned mapping.

Also improves the error the reporter hit: `:1 can't be subject and object` now reads `:1 has non-list arc http://...ns#type`, naming the offending predicate.

Note: a list head that has no incoming arcs and carries both a subject-position use and an extra arc remains an error even with the option, since it is ambiguous which arc references the list.

Naming is up for debate — `allowExtraArcs` vs e.g. `tolerateExtraArcs`/`lenient`; happy to rename.

Closes #546

cc @jeswr