### PR TITLE
chore(tests): enable jest/no-identical-title

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -298,7 +298,6 @@ export default [
       'jest/no-standalone-expect': 0,
       'jest/expect-expect': 0,
       'jest/no-done-callback': 0,
-      'jest/no-identical-title': 0,
 
       'max-nested-callbacks': 0, // Mocha works with deeply nested callbacks
       'new-cap': 0, // test constructors as regular functions

--- a/test/Literal-test.js
+++ b/test/Literal-test.js
@@ -500,7 +500,7 @@ describe('Literal', () => {
     });
   });
 
-  describe('A Literal instance created from a string without language or datatype', () => {
+  describe('A Literal instance created from a string with a language', () => {
     let literal;
     beforeAll(() => { literal = new Literal('"my @^^ string"@en-us'); });
 

--- a/test/N3DataFactory-test.js
+++ b/test/N3DataFactory-test.js
@@ -141,7 +141,7 @@ describe('DataFactory', () => {
       ));
     });
 
-    it('should return a nested quad', () => {
+    it('should return a quad with a nested quad as subject', () => {
       expect(DataFactory.quad(
         new Quad(
           new NamedNode('http://ex.org/a'),
@@ -165,7 +165,7 @@ describe('DataFactory', () => {
       ));
     });
 
-    it('should return a nested quad', () => {
+    it('should return a quad with a nested quad as graph', () => {
       expect(DataFactory.quad(
         new NamedNode('http://ex.org/a'),
         new NamedNode('http://ex.org/b'),

--- a/test/N3Lexer-test.js
+++ b/test/N3Lexer-test.js
@@ -1436,7 +1436,7 @@ describe('Lexer', () => {
     );
 
     it(
-      'should tokenize a reified triple with mixed types',
+      'should tokenize a reified triple of an IRI, a language-tagged literal, and a prefixed name',
       shouldTokenize('<<<http://ex.org/?bla#foo> "string"@nl-be c:c>> .',
         { type: '<<', line: 1 },
         { type: 'IRI', value: 'http://ex.org/?bla#foo', line: 1 },
@@ -1449,7 +1449,7 @@ describe('Lexer', () => {
     );
 
     it(
-      'should tokenize a reified triple with mixed types',
+      'should tokenize a reified triple of a blank node, a prefixed name, and a language-tagged literal',
       shouldTokenize('<<_:a a:a "string"@EN>> .',
         { type: '<<', line: 1 },
         { type: 'blank', prefix: '_', value: 'a', line: 1 },
@@ -1462,7 +1462,7 @@ describe('Lexer', () => {
     );
 
     it(
-      'should tokenize a reified triple with mixed types',
+      'should tokenize a reified triple of a language-tagged literal, an IRI, and a blank node',
       shouldTokenize('<<"literal"@AU <http://ex.org/?bla#foo> _:a>> .',
         { type: '<<', line: 1 },
         { type: 'literal', value: 'literal', line: 1 },

--- a/test/N3Parser-test.js
+++ b/test/N3Parser-test.js
@@ -1607,28 +1607,28 @@ describe('Parser', () => {
     );
 
     it(
-      'should not parse nested triple terms with too many closing tags',
+      'should not parse nested triple terms with too many closing tags after the inner term',
       shouldNotParse('<d> <e> <<(<<(<a> <b> <c>)>>)>> <f> <g>)>>.',
         'Disallowed triple term as subject on line 1.',
       ),
     );
 
     it(
-        'should not parse nested reified triples with too many closing tags',
+        'should not parse nested reified triples with too many closing tags after the inner triple',
         shouldNotParse('<d> <e> <<<<<a> <b> <c>>>>> <f> <g>>>.',
             'Expected entity but got >> on line 1.',
         ),
     );
 
     it(
-      'should not parse nested triple terms with too many closing tags',
+      'should not parse nested triple terms with too many closing tags at the end',
       shouldNotParse('<d> <e> <<(<<(<a> <b> <c>)>> <f> <g>)>>)>>.',
         'Disallowed triple term as subject on line 1.',
       ),
     );
 
     it(
-        'should not parse nested reified triples with too many closing tags',
+        'should not parse nested reified triples with too many closing tags at the end',
         shouldNotParse('<d> <e> <<<<<a> <b> <c>>> <f> <g>>>>>.',
             'Expected entity but got >> on line 1.',
         ),
@@ -2110,7 +2110,7 @@ describe('Parser', () => {
     );
 
     it(
-      'should not parse a literal as subject',
+      'should not parse a literal as subject with comments enabled',
       shouldNotParseWithComments(parser, '1 <a> <b>.',
         'Unexpected literal on line 1.'),
     );
@@ -2511,7 +2511,7 @@ describe('Parser', () => {
     );
 
     it(
-      'should parse a simple left implication',
+      'should parse a simple left implication with isImpliedBy enabled',
       shouldParse(parserIsImpliedBy, '<a> <= <b>.',
                   ['a', 'http://www.w3.org/2000/10/swap/log#isImpliedBy', 'b']),
     );
@@ -2525,7 +2525,7 @@ describe('Parser', () => {
     );
 
     it(
-      'should parse a right implication between one-triple graphs',
+      'should parse a right implication between one-triple graphs with isImpliedBy enabled',
       shouldParse(parserIsImpliedBy, '{ ?a ?b <c>. } => { <d> <e> ?a }.',
                   ['_:b0', 'http://www.w3.org/2000/10/swap/log#implies', '_:b1'],
                   ['?a', '?b', 'c',  '_:b0'],
@@ -2551,7 +2551,7 @@ describe('Parser', () => {
     );
 
     it(
-      'should parse a left implication between one-triple graphs',
+      'should parse a left implication between one-triple graphs with isImpliedBy enabled',
       shouldParse(parserIsImpliedBy, '{ ?a ?b <c>. } <= { <d> <e> ?a }.',
                   ['_:b0', 'http://www.w3.org/2000/10/swap/log#isImpliedBy', '_:b1'],
                   ['?a', '?b', 'c',  '_:b0'],

--- a/test/N3Store-test.js
+++ b/test/N3Store-test.js
@@ -172,11 +172,11 @@ describe('Store', () => {
         expect(store.size).toEqual(5);
       });
 
-      it('should return false', () => {
+      it('should return false for a triple with a quad as subject', () => {
         expect(store.addQuad(new Quad('s1', 'p1', 'o1'), 'p1', 'o1')).toBe(false);
       });
 
-      it('should not increase the size', () => {
+      it('should not increase the size for a triple with a quad as subject', () => {
         expect(store.size).toEqual(5);
       });
     });
@@ -205,13 +205,13 @@ describe('Store', () => {
         expect(store.size).toEqual(6);
       });
 
-      it('should return true', () => {
+      it('should return true for a triple with a quad as subject', () => {
         expect(
           store.addQuad(new Quad(new NamedNode('s1'), new NamedNode('p1'), new NamedNode('o1')), 'p1', 'o4'),
         ).toBe(true);
       });
 
-      it('should increase the size', () => {
+      it('should increase the size for a triple with a quad as subject', () => {
         expect(store.size).toEqual(7);
       });
 
@@ -221,7 +221,7 @@ describe('Store', () => {
         ).toBe(store);
       });
 
-      it('should increase the size', () => {
+      it('should increase the size after add', () => {
         expect(store.size).toEqual(8);
       });
     });
@@ -235,13 +235,13 @@ describe('Store', () => {
         expect(store.size).toEqual(7);
       });
 
-      it('should return true', () => {
+      it('should return true for a triple with a quad as subject', () => {
         expect(
           store.removeQuad(new Quad(new NamedNode('s1'), new NamedNode('p1'), new NamedNode('o1')), 'p1', 'o4'),
         ).toBe(true);
       });
 
-      it('should decrease the size', () => {
+      it('should decrease the size for a triple with a quad as subject', () => {
         expect(store.size).toEqual(6);
       });
 
@@ -251,7 +251,7 @@ describe('Store', () => {
         ).toBe(store);
       });
 
-      it('should increase the size', () => {
+      it('should decrease the size after delete', () => {
         expect(store.size).toEqual(5);
       });
     });
@@ -265,13 +265,13 @@ describe('Store', () => {
         expect(store.size).toEqual(5);
       });
 
-      it('should return false', () => {
+      it('should return false for a triple with a quad as subject', () => {
         expect(
           store.removeQuad(new Quad(new NamedNode('s1'), new NamedNode('p1'), new NamedNode('o4')), 'p1', 'o1'),
         ).toBe(false);
       });
 
-      it('should not decrease the size', () => {
+      it('should not decrease the size for a triple with a quad as subject', () => {
         expect(store.size).toEqual(5);
       });
     });
@@ -2302,6 +2302,13 @@ describe('Store', () => {
         store1.deleteMatches(q[0].subject, q[0].predicate, q[0].object);
         expect(store1.size).toEqual(1);
       });
+
+      it('should return the dataset without the matching quads', () => {
+        const result = store1.deleteMatches(q[0].subject, q[0].predicate, q[0].object);
+        expect(result.size).toEqual(1);
+        expect(result.has(q[0])).toBe(false);
+        expect(store1.size).toEqual(1);
+      });
     });
 
     describe('#addAll', () => {
@@ -2310,13 +2317,6 @@ describe('Store', () => {
         expect(store1.size).toEqual(3);
         store1.addAll([q[2]]);
         expect(store1.size).toEqual(3);
-      });
-    });
-
-    describe('#deleteMatches', () => {
-      it('should delete matching quads', () => {
-        store1.deleteMatches(q[0].subject, q[0].predicate, q[0].object);
-        expect(store1.size).toEqual(1);
       });
     });
 

--- a/test/N3StreamParser-test.js
+++ b/test/N3StreamParser-test.js
@@ -86,7 +86,7 @@ describe('StreamParser', () => {
     );
 
     it(
-      'emits "comment" events',
+      'does not emit "comment" events when comments are not enabled',
       shouldNotEmitCommentsWhenNotEnabled(['#comment1\n<a> <b> #comment2\n#comment3\n <c>. <d> <e> <f>.'], ['comment1', 'comment2', 'comment3']),
     );
 

--- a/test/Term-test.js
+++ b/test/Term-test.js
@@ -179,7 +179,7 @@ describe('Term', () => {
       },
     );
 
-    it('should create a Quad correctly', () => {
+    it('should create a Quad correctly with an implicit default graph', () => {
       const id = '["http://ex.org/a", "http://ex.org/b", "http://ex.org/c"]';
       expect(termFromId(id)).toEqual(new Quad(
         new NamedNode('http://ex.org/a'),
@@ -189,7 +189,7 @@ describe('Term', () => {
       ));
     });
 
-    it('should create a Quad correctly', () => {
+    it('should create a Quad correctly with a blank node graph', () => {
       const id = '["_:n3-123", "?var-a", "?var-b", "_:n3-000"]';
       expect(termFromId(id)).toEqual(new Quad(
         new BlankNode('n3-123'),
@@ -199,7 +199,7 @@ describe('Term', () => {
       ));
     });
 
-    it('should create a Quad correctly', () => {
+    it('should create a Quad correctly with a literal object', () => {
       const id = '["?var-a", "?var-b", "\\"abc\\"@en-us", "?var-d"]';
       expect(termFromId(id)).toEqual(new Quad(
         new Variable('var-a'),
@@ -209,7 +209,7 @@ describe('Term', () => {
       ));
     });
 
-    it('should create a Quad correctly', () => {
+    it('should create a Quad correctly with a named node graph', () => {
       const id = '["_:n3-000", "?var-b", "_:n3-123", "http://ex.org/d"]';
       expect(termFromId(id)).toEqual(new Quad(
         new BlankNode('n3-000'),
@@ -233,7 +233,7 @@ describe('Term', () => {
     );
 
     it(
-      'should create a Quad correctly from literal containing escaped quotes',
+      'should round-trip a Quad with a subject literal containing escaped quotes',
       () => {
         const q = new Quad(
           new Literal('"Hello "W"orl"d!"@en-us'),


### PR DESCRIPTION
Enables `jest/no-identical-title` and retitles the 25 flagged duplicates so each test names the scenario it actually covers (nested-quad position, `isImpliedBy`/comments-enabled parser variants, term-type composition, RDF-star quad-subject cases, …). No test was removed; two adjacent title bugs are also fixed ('should increase the size' after a `delete()` that shrinks the store, and a Literal `describe` labelled 'without language or datatype' whose fixture is language-tagged).

The one exception to title-only changes: the second, duplicated `#deleteMatches` describe in N3Store-test.js repeated an identical test verbatim, so it is folded into the first block as a return-value test (asserting the returned dataset no longer holds the deleted quad — previously unasserted) rather than deleted.

Refs #453

cc @jeswr