### PR TITLE
fix(datafactory): type unsafe-range numbers as xsd:double, not xsd:integer

### DIFF
--- a/src/N3DataFactory.js
+++ b/src/N3DataFactory.js
@@ -389,7 +389,13 @@ function literal(value, languageOrDataType) {
     // Convert an integer or double
     else if (typeof value === 'number') {
       if (Number.isFinite(value))
-        datatype = Number.isInteger(value) ? xsd.integer : xsd.double;
+        // Tag as xsd:integer only when the number provably denotes that exact
+        // integer. Beyond 2^53, a JS number can no longer represent every
+        // integer (9007199254740993 silently becomes ...992), and from 1e21
+        // upward its string form turns exponential ("1e+21"), which is not a
+        // valid xsd:integer lexical. In both cases xsd:double, the datatype
+        // matching the IEEE 754 value space, is the faithful typing.
+        datatype = Number.isSafeInteger(value) ? xsd.integer : xsd.double;
       else {
         datatype = xsd.double;
         if (!Number.isNaN(value))

--- a/test/N3DataFactory-test.js
+++ b/test/N3DataFactory-test.js
@@ -78,6 +78,27 @@ describe('DataFactory', () => {
       expect(DataFactory.literal(2.3)).toEqual(new Literal('"2.3"^^http://www.w3.org/2001/XMLSchema#double'));
     });
 
+    it('converts a large exponential-form integer-valued number to xsd:double', () => {
+      // String(1e21) === '1e+21', which is not a valid xsd:integer lexical
+      expect(DataFactory.literal(1e21)).toEqual(new Literal('"1e+21"^^http://www.w3.org/2001/XMLSchema#double'));
+      expect(DataFactory.literal(-1e21)).toEqual(new Literal('"-1e+21"^^http://www.w3.org/2001/XMLSchema#double'));
+      expect(DataFactory.literal(1e30)).toEqual(new Literal('"1e+30"^^http://www.w3.org/2001/XMLSchema#double'));
+    });
+
+    it('converts an integer-valued number beyond Number.MAX_SAFE_INTEGER to xsd:double', () => {
+      // 2**53 + 1 is not representable and silently becomes 2**53, so an
+      // xsd:integer tag would assert an exact integer value that was never given
+      expect(DataFactory.literal(2 ** 53 + 1)).toEqual(new Literal('"9007199254740992"^^http://www.w3.org/2001/XMLSchema#double'));
+      expect(DataFactory.literal(2 ** 53)).toEqual(new Literal('"9007199254740992"^^http://www.w3.org/2001/XMLSchema#double'));
+      expect(DataFactory.literal(-(2 ** 53))).toEqual(new Literal('"-9007199254740992"^^http://www.w3.org/2001/XMLSchema#double'));
+      expect(DataFactory.literal(1e20)).toEqual(new Literal('"100000000000000000000"^^http://www.w3.org/2001/XMLSchema#double'));
+    });
+
+    it('converts Number.MAX_SAFE_INTEGER and its negation to xsd:integer', () => {
+      expect(DataFactory.literal(2 ** 53 - 1)).toEqual(new Literal('"9007199254740991"^^http://www.w3.org/2001/XMLSchema#integer'));
+      expect(DataFactory.literal(-(2 ** 53 - 1))).toEqual(new Literal('"-9007199254740991"^^http://www.w3.org/2001/XMLSchema#integer'));
+    });
+
     it('converts Infinity', () => {
       expect(DataFactory.literal(Infinity)).toEqual(new Literal('"INF"^^http://www.w3.org/2001/XMLSchema#double'));
     });


### PR DESCRIPTION
`DataFactory.literal()` auto-types any `Number.isInteger` value as `xsd:integer`, which mis-types two ranges (reproduced on main):

- `literal(1e21)` → `"1e+21"^^xsd:integer` — an invalid integer lexical (JS stringifies |n| ≥ 1e21 in exponential form)
- `literal(2 ** 53 + 1)` → `"9007199254740992"^^xsd:integer` — the IEEE 754 value silently lost the exact integer, yet the datatype still claims exactness

Fixed by tagging `xsd:integer` only for `Number.isSafeInteger` values; everything else becomes `xsd:double`, whose value space is exactly a JS number. After: `literal(1e21)` → `"1e+21"^^xsd:double`.

Deliberate consequence to weigh: exactly-representable-but-unsafe integers such as `1e20` also move from `xsd:integer` to `xsd:double` (still a valid lexical) — beyond 2^53 neighbouring integers collapse onto the same double, so an integer typing can't be trusted. Happy to narrow the boundary to only the exponential-form range (|n| ≥ 1e21) if the safe-integer cut is considered too strict.

GIGO note: the input is a perfectly valid JS number — the wrong datatype comes from N3's own inference, so this is plain correctness, not validation.

cc @jeswr