### PR TITLE
perf(store): remove per-call allocations from index read hot paths

### DIFF
--- a/src/N3Store.js
+++ b/src/N3Store.js
@@ -90,6 +90,10 @@ export class N3EntityIndex {
      // inverse of `_ids`
     this._entities = Object.create(null);
     this._entities[1] = '';
+    // `_termCache` memoizes the materialized term per numeric entity id.
+    // Entities are never removed from `_ids`/`_entities`, so entries never go stale,
+    // and RDF/JS terms are immutable, so instances can be shared across reads.
+    this._termCache = [];
     // `_blankNodeIndex` is the index of the last automatically named blank node
     this._blankNodeIndex = 0;
     this._factory = options.factory || N3DataFactory;
@@ -108,6 +112,12 @@ export class N3EntityIndex {
       return q;
     }
     return termFromId(id, this._factory);
+  }
+
+  // ### `_termFromNumericId` materializes the term with the given numeric id,
+  // caching the result so repeated reads reuse a single term instance
+  _termFromNumericId(id) {
+    return this._termCache[id] || (this._termCache[id] = this._termFromId(this._entities[id]));
   }
 
   _termToNumericId(term) {
@@ -170,6 +180,7 @@ export default class N3Store {
     this._entityIndex = options.entityIndex || new N3EntityIndex({ factory: this._factory });
     this._entities = this._entityIndex._entities;
     this._termFromId = this._entityIndex._termFromId.bind(this._entityIndex);
+    this._termFromNumericId = this._entityIndex._termFromNumericId.bind(this._entityIndex);
     this._termToNumericId = this._entityIndex._termToNumericId.bind(this._entityIndex);
     this._termToNewNumericId = this._entityIndex._termToNewNumericId.bind(this._entityIndex);
 
@@ -234,26 +245,27 @@ export default class N3Store {
   // (for instance: _subject_, _predicate_, and _object_).
   // Finally, `graphId` will be the graph of the created quads.
   *_findInIndex(index0, key0, key1, key2, name0, name1, name2, graphId) {
-    let tmp, index1, index2;
-    const entityKeys = this._entities;
-    const graph = this._termFromId(entityKeys[graphId]);
+    let index1, index2;
+    const graph = this._termFromNumericId(graphId);
     const parts = { subject: null, predicate: null, object: null };
 
     // If a key is specified, use only that part of index 0.
-    if (key0) (tmp = index0, index0 = {})[key0] = tmp[key0];
-    for (const value0 in index0) {
+    const values0 = key0 ? [key0] : Object.keys(index0);
+    for (let i0 = 0; i0 < values0.length; i0++) {
+      const value0 = values0[i0];
       if (index1 = index0[value0]) {
-        parts[name0] = this._termFromId(entityKeys[value0]);
+        parts[name0] = this._termFromNumericId(value0);
         // If a key is specified, use only that part of index 1.
-        if (key1) (tmp = index1, index1 = {})[key1] = tmp[key1];
-        for (const value1 in index1) {
+        const values1 = key1 ? [key1] : Object.keys(index1);
+        for (let i1 = 0; i1 < values1.length; i1++) {
+          const value1 = values1[i1];
           if (index2 = index1[value1]) {
-            parts[name1] = this._termFromId(entityKeys[value1]);
+            parts[name1] = this._termFromNumericId(value1);
             // If a key is specified, use only that part of index 2, if it exists.
             const values = key2 ? (key2 in index2 ? [key2] : []) : Object.keys(index2);
             // Create quads for all items found in index 2.
             for (let l = 0; l < values.length; l++) {
-              parts[name2] = this._termFromId(entityKeys[values[l]]);
+              parts[name2] = this._termFromNumericId(values[l]);
               yield this._factory.quad(parts.subject, parts.predicate, parts.object, graph);
             }
           }
@@ -300,25 +312,41 @@ export default class N3Store {
   // The index base is `index0` and the keys at each level are `key0`, `key1`, and `key2`.
   // Any of these keys can be undefined, which is interpreted as a wildcard.
   _countInIndex(index0, key0, key1, key2) {
-    let count = 0, tmp, index1, index2;
+    let count = 0, index1;
 
     // If a key is specified, count only that part of index 0
-    if (key0) (tmp = index0, index0 = {})[key0] = tmp[key0];
-    for (const value0 in index0) {
-      if (index1 = index0[value0]) {
-        // If a key is specified, count only that part of index 1
-        if (key1) (tmp = index1, index1 = {})[key1] = tmp[key1];
-        for (const value1 in index1) {
-          if (index2 = index1[value1]) {
-            // If a key is specified, count the quad if it exists
-            if (key2) (key2 in index2) && count++;
-            // Otherwise, count all quads
-            else count += Object.keys(index2).length;
-          }
-        }
-      }
+    if (key0) {
+      if (index1 = index0[key0])
+        count = this._countInSubIndex(index1, key1, key2);
+    }
+    else {
+      for (const value0 in index0)
+        count += this._countInSubIndex(index0[value0], key1, key2);
     }
     return count;
+  }
+
+  // ### `_countInSubIndex` counts matching quads in a two-layered index
+  _countInSubIndex(index1, key1, key2) {
+    let count = 0, index2;
+
+    // If a key is specified, count only that part of index 1
+    if (key1) {
+      if (index2 = index1[key1])
+        count = this._countInLeafIndex(index2, key2);
+    }
+    else {
+      for (const value1 in index1)
+        count += this._countInLeafIndex(index1[value1], key2);
+    }
+    return count;
+  }
+
+  // ### `_countInLeafIndex` counts matching quads in a one-layered index
+  _countInLeafIndex(index2, key2) {
+    // If a key is specified, count the quad if it exists;
+    // otherwise, count all quads
+    return key2 ? (key2 in index2 ? 1 : 0) : Object.keys(index2).length;
   }
 
   // ### `_getGraphs` returns an array with the given graph,
@@ -335,7 +363,7 @@ export default class N3Store {
     return id => {
       if (!(id in uniqueIds)) {
         uniqueIds[id] = true;
-        callback(this._termFromId(this._entities[id], this._factory));
+        callback(this._termFromNumericId(id));
       }
     };
   }
@@ -747,7 +775,7 @@ export default class N3Store {
       this.some(quad => {
         callback(quad.graph);
         return true; // Halt iteration of some()
-      }, subject, predicate, object, this._termFromId(this._entities[graph]));
+      }, subject, predicate, object, this._termFromNumericId(graph));
     }
   }
 

--- a/test/N3Store-test.js
+++ b/test/N3Store-test.js
@@ -2531,6 +2531,19 @@ describe('EntityIndex', () => {
       o5: 8,
     });
   });
+
+  it('should return terms equal to freshly created terms on repeated reads', () => {
+    const store = new Store([
+      new Quad(new NamedNode('s1'), new NamedNode('p1'), new NamedNode('o1')),
+    ], { entityIndex });
+    const first = store.getQuads(null, null, null, null);
+    expect(first).toEqual([new Quad(new NamedNode('s1'), new NamedNode('p1'), new NamedNode('o1'))]);
+
+    store.addQuad(new NamedNode('s1'), new NamedNode('p1'), new NamedNode('o2'));
+    const second = store.getQuads(null, null, new NamedNode('o1'), null);
+    expect(second).toEqual([new Quad(new NamedNode('s1'), new NamedNode('p1'), new NamedNode('o1'))]);
+    expect(second[0].equals(first[0])).toBe(true);
+  });
 });
 
 function alwaysTrue()  { return true;  }


### PR DESCRIPTION
Removes per-call allocations from the `N3Store` index read hot paths. A single commit on `main`, touching only `src/N3Store.js`; behaviour-preserving (full suite passes unchanged at 100% coverage).

**What it does**

- `N3EntityIndex._termFromNumericId` + `_termCache`: memoizes the materialized term per numeric entity id. Entities are never removed from `_ids`/`_entities`, so cached terms cannot go stale. Repeated reads reuse one term instance instead of re-materializing per result; memory cost is one term per distinct entity actually read. This is safe under the RDF/JS contract — terms are immutable (the data-model spec requires it, with equivalence by `equals()` not identity), and the read path already shares instances today (the `DefaultGraph` singleton; the graph/outer terms within a single `_findInIndex` call).
- `_findInIndex` / `_countInIndex`: stops allocating a throwaway single-key object (`{ [key]: ... }` + `for`-`in`) at every bound index level on every call, iterating the bound level directly; `_countInIndex` is split into monomorphic per-level helpers.

**Why**: CPU profiles of read-heavy downstream workloads (Comunica SPARQL over an in-memory store, per-binding property lookups on a 38k-quad graph, CSS parse/serialize round-trips) showed `_findInIndex` as the dominant read self-time site, much of it term re-materialization and the garbage it produces.

**Measured** — `node perf/N3Store-perf.js 128`, this branch vs its merge base, medians of 5 interleaved runs per side, Node v25.1.0, Apple M1:

| scenario | main | this PR | speedup |
|---|---|---|---|
| fully-bound getQuads (0 variables) | 2.80 s | 1.19 s | 2.35x |
| 1-variable finds | 677 ms | 552 ms | 1.23x |
| 2-variable finds | 639 ms | 553 ms | 1.16x |
| all-bound quad finds | 463 ms | 399 ms | 1.16x |
| single-match by one term (×1M) | 1.09 s | 0.84 s | ~1.3x |
| single-match by two/three terms (×1M) | 1.21 s | 0.82 s | ~1.5x |
| full scan (all quads) | 520 ms | 484 ms | 1.07x |
| adds / RSS | — | — | parity |

Minor-GC count over one full perf-script run drops from 658 to 442 scavenges (`--trace-gc`); major GC unchanged.

**Relationship to #635**: an earlier version was stacked on #635, so its diff also showed #635's commits (the cross-index set-ops, the component-id triple-term representation, `perf/N3StoreSetOps-perf.js`), and its numbers were measured against that stack. It has been de-stacked and re-measured: the diff is now exactly the read-path change above, all numbers are against plain `main`. The two changes are independent but compound — under #635's component-id triple-term representation term materialization becomes a recursive rebuild, which the memoization here avoids on repeated reads. The design questions raised on the old diff (WeakMap for the shared index, RDF 1.2 native-indexing overlap) concern #635's content and are best discussed there.
