### PR TITLE
fix: guard termFromId JSON parsing of quoted-triple ids

### DIFF
--- a/src/N3DataFactory.js
+++ b/src/N3DataFactory.js
@@ -244,9 +244,21 @@ export function termFromId(id, factory, nested) {
     }
     return factory.literal(id.substr(1, endPos - 1),
             languageOrDatatype);
-  case '[':
-    id = JSON.parse(id);
+  case '[': {
+    // A `[`-prefixed id encodes a quoted triple as a JSON array of
+    // 3 or 4 term ids; ids that do not parse to that shape are named nodes
+    let parsed;
+    try {
+      parsed = JSON.parse(id);
+    }
+    catch (e) {
+      return factory.namedNode(id);
+    }
+    if (!Array.isArray(parsed) || parsed.length < 3 || parsed.length > 4)
+      return factory.namedNode(id);
+    id = parsed;
     break;
+  }
   default:
     if (!nested || !Array.isArray(id)) {
       return factory.namedNode(id);

--- a/test/Term-test.js
+++ b/test/Term-test.js
@@ -101,6 +101,19 @@ describe('Term', () => {
       });
     });
 
+    it('should create a NamedNode (not throw) from a "[" id that is not valid JSON', () => {
+      expect(termFromId('[bad').toJSON()).toEqual({
+        termType: 'NamedNode',
+        value: '[bad',
+      });
+    });
+
+    it('should create a NamedNode from a "[" id whose JSON is not a 3-or-4 element array', () => {
+      expect(termFromId('[]').toJSON()).toEqual({ termType: 'NamedNode', value: '[]' });
+      expect(termFromId('["a"]').toJSON()).toEqual({ termType: 'NamedNode', value: '["a"]' });
+      expect(termFromId('[1,2,3,4,5]').toJSON()).toEqual({ termType: 'NamedNode', value: '[1,2,3,4,5]' });
+    });
+
     it(
       'should create a BlankNode from a string that starts with an underscore',
       () => {


### PR DESCRIPTION
`termFromId` parses a `[`-prefixed id (a quoted triple) with `JSON.parse`. A malformed or hostile id — invalid JSON, or JSON that isn't a 3-or-4-element array — threw or produced a malformed term. This wraps the parse in try/catch and validates the shape, falling back to `factory.namedNode(id)` for anything that isn't a well-formed quoted-triple id.

Tests: focused cases for invalid/malformed `[`-prefixed ids.

The `extractLists` null-prototype hardening that was originally bundled here is split into #668, per review.
