### PR TITLE
perf: track index entry counts for constant-time removal cleanup

### DIFF
--- a/src/N3Store.js
+++ b/src/N3Store.js
@@ -7,12 +7,27 @@ import N3Writer from './N3Writer';
 
 const ITERATOR = Symbol('iter');
 
-function merge(target, source, depth = 4) {
-  if (depth === 0)
-    return Object.assign(target, source);
+// `SIZE` tracks the number of entries in an index node under a Symbol key,
+// which is invisible to `for...in` loops and `Object.keys`.
+// It makes empty-layer cleanup during removal O(1) instead of O(entries).
+// Every function that creates index nodes
+// (`_addToIndex`, `merge`, `intersect`, `difference`, and `indexMatch`)
+// must maintain it on the three levels below a graph.
+const SIZE = Symbol('size');
 
-  for (const key in source)
-    target[key] = merge(target[key] || Object.create(null), source[key], depth - 1);
+function merge(target, source, depth = 4) {
+  let size = target[SIZE] || 0;
+  for (const key in source) {
+    if (!(key in target)) {
+      size++;
+      target[key] = depth === 0 ? null : merge(Object.create(null), source[key], depth - 1);
+    }
+    else if (depth !== 0)
+      target[key] = merge(target[key], source[key], depth - 1);
+  }
+  // Depth 2 is the level of the `subjects`, `predicates`, and `objects` indexes.
+  if (depth <= 2)
+    target[SIZE] = size;
 
   return target;
 }
@@ -25,7 +40,7 @@ function merge(target, source, depth = 4) {
  * *not* be set as the value for an index.
  */
 function intersect(s1, s2, depth = 4) {
-  let target = false;
+  let target = false, size = 0;
 
   for (const key in s1) {
     if (key in s2) {
@@ -33,6 +48,7 @@ function intersect(s1, s2, depth = 4) {
       if (intersection !== false) {
         target = target || Object.create(null);
         target[key] = intersection;
+        size++;
       }
       // Depth 3 is the 'subjects', 'predicates' and 'objects' keys.
       // If the 'subjects' index is empty, so will the 'predicates' and 'objects' index.
@@ -41,6 +57,10 @@ function intersect(s1, s2, depth = 4) {
       }
     }
   }
+
+  // Depth 2 is the level of the `subjects`, `predicates`, and `objects` indexes.
+  if (depth <= 2 && target)
+    target[SIZE] = size;
 
   return target;
 }
@@ -53,7 +73,7 @@ function intersect(s1, s2, depth = 4) {
  * *not* be set as the value for an index.
  */
 function difference(s1, s2, depth = 4) {
-  let target = false;
+  let target = false, size = 0;
 
   for (const key in s1) {
     // When the key is not in the index, then none of the triples defined by s1[key] are
@@ -61,12 +81,14 @@ function difference(s1, s2, depth = 4) {
     if (!(key in s2)) {
       target = target || Object.create(null);
       target[key] = depth === 0 ? null : merge({}, s1[key], depth - 1);
+      size++;
     }
     else if (depth !== 0) {
       const diff = difference(s1[key], s2[key], depth - 1);
       if (diff !== false) {
         target = target || Object.create(null);
         target[key] = diff;
+        size++;
       }
       // Depth 3 is the 'subjects', 'predicates' and 'objects' keys.
       // If the 'subjects' index is empty, so will the 'predicates' and 'objects' index.
@@ -75,6 +97,10 @@ function difference(s1, s2, depth = 4) {
       }
     }
   }
+
+  // Depth 2 is the level of the `subjects`, `predicates`, and `objects` indexes.
+  if (depth <= 2 && target)
+    target[SIZE] = size;
 
   return target;
 }
@@ -203,13 +229,23 @@ export default class N3Store {
   // ### `_addToIndex` adds a quad to a three-layered index.
   // Returns if the index has changed, if the entry did not already exist.
   _addToIndex(index0, key0, key1, key2) {
-    // Create layers as necessary
-    const index1 = index0[key0] || (index0[key0] = {});
-    const index2 = index1[key1] || (index1[key1] = {});
+    // Create layers as necessary, maintaining their entry counters
+    let index1 = index0[key0];
+    if (!index1) {
+      index0[key0] = index1 = { [SIZE]: 0 };
+      index0[SIZE]++;
+    }
+    let index2 = index1[key1];
+    if (!index2) {
+      index1[key1] = index2 = { [SIZE]: 0 };
+      index1[SIZE]++;
+    }
     // Setting the key to _any_ value signals the presence of the quad
     const existed = key2 in index2;
-    if (!existed)
+    if (!existed) {
       index2[key2] = null;
+      index2[SIZE]++;
+    }
     return !existed;
   }
 
@@ -219,11 +255,13 @@ export default class N3Store {
     const index1 = index0[key0], index2 = index1[key1];
     delete index2[key2];
 
-    // Remove intermediary index layers if they are empty
-    for (const key in index2) return;
+    // Remove intermediary index layers if they are empty,
+    // which the entry counters detect in constant time
+    if (--index2[SIZE] !== 0) return;
     delete index1[key1];
-    for (const key in index1) return;
+    if (--index1[SIZE] !== 0) return;
     delete index0[key0];
+    index0[SIZE]--;
   }
 
   // ### `_findInIndex` finds a set of quads in a three-layered index.
@@ -365,7 +403,11 @@ export default class N3Store {
     let graphItem = this._graphs[graph];
     // Create the graph if it doesn't exist yet
     if (!graphItem) {
-      graphItem = this._graphs[graph] = { subjects: {}, predicates: {}, objects: {} };
+      graphItem = this._graphs[graph] = {
+        subjects: { [SIZE]: 0 },
+        predicates: { [SIZE]: 0 },
+        objects: { [SIZE]: 0 },
+      };
       // Freezing a graph helps subsequent `add` performance,
       // and properties will never be modified anyway
       Object.freeze(graphItem);
@@ -440,8 +482,8 @@ export default class N3Store {
     if (this._size !== null) this._size--;
 
     // Remove the graph if it is empty
-    for (subject in graphItem.subjects) return true;
-    delete graphs[graph];
+    if (graphItem.subjects[SIZE] === 0)
+      delete graphs[graph];
     return true;
   }
 
@@ -1098,15 +1140,18 @@ function indexMatch(index, ids, depth = 0) {
   if (ind && !(ind in index))
     return false;
 
-  let target = false;
+  let target = false, size = 0;
   for (const key in (ind ? { [ind]: index[ind] } : index)) {
     const result = depth === 2 ? null : indexMatch(index[key], ids, depth + 1);
 
     if (result !== false) {
       target = target || Object.create(null);
       target[key] = result;
+      size++;
     }
   }
+  if (target)
+    target[SIZE] = size;
   return target;
 }
 

--- a/src/N3Store.js
+++ b/src/N3Store.js
@@ -6,6 +6,7 @@ import { isDefaultGraph } from './N3Util';
 import N3Writer from './N3Writer';
 
 const ITERATOR = Symbol('iter');
+const SIZE = Symbol('size');
 
 function hasInIndex(index0, key0, key1, key2) {
   const index1 = index0 && index0[key0];
@@ -14,11 +15,18 @@ function hasInIndex(index0, key0, key1, key2) {
 }
 
 function merge(target, source, depth = 4) {
-  if (depth === 0)
-    return Object.assign(target, source);
-
-  for (const key in source)
-    target[key] = merge(target[key] || Object.create(null), source[key], depth - 1);
+  let size = target[SIZE] || 0;
+  for (const key in source) {
+    if (!(key in target)) {
+      size++;
+      target[key] = depth === 0 ? null : merge(Object.create(null), source[key], depth - 1);
+    }
+    else if (depth !== 0)
+      target[key] = merge(target[key], source[key], depth - 1);
+  }
+  // Depth 2 is the level of the `subjects`, `predicates`, and `objects` indexes.
+  if (depth <= 2)
+    target[SIZE] = size;
 
   return target;
 }
@@ -31,7 +39,10 @@ function merge(target, source, depth = 4) {
  * *not* be set as the value for an index.
  */
 function intersect(s1, s2, depth = 4) {
-  let target = false;
+  let target = false, size = 0;
+
+  if (depth <= 2 && s2[SIZE] < s1[SIZE])
+    [s1, s2] = [s2, s1];
 
   for (const key in s1) {
     if (key in s2) {
@@ -39,6 +50,7 @@ function intersect(s1, s2, depth = 4) {
       if (intersection !== false) {
         target = target || Object.create(null);
         target[key] = intersection;
+        size++;
       }
       // Depth 3 is the 'subjects', 'predicates' and 'objects' keys.
       // If the 'subjects' index is empty, so will the 'predicates' and 'objects' index.
@@ -47,6 +59,10 @@ function intersect(s1, s2, depth = 4) {
       }
     }
   }
+
+  // Depth 2 is the level of the `subjects`, `predicates`, and `objects` indexes.
+  if (depth <= 2 && target)
+    target[SIZE] = size;
 
   return target;
 }
@@ -59,7 +75,7 @@ function intersect(s1, s2, depth = 4) {
  * *not* be set as the value for an index.
  */
 function difference(s1, s2, depth = 4) {
-  let target = false;
+  let target = false, size = 0;
 
   for (const key in s1) {
     // When the key is not in the index, then none of the triples defined by s1[key] are
@@ -67,12 +83,14 @@ function difference(s1, s2, depth = 4) {
     if (!(key in s2)) {
       target = target || Object.create(null);
       target[key] = depth === 0 ? null : merge({}, s1[key], depth - 1);
+      size++;
     }
     else if (depth !== 0) {
       const diff = difference(s1[key], s2[key], depth - 1);
       if (diff !== false) {
         target = target || Object.create(null);
         target[key] = diff;
+        size++;
       }
       // Depth 3 is the 'subjects', 'predicates' and 'objects' keys.
       // If the 'subjects' index is empty, so will the 'predicates' and 'objects' index.
@@ -81,6 +99,10 @@ function difference(s1, s2, depth = 4) {
       }
     }
   }
+
+  // Depth 2 is the level of the `subjects`, `predicates`, and `objects` indexes.
+  if (depth <= 2 && target)
+    target[SIZE] = size;
 
   return target;
 }
@@ -200,7 +222,7 @@ export default class N3Store {
     for (const graphKey in graphs)
       for (const subjectKey in (subjects = graphs[graphKey].subjects))
         for (const predicateKey in (subject = subjects[subjectKey]))
-          size += Object.keys(subject[predicateKey]).length;
+          size += subject[predicateKey][SIZE];
     return this._size = size;
   }
 
@@ -209,13 +231,23 @@ export default class N3Store {
   // ### `_addToIndex` adds a quad to a three-layered index.
   // Returns if the index has changed, if the entry did not already exist.
   _addToIndex(index0, key0, key1, key2) {
-    // Create layers as necessary
-    const index1 = index0[key0] || (index0[key0] = {});
-    const index2 = index1[key1] || (index1[key1] = {});
+    // Create layers as necessary, maintaining their entry counters
+    let index1 = index0[key0];
+    if (!index1) {
+      index0[key0] = index1 = { [SIZE]: 0 };
+      index0[SIZE]++;
+    }
+    let index2 = index1[key1];
+    if (!index2) {
+      index1[key1] = index2 = { [SIZE]: 0 };
+      index1[SIZE]++;
+    }
     // Setting the key to _any_ value signals the presence of the quad
     const existed = key2 in index2;
-    if (!existed)
+    if (!existed) {
       index2[key2] = null;
+      index2[SIZE]++;
+    }
     return !existed;
   }
 
@@ -225,11 +257,13 @@ export default class N3Store {
     const index1 = index0[key0], index2 = index1[key1];
     delete index2[key2];
 
-    // Remove intermediary index layers if they are empty
-    for (const key in index2) return;
+    // Remove intermediary index layers if they are empty,
+    // which the entry counters detect in constant time
+    if (--index2[SIZE] !== 0) return;
     delete index1[key1];
-    for (const key in index1) return;
+    if (--index1[SIZE] !== 0) return;
     delete index0[key0];
+    index0[SIZE]--;
   }
 
   // ### `_findInIndex` finds a set of quads in a three-layered index.
@@ -332,7 +366,7 @@ export default class N3Store {
             // If a key is specified, count the quad if it exists
             if (key2) (key2 in index2) && count++;
             // Otherwise, count all quads
-            else count += Object.keys(index2).length;
+            else count += index2[SIZE];
           }
         }
       }
@@ -384,7 +418,11 @@ export default class N3Store {
     let graphItem = this._graphs[graph];
     // Create the graph if it doesn't exist yet
     if (!graphItem) {
-      graphItem = this._graphs[graph] = { subjects: {}, predicates: {}, objects: {} };
+      graphItem = this._graphs[graph] = {
+        subjects: { [SIZE]: 0 },
+        predicates: { [SIZE]: 0 },
+        objects: { [SIZE]: 0 },
+      };
       // Freezing a graph helps subsequent `add` performance,
       // and properties will never be modified anyway
       Object.freeze(graphItem);
@@ -469,8 +507,8 @@ export default class N3Store {
     if (this._size !== null) this._size--;
 
     // Remove the graph if it is empty
-    for (subject in graphItem.subjects) return true;
-    delete graphs[graph];
+    if (graphItem.subjects[SIZE] === 0)
+      delete graphs[graph];
     return true;
   }
 
@@ -1130,15 +1168,18 @@ function indexMatch(index, ids, depth = 0) {
   if (ind && !(ind in index))
     return false;
 
-  let target = false;
+  let target = false, size = 0;
   for (const key in (ind ? { [ind]: index[ind] } : index)) {
     const result = depth === 2 ? null : indexMatch(index[key], ids, depth + 1);
 
     if (result !== false) {
       target = target || Object.create(null);
       target[key] = result;
+      size++;
     }
   }
+  if (target)
+    target[SIZE] = size;
   return target;
 }
 

--- a/test/Fuzz-test.js
+++ b/test/Fuzz-test.js
@@ -8,20 +8,11 @@
 //
 // A seeded PRNG keeps runs reproducible (no flaky CI). Each iteration is
 // reduced to a boolean by a helper so assertions stay unconditional.
+import { makeRng, pick } from './util';
 import { Parser, Writer, Store, DataFactory } from '../src';
 import { isomorphic } from 'rdf-isomorphic';
 
 const { namedNode, blankNode, literal, quad, defaultGraph } = DataFactory;
-
-// Small deterministic LCG.
-function makeRng(seed) {
-  let s = seed >>> 0;
-  return function next() {
-    s = (Math.imul(s, 1664525) + 1013904223) >>> 0;
-    return s / 0x100000000;
-  };
-}
-function pick(rng, arr) { return arr[Math.floor(rng() * arr.length)]; }
 
 // Characters that historically broke lexers and writers (delimiters, quotes,
 // escapes, controls, astral). Used raw in fuzzed documents and literal values.

--- a/test/N3Store-test.js
+++ b/test/N3Store-test.js
@@ -1,3 +1,4 @@
+import { makeRng, pick } from './util';
 import {
   Store,
   termFromId, termToId,
@@ -2632,6 +2633,184 @@ describe('EntityIndex', () => {
       o5: 8,
     });
   });
+});
+
+describe('Store under randomized mutation', () => {
+  const { defaultGraph } = DataFactory;
+  const subjects   = ['s0', 's1', 's2', 's3', 's4'].map(namedNode);
+  const predicates = ['p0', 'p1', 'p2'].map(namedNode);
+  const objects    = ['o0', 'o1', 'o2', 'o3', 'o4'].map(namedNode);
+  const graphs     = [defaultGraph(), namedNode('g0'), namedNode('g1')];
+
+  function quadKey(q) {
+    return `${termToId(q.subject)} ${termToId(q.predicate)} ${termToId(q.object)} ${termToId(q.graph)}`;
+  }
+
+  // Compares the full store contents against the naive oracle set
+  function expectSameContents(store, oracle) {
+    expect(store.getQuads().map(quadKey).sort()).toEqual([...oracle].sort());
+    expect(store.size).toBe(oracle.size);
+  }
+
+  // Verifies that the entry counter of every index node
+  // matches its actual number of entries
+  function expectConsistentCounters(store) {
+    function check(node) {
+      const sizeSymbol = Object.getOwnPropertySymbols(node)
+        .find(symbol => symbol.description === 'size');
+      const keys = Object.keys(node);
+      expect(sizeSymbol).toBeDefined();
+      expect(node[sizeSymbol]).toBe(keys.length);
+      return keys;
+    }
+    for (const graphKey in store._graphs) {
+      const graphItem = store._graphs[graphKey];
+      for (const part of ['subjects', 'predicates', 'objects']) {
+        const index0 = graphItem[part];
+        for (const key0 of check(index0)) {
+          const index1 = index0[key0];
+          for (const key1 of check(index1))
+            check(index1[key1]);
+        }
+      }
+    }
+  }
+
+  function randomQuad(random) {
+    return new Quad(
+      pick(random, subjects),
+      pick(random, predicates),
+      pick(random, objects),
+      pick(random, graphs),
+    );
+  }
+
+  function randomTerm(random, terms) {
+    return random() < 0.5 ? pick(random, terms) : null;
+  }
+
+  function oracleOf(store) {
+    return new Set(store.getQuads().map(quadKey));
+  }
+
+  // Adds a quad to store and oracle, verifying the return value
+  function addAndVerify(store, oracle, q) {
+    const key = quadKey(q);
+    expect(store.addQuad(q)).toBe(!oracle.has(key));
+    oracle.add(key);
+  }
+
+  // Removes a quad from store and oracle, verifying the return value
+  function removeAndVerify(store, oracle, q) {
+    const key = quadKey(q);
+    expect(store.removeQuad(q)).toBe(oracle.has(key));
+    oracle.delete(key);
+  }
+
+  for (const seed of [1, 2, 3]) {
+    it(`should behave like a naive set of quads (seed ${seed})`, () => {
+      const random = makeRng(seed);
+      const entityIndex = new EntityIndex();
+      let store = new Store({ entityIndex });
+      let oracle = new Set();
+
+      for (let round = 0; round < 400; round++) {
+        const chance = random();
+        // Add a random quad
+        if (chance < 0.35)
+          addAndVerify(store, oracle, randomQuad(random));
+        // Remove a random quad, which may or may not exist
+        else if (chance < 0.65)
+          removeAndVerify(store, oracle, randomQuad(random));
+        // Remove all quads matching a random pattern
+        else if (chance < 0.8) {
+          const subject = randomTerm(random, subjects),
+              predicate = randomTerm(random, predicates),
+              object = randomTerm(random, objects),
+              graph = randomTerm(random, graphs);
+          store.deleteMatches(subject, predicate, object, graph);
+          for (const key of [...oracle]) {
+            const [s, p, o, g] = key.split(' ');
+            if ((!subject || termToId(subject) === s) &&
+                (!predicate || termToId(predicate) === p) &&
+                (!object || termToId(object) === o) &&
+                (!graph || termToId(graph) === g))
+              oracle.delete(key);
+          }
+        }
+        // Add multiple random quads at once
+        else if (chance < 0.9) {
+          const quads = [randomQuad(random), randomQuad(random), randomQuad(random)];
+          store.addAll(quads);
+          for (const q of quads)
+            oracle.add(quadKey(q));
+        }
+        // Replace the store by a set operation
+        // with another store sharing the same entity index,
+        // and continue mutating the result
+        else {
+          const other = new Store({ entityIndex });
+          for (let i = 0; i < 5; i++)
+            other.addQuad(randomQuad(random));
+          const otherOracle = oracleOf(other);
+          const setOp = random();
+          if (setOp < 1 / 3) {
+            store = store.union(other);
+            oracle = new Set([...oracle, ...otherOracle]);
+          }
+          else if (setOp < 2 / 3) {
+            store = store.difference(other);
+            oracle = new Set([...oracle].filter(key => !otherOracle.has(key)));
+          }
+          else {
+            store = store.intersection(other);
+            oracle = new Set([...oracle].filter(key => otherOracle.has(key)));
+          }
+        }
+
+        if (round % 50 === 49) {
+          expectSameContents(store, oracle);
+          expectConsistentCounters(store);
+        }
+      }
+
+      // Mutate a materialized `match` view of the store
+      const pattern = randomTerm(random, subjects);
+      const view = store.match(pattern, null, null, null);
+      const viewOracle = new Set([...oracle].filter(
+        key => !pattern || key.split(' ')[0] === termToId(pattern)));
+      for (let i = 0; i < 50; i++) {
+        const q = randomQuad(random);
+        if (random() < 0.5) {
+          view.add(q);
+          viewOracle.add(quadKey(q));
+        }
+        else {
+          view.delete(q);
+          viewOracle.delete(quadKey(q));
+        }
+      }
+      expectSameContents(view.filtered, viewOracle);
+      expectConsistentCounters(view.filtered);
+      // The original store is unaffected by view mutations
+      expectSameContents(store, oracle);
+
+      // Empty out the store completely; all graphs should be dropped
+      for (const key of [...oracle]) {
+        const [s, p, o, g] = key.split(' ');
+        expect(store.removeQuad(termFromId(s), termFromId(p), termFromId(o), termFromId(g))).toBe(true);
+      }
+      expect(store.size).toBe(0);
+      expect(store.getQuads()).toHaveLength(0);
+      expect(Object.keys(store._graphs)).toHaveLength(0);
+
+      // The store remains usable after being emptied
+      const q = randomQuad(random);
+      expect(store.addQuad(q)).toBe(true);
+      expect(store.getQuads().map(quadKey)).toEqual([quadKey(q)]);
+      expectConsistentCounters(store);
+    });
+  }
 });
 
 function alwaysTrue()  { return true;  }

--- a/test/N3Store-test.js
+++ b/test/N3Store-test.js
@@ -2533,6 +2533,194 @@ describe('EntityIndex', () => {
   });
 });
 
+describe('Store under randomized mutation', () => {
+  // A deterministic PRNG, so that any failure is reproducible
+  function mulberry32(seed) {
+    return () => {
+      seed = seed + 0x6D2B79F5 | 0;
+      let t = Math.imul(seed ^ seed >>> 15, 1 | seed);
+      t ^= t + Math.imul(t ^ t >>> 7, 61 | t);
+      return ((t ^ t >>> 14) >>> 0) / 4294967296;
+    };
+  }
+
+  const { defaultGraph } = DataFactory;
+  const subjects   = ['s0', 's1', 's2', 's3', 's4'].map(namedNode);
+  const predicates = ['p0', 'p1', 'p2'].map(namedNode);
+  const objects    = ['o0', 'o1', 'o2', 'o3', 'o4'].map(namedNode);
+  const graphs     = [defaultGraph(), namedNode('g0'), namedNode('g1')];
+
+  function quadKey(q) {
+    return `${termToId(q.subject)} ${termToId(q.predicate)} ${termToId(q.object)} ${termToId(q.graph)}`;
+  }
+
+  // Compares the full store contents against the naive oracle set
+  function expectSameContents(store, oracle) {
+    expect(store.getQuads().map(quadKey).sort()).toEqual([...oracle].sort());
+    expect(store.size).toBe(oracle.size);
+  }
+
+  // Verifies that the entry counter of every index node
+  // matches its actual number of entries
+  function expectConsistentCounters(store) {
+    function check(node) {
+      const sizeSymbol = Object.getOwnPropertySymbols(node)
+        .find(symbol => symbol.description === 'size');
+      const keys = Object.keys(node);
+      expect(sizeSymbol).toBeDefined();
+      expect(node[sizeSymbol]).toBe(keys.length);
+      return keys;
+    }
+    for (const graphKey in store._graphs) {
+      const graphItem = store._graphs[graphKey];
+      for (const part of ['subjects', 'predicates', 'objects']) {
+        const index0 = graphItem[part];
+        for (const key0 of check(index0)) {
+          const index1 = index0[key0];
+          for (const key1 of check(index1))
+            check(index1[key1]);
+        }
+      }
+    }
+  }
+
+  function randomQuad(random) {
+    return new Quad(
+      subjects[Math.floor(random() * subjects.length)],
+      predicates[Math.floor(random() * predicates.length)],
+      objects[Math.floor(random() * objects.length)],
+      graphs[Math.floor(random() * graphs.length)],
+    );
+  }
+
+  function randomTerm(random, terms) {
+    return random() < 0.5 ? terms[Math.floor(random() * terms.length)] : null;
+  }
+
+  function oracleOf(store) {
+    return new Set(store.getQuads().map(quadKey));
+  }
+
+  // Adds a quad to store and oracle, verifying the return value
+  function addAndVerify(store, oracle, q) {
+    const key = quadKey(q);
+    expect(store.addQuad(q)).toBe(!oracle.has(key));
+    oracle.add(key);
+  }
+
+  // Removes a quad from store and oracle, verifying the return value
+  function removeAndVerify(store, oracle, q) {
+    const key = quadKey(q);
+    expect(store.removeQuad(q)).toBe(oracle.has(key));
+    oracle.delete(key);
+  }
+
+  for (const seed of [1, 2, 3]) {
+    it(`should behave like a naive set of quads (seed ${seed})`, () => {
+      const random = mulberry32(seed);
+      const entityIndex = new EntityIndex();
+      let store = new Store({ entityIndex });
+      let oracle = new Set();
+
+      for (let round = 0; round < 400; round++) {
+        const chance = random();
+        // Add a random quad
+        if (chance < 0.35)
+          addAndVerify(store, oracle, randomQuad(random));
+        // Remove a random quad, which may or may not exist
+        else if (chance < 0.65)
+          removeAndVerify(store, oracle, randomQuad(random));
+        // Remove all quads matching a random pattern
+        else if (chance < 0.8) {
+          const subject = randomTerm(random, subjects),
+              predicate = randomTerm(random, predicates),
+              object = randomTerm(random, objects),
+              graph = randomTerm(random, graphs);
+          store.deleteMatches(subject, predicate, object, graph);
+          for (const key of [...oracle]) {
+            const [s, p, o, g] = key.split(' ');
+            if ((!subject || termToId(subject) === s) &&
+                (!predicate || termToId(predicate) === p) &&
+                (!object || termToId(object) === o) &&
+                (!graph || termToId(graph) === g))
+              oracle.delete(key);
+          }
+        }
+        // Add multiple random quads at once
+        else if (chance < 0.9) {
+          const quads = [randomQuad(random), randomQuad(random), randomQuad(random)];
+          store.addAll(quads);
+          for (const q of quads)
+            oracle.add(quadKey(q));
+        }
+        // Replace the store by a set operation
+        // with another store sharing the same entity index,
+        // and continue mutating the result
+        else {
+          const other = new Store({ entityIndex });
+          for (let i = 0; i < 5; i++)
+            other.addQuad(randomQuad(random));
+          const otherOracle = oracleOf(other);
+          const setOp = random();
+          if (setOp < 1 / 3) {
+            store = store.union(other);
+            oracle = new Set([...oracle, ...otherOracle]);
+          }
+          else if (setOp < 2 / 3) {
+            store = store.difference(other);
+            oracle = new Set([...oracle].filter(key => !otherOracle.has(key)));
+          }
+          else {
+            store = store.intersection(other);
+            oracle = new Set([...oracle].filter(key => otherOracle.has(key)));
+          }
+        }
+
+        if (round % 50 === 49) {
+          expectSameContents(store, oracle);
+          expectConsistentCounters(store);
+        }
+      }
+
+      // Mutate a materialized `match` view of the store
+      const pattern = randomTerm(random, subjects);
+      const view = store.match(pattern, null, null, null);
+      const viewOracle = new Set([...oracle].filter(
+        key => !pattern || key.split(' ')[0] === termToId(pattern)));
+      for (let i = 0; i < 50; i++) {
+        const q = randomQuad(random);
+        if (random() < 0.5) {
+          view.add(q);
+          viewOracle.add(quadKey(q));
+        }
+        else {
+          view.delete(q);
+          viewOracle.delete(quadKey(q));
+        }
+      }
+      expectSameContents(view.filtered, viewOracle);
+      expectConsistentCounters(view.filtered);
+      // The original store is unaffected by view mutations
+      expectSameContents(store, oracle);
+
+      // Empty out the store completely; all graphs should be dropped
+      for (const key of [...oracle]) {
+        const [s, p, o, g] = key.split(' ');
+        expect(store.removeQuad(termFromId(s), termFromId(p), termFromId(o), termFromId(g))).toBe(true);
+      }
+      expect(store.size).toBe(0);
+      expect(store.getQuads()).toHaveLength(0);
+      expect(Object.keys(store._graphs)).toHaveLength(0);
+
+      // The store remains usable after being emptied
+      const q = randomQuad(random);
+      expect(store.addQuad(q)).toBe(true);
+      expect(store.getQuads().map(quadKey)).toEqual([quadKey(q)]);
+      expectConsistentCounters(store);
+    });
+  }
+});
+
 function alwaysTrue()  { return true;  }
 function alwaysFalse() { return false; }
 

--- a/test/util.js
+++ b/test/util.js
@@ -1,0 +1,11 @@
+export function makeRng(seed) {
+  let state = seed >>> 0;
+  return () => {
+    state = (Math.imul(state, 1664525) + 1013904223) >>> 0;
+    return state / 0x100000000;
+  };
+}
+
+export function pick(rng, values) {
+  return values[Math.floor(rng() * values.length)];
+}


### PR DESCRIPTION
`removeQuad` checks whether the graph became empty with a `for`…`in` over **all** subjects in the graph, and `_removeFromIndex` uses the same idiom on the two inner index levels. Large index levels are dictionary-mode objects, so `for`…`in` collects (and sorts) the full key set before the first iteration — the early `return` saves nothing, making every removal O(#subjects in the graph). `deleteMatches`, `removeMatches`, `deleteGraph`, and reasoner churn all sit on this path. (The V8-side cost is reported upstream: https://issues.chromium.org/issues/530857250.)

This PR keeps an entry counter on every index node under a `Symbol` key (invisible to `for`…`in` and `Object.keys`), so empty-level cleanup and the graph-emptiness check are O(1). The invariant: every function that builds index nodes maintains the counter — `_addToIndex`, `merge`, `intersect`, `difference`, and `indexMatch` — which covers add/remove/`removeMatches`/`deleteMatches`, stores produced by `addAll`/`union`/`difference`/`intersection`, mutation of materialized `match()` views, and `N3Reasoner`.

Measured (fresh process per measurement, interleaved A/B vs main, medians of 5 rounds, checksum-gated; Apple M1, Node 25):

| workload | main | this PR |
|---|---:|---:|
| removeQuad @100k / @1M | 1 301 / 15 322 µs/op | 3.0 / 14.4 µs/op (~430× / ~1 060×) |
| deleteMatches(s,·,·) @100k / @1M | 12 749 / 153 508 µs/op | 55.7 / 202 µs/op (~230× / ~760×) |
| addQuad fresh load @100k / @1M | 5.05 / 5.44 µs/op | 3.84 / 5.75 µs/op (no regression; ±5 % noise band) |
| memory @1M | 2 457.0 B/quad | 2 449.3 B/quad (−0.3 %) |

Correctness: beyond the existing suite, a randomized differential test (3 fixed seeds × 400 mixed operations — add/remove/deleteMatches/addAll, set operations, materialized-view mutation, full drain) against a naive `Set` oracle, plus an audit that every index node's counter equals its actual entry count.

In-flight PRs: #601 touches the same `merge`/`intersect`/`difference` helpers — whichever lands second applies the counter discipline to the new helper bodies (mechanical; the invariant is documented at the `SIZE` declaration). #635 (term-id encoding) has no structural overlap; #598's delta-based view removals inherit the win.

cc @jeswr
