### PR TITLE
perf: skip prefix matching when no prefixes are registered

### DIFF
--- a/src/N3Writer.js
+++ b/src/N3Writer.js
@@ -31,6 +31,7 @@ export default class N3Writer {
   constructor(outputStream, options) {
     // ### `_prefixRegex` matches a prefixed name or IRI that begins with one of the added prefixes
     this._prefixRegex = /$0^/;
+    this._hasPrefixes = false;
 
     // Shift arguments if the first argument is not a stream
     if (outputStream && typeof outputStream.write !== 'function')
@@ -159,8 +160,8 @@ export default class N3Writer {
     // Escape special characters
     if (escape.test(iri))
       iri = iri.replace(escapeAll, characterReplacer);
-    // Try to represent the IRI as prefixed name
-    const prefixMatch = this._prefixRegex.exec(iri);
+    // Try to represent the IRI as prefixed name, unless no prefixes were added
+    const prefixMatch = this._hasPrefixes ? this._prefixRegex.exec(iri) : null;
     return !prefixMatch ? `<${iri}>` :
            (!prefixMatch[1] ? iri : this._prefixIRIs[prefixMatch[1]] + prefixMatch[2]);
   }
@@ -292,6 +293,7 @@ export default class N3Writer {
     }
     // Recreate the prefix matcher
     if (hasPrefixes) {
+      this._hasPrefixes = true;
       let IRIlist = '', prefixList = '';
       for (const prefixIRI in this._prefixIRIs) {
         IRIlist += IRIlist ? `|${prefixIRI}` : prefixIRI;


### PR DESCRIPTION
Serializing any IRI currently runs `this._prefixRegex.exec(iri)` even when the writer has no prefixes at all — the regex is then the never-matching `/$0^/` sentinel, so the exec is pure overhead. That is always the case in N-Triples/N-Quads line mode and for `quadToString`/`quadsToString` on a default writer. This PR tracks whether any prefix was registered and skips the exec otherwise.

**Measured** (Apple M1, Node 25, 1M quads, in-memory generated data; 5 interleaved main↔branch fresh-process pairs × 5 reps, process-CPU medians as the primary metric because the shared machine was contended — load avg fluctuated ~8–30 during runs):

| workload | median pairwise CPU ratio (branch/main) | pair range |
|---|---|---|
| plain Turtle → string | **0.938** | 0.816–1.030 |
| N-Quads → string | **0.905** | 0.857–0.930 |
| prefix-heavy (20 prefixes; guard-overhead check) | 0.991 | 0.918–1.056 |

**Byte identity**: verified with a differential runner that serializes eight generated 20k-quad corpora (plain / prefix-heavy / literal-heavy / TriG / N-Quads / lists / blank nodes / baseIRI) through `Writer`→string, `quadsToString`, and `StreamWriter`, plus ~60 adversarial terms (edge-case language/direction tags, `--` in values and datatype IRIs, escapes, RDF-star, foreign RDF/JS terms, `blank()`/`list()`) under Turtle / prefixes / baseIRI / N-Triples / N-Quads configurations — output is byte-identical to main throughout. Both branches of the new guard are exercised by the existing suite.

**Rebase notes**: no semantic overlap with #614 (prefix regex local-name charset) or #616 (`writeBase`); both touch `addPrefixes`, so at most a trivial textual conflict on the added `this._hasPrefixes = true;` line.

cc @jeswr
