### PR TITLE
perf: descend the SPO index in getObjects instead of scanning all objects

### DIFF
--- a/src/N3Store.js
+++ b/src/N3Store.js
@@ -296,6 +296,19 @@ export default class N3Store {
     }
   }
 
+  // ### `_loopByKey0Deep` executes the callback on all keys of index 2
+  // for a certain entry in index 0, possibly repeating keys
+  _loopByKey0Deep(index0, key0, callback) {
+    let index1, index2, key1, key2;
+    if (index1 = index0[key0]) {
+      for (key1 in index1) {
+        index2 = index1[key1];
+        for (key2 in index2)
+          callback(key2);
+      }
+    }
+  }
+
   // ### `_countInIndex` counts matching quads in a three-layered index.
   // The index base is `index0` and the keys at each level are `key0`, `key1`, and `key2`.
   // Any of these keys can be undefined, which is interpreted as a wildcard.
@@ -719,8 +732,10 @@ export default class N3Store {
             // If subject and predicate are given, the SPO index is best.
             this._loopBy2Keys(content.subjects, subjectId, predicateId, callback);
           else
-            // If only subject is given, the OSP index is best.
-            this._loopByKey1(content.objects, subjectId, callback);
+            // If only subject is given, descending the SPO index
+            // visits only the subject's own quads,
+            // instead of probing every distinct object in the graph.
+            this._loopByKey0Deep(content.subjects, subjectId, callback);
         }
         else if (predicateId)
           // If only predicate is given, the POS index is best.

--- a/src/N3Store.js
+++ b/src/N3Store.js
@@ -733,8 +733,7 @@ export default class N3Store {
             this._loopBy2Keys(content.subjects, subjectId, predicateId, callback);
           else
             // If only subject is given, descending the SPO index
-            // visits only the subject's own quads,
-            // instead of probing every distinct object in the graph.
+            // visits only the subject's own quads.
             this._loopByKey0Deep(content.subjects, subjectId, callback);
         }
         else if (predicateId)

--- a/test/N3Store-test.js
+++ b/test/N3Store-test.js
@@ -1645,6 +1645,30 @@ describe('Store', () => {
     });
   });
 
+  describe('A Store with an object recurring under multiple predicates', () => {
+    const store = new Store([
+      new Quad(new NamedNode('s1'), new NamedNode('p1'), new NamedNode('o1')),
+      new Quad(new NamedNode('s1'), new NamedNode('p1'), new NamedNode('o2')),
+      new Quad(new NamedNode('s1'), new NamedNode('p2'), new NamedNode('o1')),
+      new Quad(new NamedNode('s2'), new NamedNode('p1'), new NamedNode('o1')),
+    ]);
+
+    describe('getObjects with only the subject given', () => {
+      it('should return each matching object exactly once', () => {
+        const result = store.getObjects(new NamedNode('s1'), null, null);
+        expect(result).toHaveLength(2);
+        expect(result).toEqual(expect.arrayContaining(
+          [new NamedNode('o1'), new NamedNode('o2')]));
+      });
+    });
+
+    describe('getObjects with a term that is not a subject', () => {
+      it('should be empty', () => {
+        expect(store.getObjects(new NamedNode('o1'), null, null)).toHaveLength(0);
+      });
+    });
+  });
+
   describe('A Store containing a blank node', () => {
     const store = new Store();
     const b1 = store.createBlankNode();


### PR DESCRIPTION
`getObjects(subject, null, graph)` currently answers via `_loopByKey1(content.objects, subjectId)`: a probe of **every distinct object in the graph** (the "OSP index is best" comment is wrong for this shape), i.e. O(#objects) for a handful of results. This descends the SPO index under the bound subject instead, visiting only the subject's own quads. `_uniqueEntities` dedupe is untouched, so each object is still emitted exactly once (result order changes; order is documented as arbitrary). The theoretical worst case for the descent is a subject with more quads than the graph has distinct objects — cost stays bounded by the subject's own quad count.

Measured — fresh process per measurement, interleaved A/B vs `main`, medians of 5 rounds, checksum-gated (Apple M1, Node v25, load < 8; data: N/10 subjects, 32 predicates, N/5 named objects + 40 % unique literals):

| workload | main | this PR | speedup |
|---|---:|---:|---:|
| getObjects(s) @100k (~10 results) | 7 498 µs/op | 13.3 µs/op | ~560× |
| getObjects(s) @1M (~10 results) | 106 981 µs/op | 35.3 µs/op | ~3 000× |
| addQuad fresh load | | | unchanged |

Evaluated and **not** included: the same treatment for `getSubjects(predicate)`, which probes every subject. A cardinality-picked POS descent (choosing by `Object.keys` counts) measured *slower*: ~0.68× on realistic data and ~27× worse on an adversarial shape (many distinct objects under the predicate), because the pick itself costs a key collection of the level it inspects. The pick becomes O(1) once per-node entry counters exist (see the removal-counters PR) — left as a follow-up. `getSubjects` here is byte-identical to main: measured parity @100k (1.04×); the 1M workload is GC-dominated and swings 0.4–1.3× on identical code, so no claim is made.

`getPredicates(s)` already descends SPO and `forGraphs` shows no measured issue; both untouched.

cc @jeswr
