### PR TITLE
perf(parser): reduce per-quad allocation (no throwaway literal, no per-literal .bind, lean contexts)

### DIFF
--- a/src/N3Parser.js
+++ b/src/N3Parser.js
@@ -78,31 +78,30 @@ export default class N3Parser {
   // ### `_saveContext` stores the current parsing context
   // when entering a new scope (list, blank node, formula)
   _saveContext(type, graph, subject, predicate, object) {
-    const n3Mode = this._n3Mode;
+    // Only N3 contexts need the extra parser state.
+    if (!this._n3Mode) {
+      this._contextStack.push({ type, subject, predicate, object, graph });
+      return;
+    }
     this._contextStack.push({
       type,
       subject, predicate, object, graph,
-      inverse: n3Mode ? this._inversePredicate : false,
-      blankPrefix: n3Mode ? this._prefixes._ : '',
-      quantified: n3Mode ? this._quantified : null,
-      emptyFormula: n3Mode ? this._emptyFormula : false,
+      inverse: this._inversePredicate,
+      blankPrefix: this._prefixes._,
+      quantified: this._quantified,
+      emptyFormula: this._emptyFormula,
     });
-    // The settings below only apply to N3 streams
-    if (n3Mode) {
-      // Every new scope resets the predicate direction
-      this._inversePredicate = false;
-      // In N3, blank nodes are scoped to a formula
-      // (using a dot as separator, as a blank node label cannot start with it)
-      this._prefixes._ = (this._graph ? `${this._graph.value}.` : '.');
-      // Quantifiers are scoped to a formula
-      this._quantified = Object.create(this._quantified);
-      // A formula starts a new statement, so the subject of the
-      // enclosing statement must not leak into it,
-      // and it is empty until a statement has been read
-      if (type === 'formula') {
-        this._subject = null;
-        this._emptyFormula = true;
-      }
+    // Every new scope resets the predicate direction
+    this._inversePredicate = false;
+    // In N3, blank nodes are scoped to a formula
+    // (using a dot as separator, as a blank node label cannot start with it)
+    this._prefixes._ = (this._graph ? `${this._graph.value}.` : '.');
+    // Quantifiers are scoped to a formula
+    this._quantified = Object.create(this._quantified);
+    // A formula starts empty and must not inherit its parent's subject
+    if (type === 'formula') {
+      this._subject = null;
+      this._emptyFormula = true;
     }
   }
 
@@ -641,8 +640,9 @@ export default class N3Parser {
   }
 
   // ### `_completeLiteral` completes a literal with an optional datatype or language
+  // Defers possible direction tags without allocating bound callbacks.
   _completeLiteral(token, component) {
-    let literal, readCb;
+    let literal, readCb = false;
 
     switch (token.type) {
     // Create a datatyped literal
@@ -663,7 +663,9 @@ export default class N3Parser {
       literal = this._factory.literal(this._literalValue, token.value);
       this._literalLanguage = token.value;
       token = null;
-      readCb = this._readDirCode.bind(this, component);
+      // Save state for a possible direction tag
+      this._literalComponent = component;
+      readCb = true;
       break;
     // Create a simple string literal by default
     default:
@@ -673,7 +675,9 @@ export default class N3Parser {
     return { token, literal, readCb };
   }
 
-  _readDirCode(component, listItem, token) {
+  // ### `_readDirCode` reads an optional directional language tag
+  _readDirCode(token) {
+    const component = this._literalComponent, listItem = this._literalListItem;
     // Attempt to read a dircode
     if (token.type === 'dircode') {
       const term = this._factory.literal(this._literalValue, { language: this._literalLanguage, direction: token.value });
@@ -715,8 +719,10 @@ export default class N3Parser {
     }
 
     // Postpone completion if the literal is only partially completed (such as lang+dir).
-    if (completed.readCb)
-      return completed.readCb.bind(this, false);
+    if (completed.readCb) {
+      this._literalListItem = false;
+      return this._readDirCode;
+    }
 
     // A subject literal implies N3 mode, so it might start a path.
     if (component === 'subject') {
@@ -749,8 +755,10 @@ export default class N3Parser {
     this._object = completed.literal;
 
     // Postpone completion if the literal is only partially completed (such as lang+dir).
-    if (completed.readCb)
-      return completed.readCb.bind(this, listItem);
+    if (completed.readCb) {
+      this._literalListItem = listItem;
+      return this._readDirCode;
+    }
 
     return this._completeObjectLiteralPost(completed.token, listItem);
   }

--- a/src/N3Parser.js
+++ b/src/N3Parser.js
@@ -75,24 +75,30 @@ export default class N3Parser {
   // ### `_saveContext` stores the current parsing context
   // when entering a new scope (list, blank node, formula)
   _saveContext(type, graph, subject, predicate, object) {
-    const n3Mode = this._n3Mode;
+    // The inverse/blankPrefix/quantified fields only apply to N3 streams.
+    // For non-N3 modes (Turtle/TriG/N-Triples/N-Quads) they are always
+    // false/''/null, so push a lean 5-field context object instead (OPT-27).
+    // A parser instance has a fixed mode, so only one shape is ever pushed
+    // per instance and `_restoreContext` stays monomorphic.
+    if (!this._n3Mode) {
+      this._contextStack.push({ type, subject, predicate, object, graph });
+      return;
+    }
     this._contextStack.push({
       type,
       subject, predicate, object, graph,
-      inverse: n3Mode ? this._inversePredicate : false,
-      blankPrefix: n3Mode ? this._prefixes._ : '',
-      quantified: n3Mode ? this._quantified : null,
+      inverse: this._inversePredicate,
+      blankPrefix: this._prefixes._,
+      quantified: this._quantified,
     });
     // The settings below only apply to N3 streams
-    if (n3Mode) {
-      // Every new scope resets the predicate direction
-      this._inversePredicate = false;
-      // In N3, blank nodes are scoped to a formula
-      // (using a dot as separator, as a blank node label cannot start with it)
-      this._prefixes._ = (this._graph ? `${this._graph.value}.` : '.');
-      // Quantifiers are scoped to a formula
-      this._quantified = Object.create(this._quantified);
-    }
+    // Every new scope resets the predicate direction
+    this._inversePredicate = false;
+    // In N3, blank nodes are scoped to a formula
+    // (using a dot as separator, as a blank node label cannot start with it)
+    this._prefixes._ = (this._graph ? `${this._graph.value}.` : '.');
+    // Quantifiers are scoped to a formula
+    this._quantified = Object.create(this._quantified);
   }
 
   // ### `_restoreContext` restores the parent context
@@ -566,8 +572,13 @@ export default class N3Parser {
   }
 
   // ### `_completeLiteral` completes a literal with an optional datatype or language
+  // When the literal is a language-tagged string, a directional language tag may
+  // still follow, so completion is deferred to `_readDirCode`. Rather than binding
+  // a fresh callback per literal (OPT-26), the deferral is signalled by `readCb`
+  // and the relevant state (`component`/`listItem`) is stored on the instance,
+  // read back by the fixed `_readDirCode` method.
   _completeLiteral(token, component) {
-    let literal, readCb;
+    let literal, readCb = false;
 
     switch (token.type) {
     // Create a datatyped literal
@@ -588,7 +599,9 @@ export default class N3Parser {
       literal = this._factory.literal(this._literalValue, token.value);
       this._literalLanguage = token.value;
       token = null;
-      readCb = this._readDirCode.bind(this, component);
+      // Defer to `_readDirCode`, which reads `_literalComponent`/`_literalListItem`.
+      this._literalComponent = component;
+      readCb = true;
       break;
     // Create a simple string literal by default
     default:
@@ -598,7 +611,11 @@ export default class N3Parser {
     return { token, literal, readCb };
   }
 
-  _readDirCode(component, listItem, token) {
+  // ### `_readDirCode` reads an optional directional language tag after a
+  // language-tagged literal, using state stored by `_completeLiteral` /
+  // `_completeSubjectLiteral` / `_completeObjectLiteral`.
+  _readDirCode(token) {
+    const component = this._literalComponent, listItem = this._literalListItem;
     // Attempt to read a dircode
     if (token.type === 'dircode') {
       const term = this._factory.literal(this._literalValue, { language: this._literalLanguage, direction: token.value });
@@ -621,8 +638,10 @@ export default class N3Parser {
     this._subject = completed.literal;
 
     // Postpone completion if the literal is only partially completed (such as lang+dir).
-    if (completed.readCb)
-      return completed.readCb.bind(this, false);
+    if (completed.readCb) {
+      this._literalListItem = false;
+      return this._readDirCode;
+    }
 
     return this._readPredicateOrNamedGraph;
   }
@@ -636,8 +655,10 @@ export default class N3Parser {
     this._object = completed.literal;
 
     // Postpone completion if the literal is only partially completed (such as lang+dir).
-    if (completed.readCb)
-      return completed.readCb.bind(this, listItem);
+    if (completed.readCb) {
+      this._literalListItem = listItem;
+      return this._readDirCode;
+    }
 
     return this._completeObjectLiteralPost(completed.token, listItem);
   }

--- a/src/N3Parser.js
+++ b/src/N3Parser.js
@@ -642,9 +642,7 @@ export default class N3Parser {
 
   // ### `_completeLiteral` completes a literal with an optional datatype or language
   _completeLiteral(token, component) {
-    // Create a simple string literal by default
-    let literal = this._factory.literal(this._literalValue);
-    let readCb;
+    let literal, readCb;
 
     switch (token.type) {
     // Create a datatyped literal
@@ -667,6 +665,9 @@ export default class N3Parser {
       token = null;
       readCb = this._readDirCode.bind(this, component);
       break;
+    // Create a simple string literal by default
+    default:
+      literal = this._factory.literal(this._literalValue);
     }
 
     return { token, literal, readCb };

--- a/src/N3Parser.js
+++ b/src/N3Parser.js
@@ -567,9 +567,7 @@ export default class N3Parser {
 
   // ### `_completeLiteral` completes a literal with an optional datatype or language
   _completeLiteral(token, component) {
-    // Create a simple string literal by default
-    let literal = this._factory.literal(this._literalValue);
-    let readCb;
+    let literal, readCb;
 
     switch (token.type) {
     // Create a datatyped literal
@@ -592,6 +590,9 @@ export default class N3Parser {
       token = null;
       readCb = this._readDirCode.bind(this, component);
       break;
+    // Create a simple string literal by default
+    default:
+      literal = this._factory.literal(this._literalValue);
     }
 
     return { token, literal, readCb };

--- a/src/N3Parser.js
+++ b/src/N3Parser.js
@@ -77,7 +77,7 @@ export default class N3Parser {
   _saveContext(type, graph, subject, predicate, object) {
     // The inverse/blankPrefix/quantified fields only apply to N3 streams.
     // For non-N3 modes (Turtle/TriG/N-Triples/N-Quads) they are always
-    // false/''/null, so push a lean 5-field context object instead (OPT-27).
+    // false/''/null, so push a lean 5-field context object instead.
     // A parser instance has a fixed mode, so only one shape is ever pushed
     // per instance and `_restoreContext` stays monomorphic.
     if (!this._n3Mode) {
@@ -574,7 +574,7 @@ export default class N3Parser {
   // ### `_completeLiteral` completes a literal with an optional datatype or language
   // When the literal is a language-tagged string, a directional language tag may
   // still follow, so completion is deferred to `_readDirCode`. Rather than binding
-  // a fresh callback per literal (OPT-26), the deferral is signalled by `readCb`
+  // a fresh callback per literal, the deferral is signalled by `readCb`
   // and the relevant state (`component`/`listItem`) is stored on the instance,
   // read back by the fixed `_readDirCode` method.
   _completeLiteral(token, component) {

--- a/test/N3Parser-test.js
+++ b/test/N3Parser-test.js
@@ -119,6 +119,15 @@ describe('Parser', () => {
     );
 
     it(
+        'should not leak direction state between language-tagged literals',
+        shouldParse('<a> <b> "x"@en--rtl, "y"@fr, "z"@de--ltr.\n<c> <d> "w"@nl.',
+            ['a', 'b', '"x"@en--rtl'],
+            ['a', 'b', '"y"@fr'],
+            ['a', 'b', '"z"@de--ltr'],
+            ['c', 'd', '"w"@nl']),
+    );
+
+    it(
         'should error on a triple with a literal with direction but without language code',
         shouldNotParse('<a> <b> "string"--rtl.',
             'Unexpected "--rtl." on line 1.', {

--- a/test/N3Parser-test.js
+++ b/test/N3Parser-test.js
@@ -107,6 +107,18 @@ describe('Parser', () => {
     );
 
     it(
+        'should parse consecutive directional and plain language-tagged literals',
+        // The directional-language-tag completion stores per-literal state on the
+        // parser instance; this verifies that state does not leak between
+        // consecutive language-tagged literals (some directional, some not).
+        shouldParse('<a> <b> "x"@en--rtl, "y"@fr, "z"@de--ltr.\n<c> <d> "w"@nl.',
+            ['a', 'b', '"x"@en--rtl'],
+            ['a', 'b', '"y"@fr'],
+            ['a', 'b', '"z"@de--ltr'],
+            ['c', 'd', '"w"@nl']),
+    );
+
+    it(
         'should error on a triple with a literal with direction but without language code',
         shouldNotParse('<a> <b> "string"--rtl.',
             'Unexpected "--rtl." on line 1.', {


### PR DESCRIPTION
Reduces per-quad allocation in the parser with three small changes, at no wall-time cost:

- **No throwaway literal**: `_completeLiteral` built a plain-string `Literal` for every literal and discarded it whenever a datatype or language tag followed; the default literal is now only built in the fall-through branch.
- **No per-literal `.bind`**: the language+direction completion path allocated a fresh bound function per language-tagged literal; deferral is now a boolean plus pending state on the instance, read back by a fixed `_readDirCode(token)` method.
- **Lean non-N3 contexts**: `_saveContext` pushed a full N3 context object even for Turtle/TriG/N-Triples/N-Quads, where the N3-only fields are unused; non-N3 modes now push a five-field context.

Output is byte-identical to `main` (SHA-256 over the quad streams of the five benchmark documents). Allocation churn (sampling heap profiler, bytes allocated per quad parsed; a second run reproduced every row within ±1.2%):

| document | main | this PR |
|---|---|---|
| Turtle, 500k | 1641 | 1565 (−4.6%) |
| TriG, 500k / 10 graphs | 1701 | 1655 (−2.7%) |
| N-Triples, 500k | 1759 | 1681 (−4.4%) |
| N3, formulae + lists, 780k | 1107 | 1105 (−0.2%; N3 keeps the full context shape by design) |
| Turtle 1.2, dir-lang + annotations, 600k | 1523 | 1400 (−8.1%) |

Wall time is neutral within the machine's ±4% noise band (interleaved A/B, seven fresh-process pairs per format): this is an allocation/GC-pressure reduction, not a speed-up claim.

Deliberately excluded: a per-base `Map<rawIRI, resolved>` cache in `_resolveIRI` measured a **+16.1% wall-time regression** on fragment-relative documents because resolving `#x` is cheaper than a `Map.get`.

Rebased onto current `main`, preserving the newer empty-formula and graph-term parser behavior. The full 6,725-test suite passes with 100% measured coverage; lint and the Node build also pass.

cc @jeswr
