### PR TITLE
docs: add SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,36 @@
+# Security Policy
+
+## Supported Versions
+
+Security fixes are applied to the latest release on the most recent major version line.
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 2.x     | :white_check_mark: |
+| < 2.0   | :x:                |
+
+## Reporting a Vulnerability
+
+Please do **not** report security vulnerabilities through public GitHub issues,
+discussions, or pull requests.
+
+Instead, report them privately through
+[GitHub's private vulnerability reporting](https://github.com/rdfjs/N3.js/security/advisories/new)
+(_Security_ → _Report a vulnerability_ on this repository). If that is not
+available to you, contact the maintainers listed in
+[`package.json`](https://github.com/rdfjs/N3.js/blob/main/package.json) directly.
+
+Please include, where possible:
+
+- the affected version(s),
+- a description of the issue and its impact,
+- steps to reproduce or a minimal proof of concept.
+
+## What to Expect
+
+- We will acknowledge your report, usually within a week.
+- We will investigate and keep you informed of our progress.
+- Once a fix is available, we will coordinate the disclosure and release with
+  you, and credit you for the discovery unless you prefer to remain anonymous.
+
+Thank you for helping keep N3.js and its users safe.


### PR DESCRIPTION
Adds a standard security disclosure policy: supported versions, private reporting via GitHub's "Report a vulnerability", and response expectations. The repository currently has no `SECURITY.md`, so GitHub shows no guidance on the Security tab and reporters default to public issues.

Note: private vulnerability reporting is currently disabled in the repository settings — it needs a one-click enable (Settings → Advanced Security → Private vulnerability reporting) for the linked report form to work; the maintainer-contact fallback covers the interim.

cc @jeswr