### PR TITLE
feat(reasoner): opt-in maxDerivations and maxPremiseDepth budgets

### DIFF
--- a/README.md
+++ b/README.md
@@ -411,6 +411,23 @@ reasoner.reason(rulesDataset);
 
 **Note**: N3.js currently only supports rules with [Basic Graph Patterns](https://www.w3.org/TR/sparql11-query/#BasicGraphPattern) in the premise and conclusion. Built-ins and backward-chaining are *not* supported. For an RDF/JS reasoner that supports all Notation3 reasoning features, see [eye-js](https://github.com/eyereasoner/eye-js/).
 
+### Limiting reasoning cost
+
+When reasoning over rules or data that are not fully trusted,
+optional budgets bound the work `reason()` may perform:
+
+```JavaScript
+const reasoner = new Reasoner(store, {
+  maxDerivations: 100000, // maximum number of quads reason() may derive
+  maxPremiseDepth: 10,    // maximum number of premise triples per rule
+});
+reasoner.reason(rulesDataset);
+```
+
+Both budgets are unbounded by default;
+`reason()` throws when one is exceeded,
+leaving any quads derived up to that point in the store.
+
 ## Compatibility
 ### Format specifications
 The N3.js parser and writer is fully compatible with the following W3C specifications:

--- a/src/N3Reasoner.js
+++ b/src/N3Reasoner.js
@@ -16,14 +16,9 @@ export function getRulesFromDataset(dataset) {
 export default class N3Reasoner {
   constructor(store, options = {}) {
     this._store = store;
-    // Optional safety budgets for reasoning over rules and data that are not
-    // fully trusted. Naive forward chaining is super-linear: a transitive-closure
-    // rule over a chain of n edges derives O(n^2) quads in ~O(n^3) time, so a
-    // small input can exhaust CPU and memory. Both budgets default to unbounded
-    // for compatibility; `reason()` throws when a budget is exceeded.
+    // Optional safety budgets for reasoning over untrusted rules or data
     this._maxDerivations = options.maxDerivations === undefined ? Infinity : options.maxDerivations;
-    // `_evaluatePremise` recurses once per premise of a rule, so a single rule
-    // with very many body triples can overflow the stack. Bound the premise count.
+    // Caps a rule's premise count, as `_evaluatePremise` recurses once per premise
     this._maxPremiseDepth = options.maxPremiseDepth === undefined ? Infinity : options.maxPremiseDepth;
   }
 

--- a/src/N3Reasoner.js
+++ b/src/N3Reasoner.js
@@ -14,8 +14,17 @@ export function getRulesFromDataset(dataset) {
 }
 
 export default class N3Reasoner {
-  constructor(store) {
+  constructor(store, options = {}) {
     this._store = store;
+    // Optional safety budgets for reasoning over rules and data that are not
+    // fully trusted. Naive forward chaining is super-linear: a transitive-closure
+    // rule over a chain of n edges derives O(n^2) quads in ~O(n^3) time, so a
+    // small input can exhaust CPU and memory. Both budgets default to unbounded
+    // for compatibility; `reason()` throws when a budget is exceeded.
+    this._maxDerivations = options.maxDerivations === undefined ? Infinity : options.maxDerivations;
+    // `_evaluatePremise` recurses once per premise of a rule, so a single rule
+    // with very many body triples can overflow the stack. Bound the premise count.
+    this._maxPremiseDepth = options.maxPremiseDepth === undefined ? Infinity : options.maxPremiseDepth;
   }
 
   _add(subject, predicate, object, graphItem, cb) {
@@ -23,6 +32,11 @@ export default class N3Reasoner {
     if (!this._store._addToIndex(graphItem.subjects,   subject,   predicate, object)) return;
     this._store._addToIndex(graphItem.predicates, predicate, object,    subject);
     this._store._addToIndex(graphItem.objects,    object,    subject,   predicate);
+    // Count genuinely new derivations and fail past the budget. The check comes
+    // after all three indexes are updated, so a caught error leaves the store
+    // in a consistent state (the reasoning result is merely incomplete).
+    if (++this._derivations > this._maxDerivations)
+      throw new Error(`Reasoning exceeded the maximum of ${this._maxDerivations} derivations`);
     cb();
   }
 
@@ -129,10 +143,19 @@ export default class N3Reasoner {
   }
 
   reason(rules) {
+    this._derivations = 0;
     if (!Array.isArray(rules)) {
       rules = getRulesFromDataset(rules);
     }
     rules = rules.map(rule => this._createRule(rule));
+
+    // Reject rules with more body triples than the configured premise depth:
+    // `_evaluatePremise` recurses once per premise, so an over-long rule would
+    // otherwise overflow the stack with an uncatchable RangeError.
+    for (const rule of rules) {
+      if (rule.premise.length > this._maxPremiseDepth)
+        throw new Error(`Reasoning rule exceeds the maximum premise depth of ${this._maxPremiseDepth}`);
+    }
 
     for (const r1 of rules) {
       for (const r2 of rules) {
@@ -179,11 +202,16 @@ export default class N3Reasoner {
     }
 
     const graphs = this._store._getGraphs();
-    for (const graphId in graphs) {
-      this._reasonGraphNaive(rules, graphs[graphId]);
+    try {
+      for (const graphId in graphs) {
+        this._reasonGraphNaive(rules, graphs[graphId]);
+      }
     }
-
-    this._store._size = null;
+    finally {
+      // Invalidate the cached size even if a derivation budget was exceeded,
+      // so a caught budget error leaves the store fully consistent.
+      this._store._size = null;
+    }
   }
 }
 

--- a/test/N3Reasoner-test.js
+++ b/test/N3Reasoner-test.js
@@ -316,4 +316,64 @@ describe('Reasoner', () => {
     new Reasoner(store).reason(RDFS_RULE);
     return expect(store.size).toEqual(1830);
   });
+
+  describe('Reasoning budgets', () => {
+    // A transitive-closure rule over a chain of n edges derives O(n^2) quads
+    function chainStore(n) {
+      let doc = '@prefix : <http://example.org/>.\n';
+      for (let i = 0; i < n; i++) doc += `:x${i} :r :x${i + 1}.\n`;
+      return new Store(new Parser({ format: 'text/n3' }).parse(doc));
+    }
+    function transitiveRule() {
+      return getRulesFromDataset(new Store(new Parser({ format: 'text/n3' }).parse(
+        '@prefix : <http://example.org/>. { ?x :r ?y. ?y :r ?z } => { ?x :r ?z }.')));
+    }
+
+    it('Should fail when reasoning exceeds maxDerivations', () => {
+      const store = chainStore(400);
+      expect(() => new Reasoner(store, { maxDerivations: 1000 }).reason(transitiveRule()))
+        .toThrow('Reasoning exceeded the maximum of 1000 derivations');
+    });
+
+    it('Should leave the store consistent after a caught maxDerivations error', () => {
+      const store = chainStore(400);
+      expect(() => new Reasoner(store, { maxDerivations: 1000 }).reason(transitiveRule()))
+        .toThrow('Reasoning exceeded the maximum of 1000 derivations');
+      // Every quad reachable through the subject index must also be reachable
+      // through the predicate and object indexes, and the size must match
+      const quads = store.getQuads(null, null, null);
+      expect(store.size).toBe(quads.length);
+      for (const quad of quads) {
+        expect(store.getQuads(null, quad.predicate, null).some(q => q.equals(quad))).toBe(true);
+        expect(store.getQuads(null, null, quad.object).some(q => q.equals(quad))).toBe(true);
+      }
+    });
+
+    it('Should reason normally within a generous maxDerivations budget', () => {
+      const store = chainStore(50);
+      new Reasoner(store, { maxDerivations: 100000 }).reason(transitiveRule());
+      expect(store.size).toBe(1275);
+    });
+
+    it('Should reason normally with the default unbounded budgets', () => {
+      const store = chainStore(50);
+      new Reasoner(store).reason(transitiveRule());
+      expect(store.size).toBe(1275);
+    });
+
+    it('Should reject a rule whose premise count exceeds maxPremiseDepth', () => {
+      let body = '';
+      for (let i = 0; i < 20; i++) body += `?x :r${i} ?y${i}. `;
+      const rules = getRulesFromDataset(new Store(new Parser({ format: 'text/n3' }).parse(
+        `@prefix : <http://example.org/>. { ${body}} => { ?x :big :thing }.`)));
+      expect(() => new Reasoner(chainStore(2), { maxPremiseDepth: 5 }).reason(rules))
+        .toThrow('Reasoning rule exceeds the maximum premise depth of 5');
+    });
+
+    it('Should accept a rule whose premise count equals maxPremiseDepth', () => {
+      const store = chainStore(50);
+      new Reasoner(store, { maxPremiseDepth: 2 }).reason(transitiveRule());
+      expect(store.size).toBe(1275);
+    });
+  });
 });


### PR DESCRIPTION
Naive forward chaining is super-linear: a transitive-closure rule over a chain of n edges derives O(n²) quads in ~O(n³) time, and `getRulesFromDataset` reads rules straight from the graph — so a small semi-trusted document can exhaust CPU/memory, and a single rule with very many body triples overflows the `_evaluatePremise` recursion with an uncatchable RangeError.

Adds two opt-in constructor options (default unbounded, behaviour unchanged unless set):

- `maxDerivations` — caps genuinely-new derived quads; `reason()` throws a controlled error past the budget (measured: the 400-edge closure runs ~5 s / 80200 quads unbounded, fails closed in milliseconds at 1000).
- `maxPremiseDepth` — rejects up front any rule with more body triples than the premise recursion can take.

Consistency on throw — fixed from an earlier draft of this change, where a review bot caught an ordering bug: the budget check now runs after all three store indexes (`subjects`/`predicates`/`objects`) are updated for the derived quad, and the cached `_size` is invalidated in a `finally`, so catching the budget error leaves the store fully consistent (the reasoning result is merely incomplete). A regression test enumerates the store through the subject index and asserts every quad is also reachable through the predicate and object indexes — verified to fail if the check is placed between the index inserts.

Overhead when unset is noise: the unbounded 400-edge closure benchmark shows medians within 4% with overlapping ranges before/after (one increment + compare against Infinity per new derivation).

cc @jeswr