### PR TITLE
fix(lexer): reject \U escapes beyond U+10FFFF

### DIFF
--- a/src/N3Lexer.js
+++ b/src/N3Lexer.js
@@ -15,8 +15,9 @@ const escapeReplacements = {
 };
 const illegalIriChars = /[\x00-\x20<>\\"\{\}\|\^\`]/;
 
-function isSurrogateCodePoint(charCode) {
-  return charCode >= 0xD800 && charCode <= 0xDFFF;
+// A valid code point is a Unicode scalar value: at most U+10FFFF and not a surrogate
+function isValidCodePoint(charCode) {
+  return charCode <= 0x10FFFF && (charCode < 0xD800 || charCode > 0xDFFF);
 }
 
 const lineModeRegExps = {
@@ -425,7 +426,7 @@ export default class N3Lexer {
       // 4-digit unicode character
       if (typeof unicode4 === 'string') {
         const charCode = Number.parseInt(unicode4, 16);
-        if (isSurrogateCodePoint(charCode)) {
+        if (!isValidCodePoint(charCode)) {
           invalid = true;
           return '';
         }
@@ -434,8 +435,7 @@ export default class N3Lexer {
       // 8-digit unicode character
       if (typeof unicode8 === 'string') {
         let charCode = Number.parseInt(unicode8, 16);
-        // Reject code points beyond U+10FFFF, which are not Unicode scalar values
-        if (charCode > 0x10FFFF || isSurrogateCodePoint(charCode)) {
+        if (!isValidCodePoint(charCode)) {
           invalid = true;
           return '';
         }

--- a/src/N3Lexer.js
+++ b/src/N3Lexer.js
@@ -434,7 +434,8 @@ export default class N3Lexer {
       // 8-digit unicode character
       if (typeof unicode8 === 'string') {
         let charCode = Number.parseInt(unicode8, 16);
-        if (isSurrogateCodePoint(charCode)) {
+        // Reject code points beyond U+10FFFF, which are not Unicode scalar values
+        if (charCode > 0x10FFFF || isSurrogateCodePoint(charCode)) {
           invalid = true;
           return '';
         }

--- a/test/N3Lexer-test.js
+++ b/test/N3Lexer-test.js
@@ -101,8 +101,8 @@ describe('Lexer', () => {
 
     it(
       'should tokenize an IRI with eight-digit unicode escapes',
-      shouldTokenize('<http://a.example/\\U00000073\\U00A00073>',
-                     { type: 'IRI', value: 'http://a.example/s\uffc0\udc73', line: 1 },
+      shouldTokenize('<http://a.example/\\U00000073\\U0001F0A1>',
+                     { type: 'IRI', value: 'http://a.example/s\ud83c\udca1', line: 1 },
                      { type: 'eof', line: 1 }),
     );
 
@@ -386,6 +386,25 @@ describe('Lexer', () => {
     );
 
     it(
+      'should not tokenize a literal with an 8-digit unicode escape beyond U+10FFFF',
+      shouldNotTokenize('"\\U00110000" ',
+                        'Unexpected ""\\U00110000"" on line 1.'),
+    );
+
+    it(
+      'should not tokenize an IRI with an 8-digit unicode escape beyond U+10FFFF',
+      shouldNotTokenize('<urn:\\U00110000>',
+                        'Unexpected "<urn:\\U00110000>" on line 1.'),
+    );
+
+    it(
+      'should tokenize a literal with the highest valid 8-digit unicode escape',
+      shouldTokenize('"\\U0010FFFF" ',
+                     { type: 'literal', value: '\u{10FFFF}', line: 1 },
+                     { type: 'eof', line: 1 }),
+    );
+
+    it(
       'should not tokenize a double-quoted string ending with an escaped quote',
       shouldNotTokenize('"abc\\"',
                         'Unexpected ""abc\\"" on line 1.'),
@@ -518,9 +537,9 @@ describe('Lexer', () => {
 
     it(
       'should tokenize a single-quoted string with escape characters',
-      shouldTokenize("'\\\\ \\\" \\' \\n \\r \\t \\ua1b2' \n '''\\\\ \\\" \\' \\n \\r \\t \\U0020a1b2'''",
+      shouldTokenize("'\\\\ \\\" \\' \\n \\r \\t \\ua1b2' \n '''\\\\ \\\" \\' \\n \\r \\t \\U0001F0A1'''",
                      { type: 'literal', value: '\\ " \' \n \r \t \ua1b2', line: 1 },
-                     { type: 'literal', value: '\\ " \' \n \r \t \udfe8\uddb2', line: 2 },
+                     { type: 'literal', value: '\\ " \' \n \r \t \ud83c\udca1', line: 2 },
                      { type: 'eof', line: 2 }),
     );
 


### PR DESCRIPTION
#593 rejects `\u`/`\U` escapes in the surrogate range, but `\U` escapes above U+10FFFF are still accepted and silently mangled: on main, `"\U00110000"` parses to a length-2 string of unpaired code units `0xDC00 0xDC00` (the surrogate-pair arithmetic applied beyond its domain). Code points above U+10FFFF are not Unicode scalar values (Turtle UCHAR / RFC 3987), so there is no character the escape could denote.

Reject `charCode > 0x10FFFF` in `_unescape`'s 8-digit branch, next to #593's surrogate check; the error is the same shape as the surrogate rejection (`Unexpected ""\U00110000"" on line 1.`). Two existing tests asserted the old over-accepting behaviour (expecting the mangled code units); they now use a valid astral escape (`\U0001F0A1`) instead. Added negative tests for the literal and IRI positions plus a boundary test for `\U0010FFFF`.

Note: this is the residual half of the `bad-numeric-escape` conformance skip (the surrogate half was #593); removing that skip can follow separately once this lands.

GIGO note: same class as #593 — accepting the escape can only ever produce corrupt output from N3's own unescaping.

cc @jeswr