### PR TITLE
docs: deprecate direct term construction in favor of the data factory

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,16 @@ console.log(myQuad.object.datatype.value); // http://www.w3.org/1999/02/22-rdf-s
 console.log(myQuad.object.language);       // en
 ```
 
+Always create terms through a data factory such as `N3.DataFactory`,
+and not by instantiating the term classes directly:
+direct construction is deprecated,
+because the factory functions are where term validation can be applied.
+In line with the [RDF/JS specification](http://rdf.js.org/data-model-spec/),
+N3.js assumes that the value of any RDF/JS term it receives —
+whether from its own factory or from another implementation —
+was already validated when the term was created,
+and does not re-validate terms.
+
 In the rest of this document, we will treat “triples” and “quads” equally:
 we assume that a quad is simply a triple in a named or default graph.
 

--- a/src/N3DataFactory.js
+++ b/src/N3DataFactory.js
@@ -65,6 +65,16 @@ export class Term {
 
 // ## NamedNode constructor
 export class NamedNode extends Term {
+  // ### Creates a named node
+  /**
+   * @deprecated Create named nodes through a data factory instead
+   * (`DataFactory.namedNode(iri)`), so that term validation can be applied;
+   * the constructor assumes an already-validated IRI.
+   */
+  constructor(iri) {
+    super(iri);
+  }
+
   // ### The term type of this term
   get termType() {
     return 'NamedNode';
@@ -73,6 +83,17 @@ export class NamedNode extends Term {
 
 // ## Literal constructor
 export class Literal extends Term {
+  // ### Creates a literal
+  /**
+   * @deprecated Create literals through a data factory instead
+   * (`DataFactory.literal(value, languageOrDatatype)`), so that term
+   * validation can be applied; the constructor takes the internal
+   * id representation and assumes it is already valid.
+   */
+  constructor(id) {
+    super(id);
+  }
+
   // ### The term type of this term
   get termType() {
     return 'Literal';
@@ -146,6 +167,12 @@ export class Literal extends Term {
 
 // ## BlankNode constructor
 export class BlankNode extends Term {
+  // ### Creates a blank node
+  /**
+   * @deprecated Create blank nodes through a data factory instead
+   * (`DataFactory.blankNode(name)`), so that term validation can be applied;
+   * the constructor assumes an already-validated name.
+   */
   constructor(name) {
     super(`_:${name}`);
   }
@@ -162,6 +189,12 @@ export class BlankNode extends Term {
 }
 
 export class Variable extends Term {
+  // ### Creates a variable
+  /**
+   * @deprecated Create variables through a data factory instead
+   * (`DataFactory.variable(name)`), so that term validation can be applied;
+   * the constructor assumes an already-validated name.
+   */
   constructor(name) {
     super(`?${name}`);
   }
@@ -179,6 +212,11 @@ export class Variable extends Term {
 
 // ## DefaultGraph constructor
 export class DefaultGraph extends Term {
+  // ### Creates the default graph
+  /**
+   * @deprecated Obtain the default graph through a data factory instead
+   * (`DataFactory.defaultGraph()`).
+   */
   constructor() {
     super('');
     return DEFAULTGRAPH || this;
@@ -299,6 +337,12 @@ export function termToId(term, nested) {
 
 // ## Quad constructor
 export class Quad extends Term {
+  // ### Creates a quad
+  /**
+   * @deprecated Create quads through a data factory instead
+   * (`DataFactory.quad(subject, predicate, object, graph)`), so that term
+   * validation can be applied; the constructor assumes already-validated terms.
+   */
   constructor(subject, predicate, object, graph) {
     super('');
     this._subject   = subject;


### PR DESCRIPTION
Implements the maintainers' decision to deprecate the term class constructors and direct users to the data factory, so that term validation is applied at the factory boundary rather than in the constructors.

- Adds `@deprecated` JSDoc to the constructors of the exported `NamedNode`, `Literal`, `BlankNode`, `Variable`, `DefaultGraph` and `Quad` classes, each pointing to the corresponding `DataFactory` function. The tags sit on the *constructors*, not the classes, so editors flag `new NamedNode(...)` while `instanceof` checks and type references stay clean — and `import-x/no-deprecated` (enforced by this repo's lint) does not flag the library's own internal uses, which deliberately keep the raw constructors on the parsing hot path.
- `NamedNode` and `Literal` gain explicit, behavior-identical constructors to carry the tag.
- Documents the accompanying contract in the README (*Creating triples/quads*): N3.js assumes the value of any RDF/JS term it receives — from its own factory or another implementation — was already validated when the term was created, and does not re-validate terms.

Deprecation only: nothing is removed, no runtime warning is emitted (to keep output clean for the many downstream users of these classes), and no validation is added to the constructors — constructor-time validation was explicitly ruled out for performance reasons. Complements the validation docs in #622 and the opt-in parser validation of #634.

> **Review timing:** This draft was prepared with Claude; I (@jeswr) will personally review it before it progresses. I'm currently batching a lot of work in flight, so expect active review Wednesday–Friday (8–10 July).
