### PR TITLE
fix: accept lists in the predicate position in N3 mode

### DIFF
--- a/src/N3Parser.js
+++ b/src/N3Parser.js
@@ -202,6 +202,18 @@ export default class N3Parser {
     return value;
   }
 
+  // ### `_readList` starts reading a list in the subject, predicate, or object position
+  _readList(token, subject, predicate, object) {
+    const stack = this._contextStack, parent = stack.length && stack[stack.length - 1];
+    if (parent.type === '<<') {
+      return this._error('Unexpected list in reified triple', token);
+    }
+    // Start a new list
+    this._saveContext('list', this._graph, subject, predicate, object);
+    this._subject = null;
+    return this._readListItem;
+  }
+
   // ### `_readSubject` reads a quad's subject
   _readSubject(token) {
     this._predicate = null;
@@ -212,14 +224,7 @@ export default class N3Parser {
                         this._subject = this._factory.blankNode(), null, null);
       return this._readBlankNodeHead;
     case '(':
-      const stack = this._contextStack, parent = stack.length && stack[stack.length - 1];
-      if (parent.type === '<<') {
-        return this._error('Unexpected list in reified triple', token);
-      }
-      // Start a new list
-      this._saveContext('list', this._graph, this.RDF_NIL, null, null);
-      this._subject = null;
-      return this._readListItem;
+      return this._readList(token, this.RDF_NIL, null, null);
     case '{':
       // Start a new formula
       if (!this._n3Mode)
@@ -302,6 +307,11 @@ export default class N3Parser {
       // Additional semicolons can be safely ignored
       return this._predicate !== null ? this._readPredicate :
              this._error('Expected predicate but got ;', token);
+    case '(':
+      // In N3, a list can be a predicate
+      return this._n3Mode ?
+        this._readList(token, this._subject, this.RDF_NIL, null) :
+        this._error(`Expected entity but got ${type}`, token);
     case '[':
       if (this._n3Mode) {
         // Start a new quad with a new blank node as subject
@@ -340,14 +350,7 @@ export default class N3Parser {
                         this._subject = this._factory.blankNode());
       return this._readBlankNodeHead;
     case '(':
-      const stack = this._contextStack, parent = stack.length && stack[stack.length - 1];
-      if (parent.type === '<<') {
-        return this._error('Unexpected list in reified triple', token);
-      }
-      // Start a new list
-      this._saveContext('list', this._graph, this._subject, this._predicate, this.RDF_NIL);
-      this._subject = null;
-      return this._readListItem;
+      return this._readList(token, this._subject, this._predicate, this.RDF_NIL);
     case '{':
       // Start a new formula
       if (!this._n3Mode)
@@ -479,6 +482,14 @@ export default class N3Parser {
         if (this._subject === this.RDF_NIL)
           return next;
       }
+      // Was this list the parent's predicate?
+      else if (this._object === null) {
+        // The next token is the object
+        next = this._readObject;
+        // No list tail if this was an empty list
+        if (this._predicate === this.RDF_NIL)
+          return next;
+      }
       // The list was in the parent context's object
       else {
         next = this._getContextEndReader();
@@ -528,9 +539,13 @@ export default class N3Parser {
 
     // Is this the first element of the list?
     if (previousList === null) {
-      // This list is either the subject or the object of its parent
+      // The list is the subject of the parent
       if (parent.predicate === null)
         parent.subject = list;
+      // The list is the predicate of the parent
+      else if (parent.object === null)
+        parent.predicate = list;
+      // The list is the object of the parent
       else
         parent.object = list;
     }

--- a/src/N3Parser.js
+++ b/src/N3Parser.js
@@ -213,6 +213,18 @@ export default class N3Parser {
     return value;
   }
 
+  // ### `_readList` starts reading a list in the subject, predicate, or object position
+  _readList(token, subject, predicate, object) {
+    const stack = this._contextStack, parent = stack.length && stack[stack.length - 1];
+    if (parent.type === '<<') {
+      return this._error('Unexpected list in reified triple', token);
+    }
+    // Start a new list
+    this._saveContext('list', this._graph, subject, predicate, object);
+    this._subject = null;
+    return this._readListItem;
+  }
+
   // ### `_readSubject` reads a quad's subject
   _readSubject(token) {
     this._predicate = null;
@@ -226,14 +238,7 @@ export default class N3Parser {
                         this._subject = this._factory.blankNode(), null, null);
       return this._readBlankNodeHead;
     case '(':
-      const stack = this._contextStack, parent = stack.length && stack[stack.length - 1];
-      if (parent.type === '<<') {
-        return this._error('Unexpected list in reified triple', token);
-      }
-      // Start a new list
-      this._saveContext('list', this._graph, this.RDF_NIL, null, null);
-      this._subject = null;
-      return this._readListItem;
+      return this._readList(token, this.RDF_NIL, null, null);
     case '{':
       // Start a new formula
       if (!this._n3Mode)
@@ -330,6 +335,11 @@ export default class N3Parser {
         this._predicate = this._factory.literal(token.value, this._factory.namedNode(token.prefix));
 
       break;
+    case '(':
+      // In N3, a list can be a predicate
+      return this._n3Mode ?
+        this._readList(token, this._subject, this.RDF_NIL, null) :
+        this._error(`Expected entity but got ${type}`, token);
     case '[':
       if (this._n3Mode) {
         // Start a new quad with a new blank node as subject
@@ -372,14 +382,7 @@ export default class N3Parser {
                         this._subject = this._factory.blankNode());
       return this._readBlankNodeHead;
     case '(':
-      const stack = this._contextStack, parent = stack.length && stack[stack.length - 1];
-      if (parent.type === '<<') {
-        return this._error('Unexpected list in reified triple', token);
-      }
-      // Start a new list
-      this._saveContext('list', this._graph, this._subject, this._predicate, this.RDF_NIL);
-      this._subject = null;
-      return this._readListItem;
+      return this._readList(token, this._subject, this._predicate, this.RDF_NIL);
     case '{':
       // Start a new formula
       if (!this._n3Mode)
@@ -523,6 +526,14 @@ export default class N3Parser {
         if (this._subject === this.RDF_NIL)
           return next;
       }
+      // Was this list the parent's predicate?
+      else if (this._object === null) {
+        // The next token is the object
+        next = this._readObject;
+        // No list tail if this was an empty list
+        if (this._predicate === this.RDF_NIL)
+          return next;
+      }
       // The list was in the parent context's object
       else {
         next = this._getContextEndReader();
@@ -600,9 +611,13 @@ export default class N3Parser {
 
     // Is this the first element of the list?
     if (previousList === null) {
-      // This list is either the subject or the object of its parent
+      // The list is the subject of the parent
       if (parent.predicate === null)
         parent.subject = list;
+      // The list is the predicate of the parent
+      else if (parent.object === null)
+        parent.predicate = list;
+      // The list is the object of the parent
       else
         parent.object = list;
     }

--- a/test/N3Parser-test.js
+++ b/test/N3Parser-test.js
@@ -1,4 +1,4 @@
-import { Parser, NamedNode, BlankNode, Quad, termFromId, DataFactory as DF } from '../src';
+import { Parser, Writer, NamedNode, BlankNode, Quad, termFromId, DataFactory as DF } from '../src';
 import rdfDataModel from '@rdfjs/data-model';
 import { isomorphic } from 'rdf-isomorphic';
 
@@ -3123,6 +3123,186 @@ describe('Parser', () => {
                   ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil'],
                   ['ex:joe', 'f:mother', '_:b1']),
     );
+
+    it(
+      'should parse nested lists in the subject, predicate, and object simultaneously',
+      // Subject ((<a>) (<b> (<c>))): _:b0 [_:b1 (a), _:b2 [_:b3 (b), _:b4 (_:b5 (c))]]
+      // Predicate ((<p>)): _:b6 (_:b7 (p)); object ((<x> (<y>))): _:b8 (_:b9 (x), _:b10 (_:b11 (y)))
+      shouldParse(parser, '((<a>) (<b> (<c>))) ((<p>)) ((<x> (<y>))).',
+                  ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', '_:b1'],
+                  ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', '_:b2'],
+                  ['_:b1', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', 'a'],
+                  ['_:b1', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil'],
+                  ['_:b2', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', '_:b3'],
+                  ['_:b2', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil'],
+                  ['_:b3', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', 'b'],
+                  ['_:b3', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', '_:b4'],
+                  ['_:b4', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', '_:b5'],
+                  ['_:b4', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil'],
+                  ['_:b5', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', 'c'],
+                  ['_:b5', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil'],
+                  ['_:b6', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', '_:b7'],
+                  ['_:b6', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil'],
+                  ['_:b7', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', 'p'],
+                  ['_:b7', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil'],
+                  ['_:b8', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', '_:b9'],
+                  ['_:b8', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil'],
+                  ['_:b9', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', 'x'],
+                  ['_:b9', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', '_:b10'],
+                  ['_:b10', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', '_:b11'],
+                  ['_:b10', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil'],
+                  ['_:b11', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', 'y'],
+                  ['_:b11', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil'],
+                  ['_:b0', '_:b6', '_:b8']),
+    );
+
+    it(
+      'should parse a triple-nested list in the predicate',
+      shouldParse(parser, '<a> (((<p>))) <b>.',
+                  ['a', '_:b0', 'b'],
+                  ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', '_:b1'],
+                  ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil'],
+                  ['_:b1', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', '_:b2'],
+                  ['_:b1', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil'],
+                  ['_:b2', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', 'p'],
+                  ['_:b2', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil']),
+    );
+
+    it(
+      'should parse a nested list in the predicate within a formula',
+      // The list structure belongs to the formula's graph
+      shouldParse(parser, '<s> <p> { <a> ((<q>)) <b>. }.',
+                  ['s', 'p', '_:b0'],
+                  ['a', '_:b1', 'b', '_:b0'],
+                  ['_:b1', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', '_:b2', '_:b0'],
+                  ['_:b1', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil', '_:b0'],
+                  ['_:b2', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', 'q', '_:b0'],
+                  ['_:b2', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil', '_:b0']),
+    );
+
+    it(
+      'should parse empty lists at each depth and position',
+      // An empty list is the IRI rdf:nil, so only non-empty enclosing lists produce cells
+      shouldParse(parser, '(()) (() ()) ((() ())).',
+                  ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil'],
+                  ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil'],
+                  ['_:b1', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil'],
+                  ['_:b1', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', '_:b2'],
+                  ['_:b2', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil'],
+                  ['_:b2', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil'],
+                  ['_:b3', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', '_:b4'],
+                  ['_:b3', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil'],
+                  ['_:b4', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil'],
+                  ['_:b4', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', '_:b5'],
+                  ['_:b5', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil'],
+                  ['_:b5', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil'],
+                  ['_:b0', '_:b1', '_:b3']),
+    );
+
+    it(
+      'should parse lists in every position of a statement in a formula',
+      shouldParse(parser, '{ (<a>) (<p>) (<b>). } => { <x> <y> <z>. }.',
+                  ['_:b1', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', 'a', '_:b0'],
+                  ['_:b1', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil', '_:b0'],
+                  ['_:b2', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', 'p', '_:b0'],
+                  ['_:b2', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil', '_:b0'],
+                  ['_:b3', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', 'b', '_:b0'],
+                  ['_:b3', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil', '_:b0'],
+                  ['_:b1', '_:b2', '_:b3', '_:b0'],
+                  ['x', 'y', 'z', '_:b4'],
+                  ['_:b0', 'http://www.w3.org/2000/10/swap/log#implies', '_:b4']),
+    );
+
+    describe('nested lists across all positions', () => {
+      const RDF_FIRST = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first',
+          RDF_REST = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest',
+          RDF_NIL = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil';
+
+      // A term of depth 0 is a plain IRI;
+      // a term of depth n is a two-element list of an IRI and a term of depth n - 1,
+      // so a term of depth n contributes exactly 2n list cells (4n quads)
+      function nested(depth, name) {
+        return depth === 0 ? `<${name}>` : `(<${name}${depth}> ${nested(depth - 1, name)})`;
+      }
+
+      // Verifies that `term` is the well-formed list produced by `nested(depth, name)`:
+      // each cell has exactly one rdf:first and one rdf:rest arc,
+      // each chain terminates in rdf:nil, and no cell is shared
+      function verifyTerm(term, depth, firsts, rests, seen) {
+        if (depth === 0) {
+          expect(term.termType).toBe('NamedNode');
+          return;
+        }
+        expect(term.termType).toBe('BlankNode');
+        const head = term.value;
+        expect(seen).not.toContain(head);
+        seen.push(head);
+        expect(firsts[head].termType).toBe('NamedNode');
+        expect(firsts[head].value).not.toBe(RDF_NIL);
+        const tail = rests[head];
+        expect(tail.termType).toBe('BlankNode');
+        expect(seen).not.toContain(tail.value);
+        seen.push(tail.value);
+        verifyTerm(firsts[tail.value], depth - 1, firsts, rests, seen);
+        expect(rests[tail.value].value).toBe(RDF_NIL);
+      }
+
+      // Deterministically cover every combination of nesting depths 0-3
+      // across the subject, predicate, and object position
+      for (let subjectDepth = 0; subjectDepth < 4; subjectDepth++) {
+        for (let predicateDepth = 0; predicateDepth < 4; predicateDepth++) {
+          for (let objectDepth = subjectDepth || predicateDepth ? 0 : 1; objectDepth < 4; objectDepth++) {
+            it(`should parse lists of depths ${subjectDepth}, ${predicateDepth}, and ${objectDepth
+                } in the subject, predicate, and object`, done => {
+              const doc = `${nested(subjectDepth, 's')} ${nested(predicateDepth, 'p')} ${nested(objectDepth, 'o')}.`;
+              const quads = new Parser({ baseIRI: BASE_IRI, format: 'N3' }).parse(doc);
+
+              // Each nesting level contributes two cells of two quads each
+              const cells = 2 * (subjectDepth + predicateDepth + objectDepth);
+              expect(quads).toHaveLength(1 + 2 * cells);
+
+              // Everything lives in the default graph
+              expect(quads.every(quad => quad.graph.termType === 'DefaultGraph')).toBe(true);
+
+              // Index the list arcs by cell
+              const firsts = {}, rests = {}, statements = [];
+              let duplicateArcs = 0;
+              for (const quad of quads) {
+                const arcs = quad.predicate.value === RDF_FIRST ? firsts :
+                             quad.predicate.value === RDF_REST  ? rests : null;
+                if (arcs === null)
+                  statements.push(quad);
+                else if (quad.subject.value in arcs)
+                  duplicateArcs++;
+                else
+                  arcs[quad.subject.value] = quad.object;
+              }
+              // Every cell has exactly one rdf:first and one rdf:rest arc
+              expect(duplicateArcs).toBe(0);
+              expect(Object.keys(firsts).sort()).toEqual(Object.keys(rests).sort());
+              // Only the main statement is not part of a list structure
+              expect(statements).toHaveLength(1);
+
+              // Every cell is on a nil-terminated chain hanging off the main statement
+              const seen = [];
+              verifyTerm(statements[0].subject, subjectDepth, firsts, rests, seen);
+              verifyTerm(statements[0].predicate, predicateDepth, firsts, rests, seen);
+              verifyTerm(statements[0].object, objectDepth, firsts, rests, seen);
+              expect(seen).toHaveLength(cells);
+
+              // The parsed quads survive a round trip through the writer
+              const writer = new Writer({ format: 'text/n3' });
+              writer.addQuads(quads);
+              writer.end((error, output) => {
+                expect(error).toBeFalsy();
+                expect(isomorphic(new Parser({ baseIRI: BASE_IRI, format: 'N3' }).parse(output), quads)).toBe(true);
+                done();
+              });
+            });
+          }
+        }
+      }
+    });
 
     it(
       'should parse a ! path in a list as subject',

--- a/test/N3Parser-test.js
+++ b/test/N3Parser-test.js
@@ -1,4 +1,4 @@
-import { Parser, NamedNode, BlankNode, Quad, termFromId, DataFactory as DF } from '../src';
+import { Parser, Writer, NamedNode, BlankNode, Quad, termFromId, DataFactory as DF } from '../src';
 import rdfDataModel from '@rdfjs/data-model';
 import { isomorphic } from 'rdf-isomorphic';
 
@@ -2887,6 +2887,186 @@ describe('Parser', () => {
                   ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil'],
                   ['ex:joe', 'f:mother', '_:b1']),
     );
+
+    it(
+      'should parse nested lists in the subject, predicate, and object simultaneously',
+      // Subject ((<a>) (<b> (<c>))): _:b0 [_:b1 (a), _:b2 [_:b3 (b), _:b4 (_:b5 (c))]]
+      // Predicate ((<p>)): _:b6 (_:b7 (p)); object ((<x> (<y>))): _:b8 (_:b9 (x), _:b10 (_:b11 (y)))
+      shouldParse(parser, '((<a>) (<b> (<c>))) ((<p>)) ((<x> (<y>))).',
+                  ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', '_:b1'],
+                  ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', '_:b2'],
+                  ['_:b1', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', 'a'],
+                  ['_:b1', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil'],
+                  ['_:b2', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', '_:b3'],
+                  ['_:b2', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil'],
+                  ['_:b3', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', 'b'],
+                  ['_:b3', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', '_:b4'],
+                  ['_:b4', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', '_:b5'],
+                  ['_:b4', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil'],
+                  ['_:b5', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', 'c'],
+                  ['_:b5', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil'],
+                  ['_:b6', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', '_:b7'],
+                  ['_:b6', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil'],
+                  ['_:b7', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', 'p'],
+                  ['_:b7', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil'],
+                  ['_:b8', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', '_:b9'],
+                  ['_:b8', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil'],
+                  ['_:b9', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', 'x'],
+                  ['_:b9', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', '_:b10'],
+                  ['_:b10', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', '_:b11'],
+                  ['_:b10', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil'],
+                  ['_:b11', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', 'y'],
+                  ['_:b11', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil'],
+                  ['_:b0', '_:b6', '_:b8']),
+    );
+
+    it(
+      'should parse a triple-nested list in the predicate',
+      shouldParse(parser, '<a> (((<p>))) <b>.',
+                  ['a', '_:b0', 'b'],
+                  ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', '_:b1'],
+                  ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil'],
+                  ['_:b1', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', '_:b2'],
+                  ['_:b1', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil'],
+                  ['_:b2', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', 'p'],
+                  ['_:b2', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil']),
+    );
+
+    it(
+      'should parse a nested list in the predicate within a formula',
+      // The list structure belongs to the formula's graph
+      shouldParse(parser, '<s> <p> { <a> ((<q>)) <b>. }.',
+                  ['s', 'p', '_:b0'],
+                  ['a', '_:b1', 'b', '_:b0'],
+                  ['_:b1', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', '_:b2', '_:b0'],
+                  ['_:b1', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil', '_:b0'],
+                  ['_:b2', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', 'q', '_:b0'],
+                  ['_:b2', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil', '_:b0']),
+    );
+
+    it(
+      'should parse empty lists at each depth and position',
+      // An empty list is the IRI rdf:nil, so only non-empty enclosing lists produce cells
+      shouldParse(parser, '(()) (() ()) ((() ())).',
+                  ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil'],
+                  ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil'],
+                  ['_:b1', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil'],
+                  ['_:b1', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', '_:b2'],
+                  ['_:b2', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil'],
+                  ['_:b2', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil'],
+                  ['_:b3', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', '_:b4'],
+                  ['_:b3', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil'],
+                  ['_:b4', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil'],
+                  ['_:b4', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', '_:b5'],
+                  ['_:b5', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil'],
+                  ['_:b5', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil'],
+                  ['_:b0', '_:b1', '_:b3']),
+    );
+
+    it(
+      'should parse lists in every position of a statement in a formula',
+      shouldParse(parser, '{ (<a>) (<p>) (<b>). } => { <x> <y> <z>. }.',
+                  ['_:b1', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', 'a', '_:b0'],
+                  ['_:b1', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil', '_:b0'],
+                  ['_:b2', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', 'p', '_:b0'],
+                  ['_:b2', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil', '_:b0'],
+                  ['_:b3', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', 'b', '_:b0'],
+                  ['_:b3', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil', '_:b0'],
+                  ['_:b1', '_:b2', '_:b3', '_:b0'],
+                  ['x', 'y', 'z', '_:b4'],
+                  ['_:b0', 'http://www.w3.org/2000/10/swap/log#implies', '_:b4']),
+    );
+
+    describe('nested lists across all positions', () => {
+      const RDF_FIRST = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first',
+          RDF_REST = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest',
+          RDF_NIL = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil';
+
+      // A term of depth 0 is a plain IRI;
+      // a term of depth n is a two-element list of an IRI and a term of depth n - 1,
+      // so a term of depth n contributes exactly 2n list cells (4n quads)
+      function nested(depth, name) {
+        return depth === 0 ? `<${name}>` : `(<${name}${depth}> ${nested(depth - 1, name)})`;
+      }
+
+      // Verifies that `term` is the well-formed list produced by `nested(depth, name)`:
+      // each cell has exactly one rdf:first and one rdf:rest arc,
+      // each chain terminates in rdf:nil, and no cell is shared
+      function verifyTerm(term, depth, firsts, rests, seen) {
+        if (depth === 0) {
+          expect(term.termType).toBe('NamedNode');
+          return;
+        }
+        expect(term.termType).toBe('BlankNode');
+        const head = term.value;
+        expect(seen).not.toContain(head);
+        seen.push(head);
+        expect(firsts[head].termType).toBe('NamedNode');
+        expect(firsts[head].value).not.toBe(RDF_NIL);
+        const tail = rests[head];
+        expect(tail.termType).toBe('BlankNode');
+        expect(seen).not.toContain(tail.value);
+        seen.push(tail.value);
+        verifyTerm(firsts[tail.value], depth - 1, firsts, rests, seen);
+        expect(rests[tail.value].value).toBe(RDF_NIL);
+      }
+
+      // Deterministically cover every combination of nesting depths 0-3
+      // across the subject, predicate, and object position
+      for (let subjectDepth = 0; subjectDepth < 4; subjectDepth++) {
+        for (let predicateDepth = 0; predicateDepth < 4; predicateDepth++) {
+          for (let objectDepth = subjectDepth || predicateDepth ? 0 : 1; objectDepth < 4; objectDepth++) {
+            it(`should parse lists of depths ${subjectDepth}, ${predicateDepth}, and ${objectDepth
+                } in the subject, predicate, and object`, done => {
+              const doc = `${nested(subjectDepth, 's')} ${nested(predicateDepth, 'p')} ${nested(objectDepth, 'o')}.`;
+              const quads = new Parser({ baseIRI: BASE_IRI, format: 'N3' }).parse(doc);
+
+              // Each nesting level contributes two cells of two quads each
+              const cells = 2 * (subjectDepth + predicateDepth + objectDepth);
+              expect(quads).toHaveLength(1 + 2 * cells);
+
+              // Everything lives in the default graph
+              expect(quads.every(quad => quad.graph.termType === 'DefaultGraph')).toBe(true);
+
+              // Index the list arcs by cell
+              const firsts = {}, rests = {}, statements = [];
+              let duplicateArcs = 0;
+              for (const quad of quads) {
+                const arcs = quad.predicate.value === RDF_FIRST ? firsts :
+                             quad.predicate.value === RDF_REST  ? rests : null;
+                if (arcs === null)
+                  statements.push(quad);
+                else if (quad.subject.value in arcs)
+                  duplicateArcs++;
+                else
+                  arcs[quad.subject.value] = quad.object;
+              }
+              // Every cell has exactly one rdf:first and one rdf:rest arc
+              expect(duplicateArcs).toBe(0);
+              expect(Object.keys(firsts).sort()).toEqual(Object.keys(rests).sort());
+              // Only the main statement is not part of a list structure
+              expect(statements).toHaveLength(1);
+
+              // Every cell is on a nil-terminated chain hanging off the main statement
+              const seen = [];
+              verifyTerm(statements[0].subject, subjectDepth, firsts, rests, seen);
+              verifyTerm(statements[0].predicate, predicateDepth, firsts, rests, seen);
+              verifyTerm(statements[0].object, objectDepth, firsts, rests, seen);
+              expect(seen).toHaveLength(cells);
+
+              // The parsed quads survive a round trip through the writer
+              const writer = new Writer({ format: 'text/n3' });
+              writer.addQuads(quads);
+              writer.end((error, output) => {
+                expect(error).toBeFalsy();
+                expect(isomorphic(new Parser({ baseIRI: BASE_IRI, format: 'N3' }).parse(output), quads)).toBe(true);
+                done();
+              });
+            });
+          }
+        }
+      }
+    });
 
     it(
       'should parse a ! path in a list as subject',

--- a/test/N3Parser-test.js
+++ b/test/N3Parser-test.js
@@ -648,6 +648,12 @@ describe('Parser', () => {
                   ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil']),
     );
 
+    it(
+      'should not parse statements with a list in the predicate',
+      shouldNotParse('<a> (<b>) <c>.',
+                     'Expected entity but got ( on line 1.'),
+    );
+
     it('should parse a list with a literal', shouldParse('<a> <b> ("x").',
                 ['a', 'b', '_:b0'],
                 ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', '"x"'],
@@ -2170,6 +2176,12 @@ describe('Parser', () => {
 
     it('should parse a default graph', shouldParse(parser, '{}'));
 
+    it(
+      'should not parse statements with a list in the predicate',
+      shouldNotParse(parser, '<a> (<b>) <c>.',
+                     'Expected entity but got ( on line 1.'),
+    );
+
     it('should parse a named graph', shouldParse(parser, '<g> {}'));
 
     it(
@@ -2809,6 +2821,71 @@ describe('Parser', () => {
                   ['x', 'is', '_:b0'],
                   ['_:b0', 'f:knows', '_:b1'],
                   ['_:b1', 'f:son', 'ex:joe']),
+    );
+
+    it(
+      'should parse statements with an empty list in the predicate',
+      shouldParse(parser, '<a> () <b>.',
+                  ['a', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil', 'b']),
+    );
+
+    it(
+      'should parse statements with a single-element list in the predicate',
+      shouldParse(parser, '<a> (<p>) <b>.',
+                  ['a', '_:b0', 'b'],
+                  ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', 'p'],
+                  ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil']),
+    );
+
+    it(
+      'should parse statements with a multi-element list in the predicate',
+      shouldParse(parser, '<a> (<p> <q>) <b>.',
+                  ['a', '_:b0', 'b'],
+                  ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', 'p'],
+                  ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', '_:b1'],
+                  ['_:b1', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', 'q'],
+                  ['_:b1', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil']),
+    );
+
+    it(
+      'should parse statements with a nested list in the predicate',
+      shouldParse(parser, '<a> ((<p>) <q>) <b>.',
+                  ['a', '_:b0', 'b'],
+                  ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', '_:b1'],
+                  ['_:b1', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', 'p'],
+                  ['_:b1', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil'],
+                  ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', '_:b2'],
+                  ['_:b2', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', 'q'],
+                  ['_:b2', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil']),
+    );
+
+    it(
+      'should parse statements after a list in the predicate',
+      shouldParse(parser, '<a> (<p>) <b>. <c> <d> <e>.',
+                  ['a', '_:b0', 'b'],
+                  ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', 'p'],
+                  ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil'],
+                  ['c', 'd', 'e']),
+    );
+
+    it(
+      'should parse a list in the predicate within a formula',
+      shouldParse(parser, '{ <a> (<p>) <b>. } => { <a> <b> <c>. }.',
+                  ['_:b1', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', 'p', '_:b0'],
+                  ['_:b1', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil', '_:b0'],
+                  ['a', '_:b1', 'b', '_:b0'],
+                  ['a', 'b', 'c', '_:b2'],
+                  ['_:b0', 'http://www.w3.org/2000/10/swap/log#implies', '_:b2']),
+    );
+
+    it(
+      'should parse a ! path in a list as predicate',
+      shouldParse(parser, '@prefix : <ex:>. @prefix fam: <f:>.' +
+                          '<l> (:joe!fam:mother) <m>.',
+                  ['l', '_:b0', 'm'],
+                  ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', '_:b1'],
+                  ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil'],
+                  ['ex:joe', 'f:mother', '_:b1']),
     );
 
     it(

--- a/test/N3Parser-test.js
+++ b/test/N3Parser-test.js
@@ -669,6 +669,12 @@ describe('Parser', () => {
                   ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil']),
     );
 
+    it(
+      'should not parse statements with a list in the predicate',
+      shouldNotParse('<a> (<b>) <c>.',
+                     'Expected entity but got ( on line 1.'),
+    );
+
     it('should parse a list with a literal', shouldParse('<a> <b> ("x").',
                 ['a', 'b', '_:b0'],
                 ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', '"x"'],
@@ -2364,6 +2370,12 @@ describe('Parser', () => {
 
     it('should parse a default graph', shouldParse(parser, '{}'));
 
+    it(
+      'should not parse statements with a list in the predicate',
+      shouldNotParse(parser, '<a> (<b>) <c>.',
+                     'Expected entity but got ( on line 1.'),
+    );
+
     it('should parse a named graph', shouldParse(parser, '<g> {}'));
 
     it(
@@ -3045,6 +3057,71 @@ describe('Parser', () => {
                   ['x', 'is', '_:b0'],
                   ['_:b0', 'f:knows', '_:b1'],
                   ['_:b1', 'f:son', 'ex:joe']),
+    );
+
+    it(
+      'should parse statements with an empty list in the predicate',
+      shouldParse(parser, '<a> () <b>.',
+                  ['a', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil', 'b']),
+    );
+
+    it(
+      'should parse statements with a single-element list in the predicate',
+      shouldParse(parser, '<a> (<p>) <b>.',
+                  ['a', '_:b0', 'b'],
+                  ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', 'p'],
+                  ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil']),
+    );
+
+    it(
+      'should parse statements with a multi-element list in the predicate',
+      shouldParse(parser, '<a> (<p> <q>) <b>.',
+                  ['a', '_:b0', 'b'],
+                  ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', 'p'],
+                  ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', '_:b1'],
+                  ['_:b1', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', 'q'],
+                  ['_:b1', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil']),
+    );
+
+    it(
+      'should parse statements with a nested list in the predicate',
+      shouldParse(parser, '<a> ((<p>) <q>) <b>.',
+                  ['a', '_:b0', 'b'],
+                  ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', '_:b1'],
+                  ['_:b1', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', 'p'],
+                  ['_:b1', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil'],
+                  ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', '_:b2'],
+                  ['_:b2', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', 'q'],
+                  ['_:b2', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil']),
+    );
+
+    it(
+      'should parse statements after a list in the predicate',
+      shouldParse(parser, '<a> (<p>) <b>. <c> <d> <e>.',
+                  ['a', '_:b0', 'b'],
+                  ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', 'p'],
+                  ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil'],
+                  ['c', 'd', 'e']),
+    );
+
+    it(
+      'should parse a list in the predicate within a formula',
+      shouldParse(parser, '{ <a> (<p>) <b>. } => { <a> <b> <c>. }.',
+                  ['_:b1', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', 'p', '_:b0'],
+                  ['_:b1', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil', '_:b0'],
+                  ['a', '_:b1', 'b', '_:b0'],
+                  ['a', 'b', 'c', '_:b2'],
+                  ['_:b0', 'http://www.w3.org/2000/10/swap/log#implies', '_:b2']),
+    );
+
+    it(
+      'should parse a ! path in a list as predicate',
+      shouldParse(parser, '@prefix : <ex:>. @prefix fam: <f:>.' +
+                          '<l> (:joe!fam:mother) <m>.',
+                  ['l', '_:b0', 'm'],
+                  ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', '_:b1'],
+                  ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil'],
+                  ['ex:joe', 'f:mother', '_:b1']),
     );
 
     it(


### PR DESCRIPTION
In N3 mode, `_readPredicate` rejected `(`, so `<a> (<b> <c>) <d>.` failed with `Expected entity but got (` while lists in the subject and object positions parsed fine. This extracts the shared list-start logic into a `_readList` helper, allows `(` as a predicate in N3 mode only (Turtle/TriG still reject it with the same error as before), and teaches the list-close/first-element paths to install the list head as the predicate and continue into the object.

Ports #345 from the superseded `versions/2.0.0` branch onto `main`; the surrounding code has changed since (reified-triple guards, `_readListItem`), so this re-applies the intent rather than the patch.

Note: small expected rebase overlap with in-flight #613 (`_readPredicate`) and #617 (`_readListItem`) — whichever lands last rebases.

Closes #619

cc @jeswr