### PR TITLE
feat: add a graphs option to control named-graph handling in the writer

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,12 @@ To write N-Triples (or N-Quads) instead, pass a `format` argument upon creation
 const writer1 = new N3.Writer({ format: 'N-Triples' });
 const writer2 = new N3.Writer({ format: 'application/trig' });
 ```
+To exclude the graph name from the serialization, pass a `graphs` argument upon creation:
+```JavaScript
+const writer3 = new N3.Writer({ graphs: 'keep' }); // Keeps the graph names (default)
+const writer4 = new N3.Writer({ graphs: 'ignore' }); // Ignores the graph name
+const writer5 = new N3.Writer({ graphs: 'error' }); // Throws an error when writing a graph name
+```
 
 ### From quads to an RDF stream
 

--- a/README.md
+++ b/README.md
@@ -229,11 +229,11 @@ To write N-Triples (or N-Quads) instead, pass a `format` argument upon creation
 const writer1 = new N3.Writer({ format: 'N-Triples' });
 const writer2 = new N3.Writer({ format: 'application/trig' });
 ```
-To exclude the graph name from the serialization, pass a `graphs` argument upon creation:
+To control how quads in a named graph are handled, pass a `graphs` argument upon creation:
 ```JavaScript
-const writer3 = new N3.Writer({ graphs: 'keep' }); // Keeps the graph names (default)
-const writer4 = new N3.Writer({ graphs: 'ignore' }); // Ignores the graph name
-const writer5 = new N3.Writer({ graphs: 'error' }); // Throws an error when writing a graph name
+const writer3 = new N3.Writer({ graphs: 'keep' });   // Write the graph name (default)
+const writer4 = new N3.Writer({ graphs: 'ignore' }); // Write the triple without its graph name
+const writer5 = new N3.Writer({ graphs: 'error' });  // Emit an error on quads in a named graph
 ```
 
 ### From quads to an RDF stream

--- a/src/N3Writer.js
+++ b/src/N3Writer.js
@@ -38,6 +38,8 @@ export default class N3Writer {
     options = options || {};
     this._lists = options.lists;
     this._graphs = options.graphs || 'keep';
+    if (this._graphs !== 'keep' && this._graphs !== 'ignore' && this._graphs !== 'error')
+      throw new Error(`Unexpected "graphs" option value: ${this._graphs}`);
 
     // If no output stream given, send the output as string through the end callback
     if (!outputStream) {
@@ -85,9 +87,9 @@ export default class N3Writer {
   // ### `_writeQuad` writes the quad to the output stream
   _writeQuad(subject, predicate, object, graph, done) {
     try {
-      if (this._graphs === 'error' && !DEFAULTGRAPH.equals(graph)) {
-        done(new Error('Encountered graph name, this is forbidden.'));
-      }
+      // Refuse to write a quad in a named graph if the `graphs` option demands it
+      if (this._graphs === 'error' && !DEFAULTGRAPH.equals(graph))
+        throw new Error('The chosen serialization settings do not support triples in a non-default graph.');
       // Write the graph's label if it has changed
       if (this._graphs === 'keep' && !graph.equals(this._graph)) {
         // Close the previous graph and start the new one
@@ -121,16 +123,17 @@ export default class N3Writer {
   _writeQuadLine(subject, predicate, object, graph, done) {
     // Write the quad without prefixes
     delete this._prefixMatch;
-    this._write(this.quadToString(subject, predicate, object, graph, done), done);
+    try {
+      this._write(this.quadToString(subject, predicate, object, graph), done);
+    }
+    catch (error) { done && done(error); }
   }
 
   // ### `quadToString` serializes a quad as a string
-  quadToString(subject, predicate, object, graph, done) {
-    if (this._graphs === 'error' && !DEFAULTGRAPH.equals(graph)) {
-      const err = new Error('Encountered graph name, this is forbidden.');
-      if (done) return done(err);
-      throw err;
-    }
+  quadToString(subject, predicate, object, graph) {
+    // Refuse to serialize a quad in a named graph if the `graphs` option demands it
+    if (this._graphs === 'error' && graph && graph.value)
+      throw new Error('The chosen serialization settings do not support triples in a non-default graph.');
     return  `${this._encodeSubject(subject)} ${
             this._encodeIriOrBlank(predicate)} ${
             this._encodeObject(object)

--- a/src/N3Writer.js
+++ b/src/N3Writer.js
@@ -37,6 +37,7 @@ export default class N3Writer {
       options = outputStream, outputStream = null;
     options = options || {};
     this._lists = options.lists;
+    this._graphs = options.graphs || 'keep';
 
     // If no output stream given, send the output as string through the end callback
     if (!outputStream) {
@@ -84,8 +85,11 @@ export default class N3Writer {
   // ### `_writeQuad` writes the quad to the output stream
   _writeQuad(subject, predicate, object, graph, done) {
     try {
+      if (this._graphs === 'error' && !DEFAULTGRAPH.equals(graph)) {
+        done(new Error('Encountered graph name, this is forbidden.'));
+      }
       // Write the graph's label if it has changed
-      if (!graph.equals(this._graph)) {
+      if (this._graphs === 'keep' && !graph.equals(this._graph)) {
         // Close the previous graph and start the new one
         this._write((this._subject === null ? '' : (this._inDefaultGraph ? '.\n' : '\n}\n')) +
                     (DEFAULTGRAPH.equals(graph) ? '' : `${this._encodeIriOrBlank(graph)} {\n`));
@@ -117,15 +121,20 @@ export default class N3Writer {
   _writeQuadLine(subject, predicate, object, graph, done) {
     // Write the quad without prefixes
     delete this._prefixMatch;
-    this._write(this.quadToString(subject, predicate, object, graph), done);
+    this._write(this.quadToString(subject, predicate, object, graph, done), done);
   }
 
   // ### `quadToString` serializes a quad as a string
-  quadToString(subject, predicate, object, graph) {
+  quadToString(subject, predicate, object, graph, done) {
+    if (this._graphs === 'error' && !DEFAULTGRAPH.equals(graph)) {
+      const err = new Error('Encountered graph name, this is forbidden.');
+      if (done) return done(err);
+      throw err;
+    }
     return  `${this._encodeSubject(subject)} ${
             this._encodeIriOrBlank(predicate)} ${
             this._encodeObject(object)
-            }${graph && graph.value ? ` ${this._encodeIriOrBlank(graph)} .\n` : ' .\n'}`;
+            }${this._graphs === 'keep' && graph && graph.value ? ` ${this._encodeIriOrBlank(graph)} .\n` : ' .\n'}`;
   }
 
   // ### `quadsToString` serializes an array of quads as a string

--- a/test/N3Writer-test.js
+++ b/test/N3Writer-test.js
@@ -36,6 +36,17 @@ describe('Writer', () => {
         writer.quadToString(new NamedNode('a'), new NamedNode('b'), new NamedNode('c'), new NamedNode('g')),
       ).toBe('<a> <b> <c> <g> .\n');
     });
+    it('should throw error when it\'s forbidden to pass graphname', done => {
+      const writer = new Writer({ graphs: 'error' });
+      try {
+        writer.quadToString(new NamedNode('a'), new NamedNode('b'), new NamedNode('c'), new NamedNode('g')).should.equal('<a> <b> <c> <g> .\n');
+      }
+      catch (error) {
+        error.should.be.an.instanceof(Error);
+        error.should.have.property('message', 'Encountered graph name, this is forbidden.');
+        done();
+      }
+    });
 
     it('should serialize an array of triples', () => {
       const writer = new Writer();
@@ -790,6 +801,57 @@ describe('Writer', () => {
         expect(called).toBe(true);
         expect(output).toBe('<a> <b> <c> .\n<a> <b> <d> <g> .\n');
         done(error);
+      });
+    });
+
+    it('ignores the graph name when needed in N-Quads mode', done => {
+      const writer = new Writer({ graphs: 'ignore', format: 'n-quads' });
+      writer.addQuad(new Quad(
+        new NamedNode('a:a'),
+        new NamedNode('b:b'),
+        new NamedNode('c:c'),
+        new NamedNode('g:g')));
+      writer.end((error, output) => {
+        output.should.equal('<a:a> <b:b> <c:c> .\n');
+        done(error);
+      });
+    });
+
+    it('throws an graph-found error needed in N-Quads mode', done => {
+      const writer = new Writer({ graphs: 'error', format: 'n-quads' });
+      writer.addQuad(new Quad(
+        new NamedNode('a:a'),
+        new NamedNode('b:b'),
+        new NamedNode('c:c'),
+        new NamedNode('g:g')), error => {
+        error.should.be.an.instanceof(Error);
+        error.should.have.property('message', 'Encountered graph name, this is forbidden.');
+        done();
+      });
+    });
+    it('ignores the graph name when needed', done => {
+      const writer = new Writer({ graphs: 'ignore' });
+      writer.addQuad(new Quad(
+        new NamedNode('a:a'),
+        new NamedNode('b:b'),
+        new NamedNode('c:c'),
+        new NamedNode('g:g')));
+      writer.end((error, output) => {
+        output.should.equal('<a:a> <b:b> <c:c>.\n');
+        done(error);
+      });
+    });
+
+    it('throws an graph-found error needed', done => {
+      const writer = new Writer({ graphs: 'error' });
+      writer.addQuad(new Quad(
+        new NamedNode('a:a'),
+        new NamedNode('b:b'),
+        new NamedNode('c:c'),
+        new NamedNode('g:g')), error => {
+        error.should.be.an.instanceof(Error);
+        error.should.have.property('message', 'Encountered graph name, this is forbidden.');
+        done();
       });
     });
 

--- a/test/N3Writer-test.js
+++ b/test/N3Writer-test.js
@@ -36,16 +36,18 @@ describe('Writer', () => {
         writer.quadToString(new NamedNode('a'), new NamedNode('b'), new NamedNode('c'), new NamedNode('g')),
       ).toBe('<a> <b> <c> <g> .\n');
     });
-    it('should throw error when it\'s forbidden to pass graphname', done => {
+    it('should not serialize a single quad if the graphs option is set to error', () => {
       const writer = new Writer({ graphs: 'error' });
-      try {
-        writer.quadToString(new NamedNode('a'), new NamedNode('b'), new NamedNode('c'), new NamedNode('g')).should.equal('<a> <b> <c> <g> .\n');
-      }
-      catch (error) {
-        error.should.be.an.instanceof(Error);
-        error.should.have.property('message', 'Encountered graph name, this is forbidden.');
-        done();
-      }
+      expect(
+        () => writer.quadToString(new NamedNode('a'), new NamedNode('b'), new NamedNode('c'), new NamedNode('g')),
+      ).toThrow('The chosen serialization settings do not support triples in a non-default graph.');
+    });
+
+    it('should serialize a single triple if the graphs option is set to error', () => {
+      const writer = new Writer({ graphs: 'error' });
+      expect(
+        writer.quadToString(new NamedNode('a'), new NamedNode('b'), new NamedNode('c')),
+      ).toBe('<a> <b> <c> .\n');
     });
 
     it('should serialize an array of triples', () => {
@@ -804,7 +806,25 @@ describe('Writer', () => {
       });
     });
 
-    it('ignores the graph name when needed in N-Quads mode', done => {
+    it('should throw when the graphs option has an unknown value', () => {
+      expect(() => new Writer({ graphs: 'drop' }))
+        .toThrow('Unexpected "graphs" option value: drop');
+    });
+
+    it('should write the graph name when the graphs option is set to keep', done => {
+      const writer = new Writer({ graphs: 'keep', format: 'n-quads' });
+      writer.addQuad(new Quad(
+        new NamedNode('a:a'),
+        new NamedNode('b:b'),
+        new NamedNode('c:c'),
+        new NamedNode('g:g')));
+      writer.end((error, output) => {
+        expect(output).toBe('<a:a> <b:b> <c:c> <g:g> .\n');
+        done(error);
+      });
+    });
+
+    it('should omit the graph name when the graphs option is set to ignore in N-Quads mode', done => {
       const writer = new Writer({ graphs: 'ignore', format: 'n-quads' });
       writer.addQuad(new Quad(
         new NamedNode('a:a'),
@@ -812,24 +832,57 @@ describe('Writer', () => {
         new NamedNode('c:c'),
         new NamedNode('g:g')));
       writer.end((error, output) => {
-        output.should.equal('<a:a> <b:b> <c:c> .\n');
+        expect(output).toBe('<a:a> <b:b> <c:c> .\n');
         done(error);
       });
     });
 
-    it('throws an graph-found error needed in N-Quads mode', done => {
+    it('should error exactly once and not write the quad when the graphs option is set to error in N-Quads mode', done => {
       const writer = new Writer({ graphs: 'error', format: 'n-quads' });
+      let errors = 0, lastError = null;
       writer.addQuad(new Quad(
         new NamedNode('a:a'),
         new NamedNode('b:b'),
         new NamedNode('c:c'),
         new NamedNode('g:g')), error => {
-        error.should.be.an.instanceof(Error);
-        error.should.have.property('message', 'Encountered graph name, this is forbidden.');
-        done();
+        errors++;
+        lastError = error;
+      });
+      writer.end((error, output) => {
+        expect(errors).toBe(1);
+        expect(lastError).toBeInstanceOf(Error);
+        expect(lastError).toHaveProperty('message', 'The chosen serialization settings do not support triples in a non-default graph.');
+        expect(output).toBe('');
+        done(error);
       });
     });
-    it('ignores the graph name when needed', done => {
+
+    it('should write a quad in the default graph when the graphs option is set to error in N-Triples mode', done => {
+      const writer = new Writer({ graphs: 'error', format: 'n-triples' });
+      writer.addQuad(new Quad(
+        new NamedNode('a:a'),
+        new NamedNode('b:b'),
+        new NamedNode('c:c')));
+      writer.end((error, output) => {
+        expect(output).toBe('<a:a> <b:b> <c:c> .\n');
+        done(error);
+      });
+    });
+
+    it('should not write the quad when the graphs option is set to error in N-Triples mode and no callback is given', done => {
+      const writer = new Writer({ graphs: 'error', format: 'n-triples' });
+      writer.addQuad(new Quad(
+        new NamedNode('a:a'),
+        new NamedNode('b:b'),
+        new NamedNode('c:c'),
+        new NamedNode('g:g')));
+      writer.end((error, output) => {
+        expect(output).toBe('');
+        done(error);
+      });
+    });
+
+    it('should omit the graph name when the graphs option is set to ignore', done => {
       const writer = new Writer({ graphs: 'ignore' });
       writer.addQuad(new Quad(
         new NamedNode('a:a'),
@@ -837,21 +890,50 @@ describe('Writer', () => {
         new NamedNode('c:c'),
         new NamedNode('g:g')));
       writer.end((error, output) => {
-        output.should.equal('<a:a> <b:b> <c:c>.\n');
+        expect(output).toBe('<a:a> <b:b> <c:c>.\n');
         done(error);
       });
     });
 
-    it('throws an graph-found error needed', done => {
+    it('should merge quads from different graphs when the graphs option is set to ignore in TriG mode', done => {
+      const writer = new Writer({ graphs: 'ignore', format: 'trig' });
+      writer.addQuad(new Quad(
+        new NamedNode('a:a'),
+        new NamedNode('b:b'),
+        new NamedNode('c:c'),
+        new NamedNode('g:g')));
+      writer.addQuad(new Quad(
+        new NamedNode('a:a'),
+        new NamedNode('b:b'),
+        new NamedNode('d:d'),
+        new NamedNode('h:h')));
+      writer.end((error, output) => {
+        expect(output).toBe('<a:a> <b:b> <c:c>, <d:d>.\n');
+        const quads = new Parser({ format: 'trig' }).parse(output);
+        expect(quads).toHaveLength(2);
+        for (const quad of quads)
+          expect(quad.graph.termType).toBe('DefaultGraph');
+        done(error);
+      });
+    });
+
+    it('should error exactly once and not write the quad when the graphs option is set to error', done => {
       const writer = new Writer({ graphs: 'error' });
+      let errors = 0, lastError = null;
       writer.addQuad(new Quad(
         new NamedNode('a:a'),
         new NamedNode('b:b'),
         new NamedNode('c:c'),
         new NamedNode('g:g')), error => {
-        error.should.be.an.instanceof(Error);
-        error.should.have.property('message', 'Encountered graph name, this is forbidden.');
-        done();
+        errors++;
+        lastError = error;
+      });
+      writer.end((error, output) => {
+        expect(errors).toBe(1);
+        expect(lastError).toBeInstanceOf(Error);
+        expect(lastError).toHaveProperty('message', 'The chosen serialization settings do not support triples in a non-default graph.');
+        expect(output).toBe('');
+        done(error);
       });
     });
 


### PR DESCRIPTION
This adds a `graphs` option to `N3.Writer` that controls how quads in a named graph are serialized, implementing the design settled in #165 (`graphs: 'keep' | 'ignore' | 'error'`, default `'keep'`, per @RubenVerborgh's final comment there and his approval of #319):

- `'keep'` (default): current behaviour — graph names are written;
- `'ignore'`: the triple is written without its graph name (per the #165 discussion, this omits the graph name rather than dropping the quad);
- `'error'`: an error is raised for any quad in a non-default graph.

As in the original branch, the option applies uniformly in all formats, including N-Quads/TriG.

Supersedes #339 (its head branch lives on the upstream repo and cannot be pushed to; Laurens Rietveld's original commit is preserved via cherry-pick). On top of it, this branch fixes the callback firing twice — and the quad still being written — after an error in `_writeQuad`, keeps `quadToString` synchronous (it throws; `_writeQuadLine` routes the error to the callback), validates the option value in the constructor, and ports/extends the tests to the current jest style.

Note: #165 suggests flipping the default to `'error'`; that would be a breaking change and a candidate for the next major, so it is left out here.

Closes #165

cc @jeswr
