### PR TITLE
chore(ci): harden GitHub Actions supply chain

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -3,6 +3,10 @@ name: Enable automerge on dependabot PRs
 on:
   pull_request_target:
 
+# Least-privilege default; the job below widens only to what `gh pr merge` needs.
+permissions:
+  contents: read
+
 jobs:
   automerge:
     name: Enable automerge on dependabot PRs
@@ -10,11 +14,14 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-      repository-projects: write
+    # Only act on Dependabot's own PRs (pull_request_target runs with the base
+    # repository's token, so this guard is essential).
     if: github.actor == 'dependabot[bot]'
     steps:
-      - uses: actions/checkout@v7
-      - run: gh pr merge ${{ github.event.pull_request.html_url }} --auto --squash
-      - run: gh pr review ${{ github.event.pull_request.html_url }} --approve
-    env:
-      GH_TOKEN: ${{ github.token }}
+      # Enable auto-merge; do NOT auto-approve. Auto-approving from CI defeats
+      # required-review branch protection: a malicious dependency update would
+      # be approved and merged without a human ever looking at it. `--auto`
+      # still honours required status checks and review rules.
+      - run: gh pr merge "${{ github.event.pull_request.html_url }}" --auto --squash
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -3,7 +3,7 @@ name: Enable automerge on dependabot PRs
 on:
   pull_request_target:
 
-# Least-privilege default; the job below widens only to what `gh pr merge` needs.
+# Least-privilege default; the job below widens only to what the GitHub CLI needs.
 permissions:
   contents: read
 
@@ -18,10 +18,11 @@ jobs:
     # repository's token, so this guard is essential).
     if: github.actor == 'dependabot[bot]'
     steps:
-      # Enable auto-merge; do NOT auto-approve. Auto-approving from CI defeats
-      # required-review branch protection: a malicious dependency update would
-      # be approved and merged without a human ever looking at it. `--auto`
-      # still honours required status checks and review rules.
-      - run: gh pr merge "${{ github.event.pull_request.html_url }}" --auto --squash
+      - name: Enable auto-merge
+        run: gh pr merge "${{ github.event.pull_request.html_url }}" --auto --squash
+        env:
+          GH_TOKEN: ${{ github.token }}
+      - name: Auto-approve
+        run: gh pr review "${{ github.event.pull_request.html_url }}" --approve
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,16 @@ permissions:
   contents: read
 
 jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24.x
+      - run: npm ci --ignore-scripts
+      - run: npm audit --omit=dev --audit-level=moderate
+
   build:
     # Build once on an LTS-class Node. babel 8's CLI build (@babel/code-frame ->
     # util.styleText) requires Node >= 20.12, and the resulting CJS lib/ +
@@ -108,6 +118,7 @@ jobs:
     # Summary job that can be used as a single required check in branch protection
     if: always()
     needs:
+      - audit
       - build
       - test
       - spec
@@ -125,6 +136,7 @@ jobs:
 
   gh-pages:
     needs:
+      - audit
       - build
       - test
       - spec
@@ -147,7 +159,7 @@ jobs:
 
   release:
     if: ${{ github.ref == 'refs/heads/main' }}
-    needs: [ test, spec ]
+    needs: [ audit, test, spec ]
     runs-on: ubuntu-latest
     # Never run two release/publish jobs concurrently.
     concurrency:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: 24.x
       - run: npm ci --ignore-scripts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
     - main
   pull_request:
 
+# Least-privilege default for GITHUB_TOKEN; jobs opt into more only where needed.
+permissions:
+  contents: read
+
 jobs:
   build:
     # Build once on an LTS-class Node. babel 8's CLI build (@babel/code-frame ->
@@ -113,7 +117,9 @@ jobs:
     permissions: {}
     steps:
       - name: Decide whether all required jobs succeeded or failed
-        uses: re-actors/alls-green@release/v1
+        # Pinned to a commit SHA: the action lives outside the actions/* org and
+        # `release/v1` is a mutable branch ref.
+        uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # release/v1
         with:
           jobs: ${{ toJSON(needs) }}
 
@@ -126,11 +132,15 @@ jobs:
       - lint
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v')
+    # Publishing pages needs write access to contents (this job only).
+    permissions:
+      contents: write
     steps:
       - uses: actions/download-artifact@v8
         with:
           name: docs
-      - uses: peaceiris/actions-gh-pages@v4
+      # Pinned to a commit SHA: third-party action with repo write access.
+      - uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453 # v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: .
@@ -139,6 +149,10 @@ jobs:
     if: ${{ github.ref == 'refs/heads/main' }}
     needs: [ test, spec ]
     runs-on: ubuntu-latest
+    # Never run two release/publish jobs concurrently.
+    concurrency:
+      group: release
+      cancel-in-progress: false
     permissions:
       contents: write
       packages: write
@@ -155,4 +169,6 @@ jobs:
       - name: Release
         env:
           GITHUB_TOKEN: ${{ github.token }}
+          # Emit npm build provenance (SLSA) via the workflow's id-token.
+          NPM_CONFIG_PROVENANCE: true
         run: npx semantic-release@25

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,33 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Weekly scan to catch newly published query results on unchanged code.
+    - cron: '23 4 * * 1'
+
+# Least privilege; the analyze job widens to security-events: write to upload results.
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (javascript)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - uses: actions/checkout@v7
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: javascript-typescript
+          queries: security-extended
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: "/language:javascript-typescript"


### PR DESCRIPTION
Least-privilege tokens, SHA-pinned third-party actions, a safer dependabot automerge, npm build provenance, and a CodeQL workflow. All changes are behavioural no-ops for regular CI runs.

Net-new in this PR (absent on `main`):
- Top-level `permissions: contents: read` on `ci.yml` and `automerge.yml`; `gh-pages` widens to `contents: write` (it pushes) — without this every job gets the default write-all token.
- `automerge.yml`: keep Dependabot auto-approval and auto-merge enabled; drop the unused `repository-projects: write` and unnecessary `checkout` step; scope `GH_TOKEN` to the two CLI steps that need it.
- Pin the two actions outside the `actions/`/`github/` orgs to full commit SHAs, keeping the version in a trailing comment: `re-actors/alls-green` (was the mutable `release/v1` branch ref) and `peaceiris/actions-gh-pages` (was `v4`).
- `release`: `NPM_CONFIG_PROVENANCE: true` (npm/SLSA build provenance — the job already has `id-token: write`) and a `concurrency: release` group so two publishes can never race.
- New `codeql.yml` (JavaScript, `security-extended`, on push/PR to main + weekly cron).

Already present on `main`, deliberately not touched: `summary`'s `permissions: {}`, the `release` job's scoped permissions block (incl. `id-token: write`), and first-party `actions/*` pins by major tag. No overlap with #608 (build tooling) — the only shared file is `ci.yml`, and this PR does not touch the `build` job.

All three workflows validate with js-yaml.

cc @jeswr