### PR TITLE
fix(writer): support serialisation of variables in the writer

### DIFF
--- a/src/N3Writer.js
+++ b/src/N3Writer.js
@@ -151,7 +151,8 @@ export default class N3Writer {
       // If it is a list head, pretty-print it
       if (this._lists && (entity.value in this._lists))
         entity = this.list(this._lists[entity.value]);
-      return 'id' in entity ? entity.id : `_:${entity.value}`;
+      return entity.termType === 'Variable' ? `?${entity.value}` :
+             'id' in entity ? entity.id : `_:${entity.value}`;
     }
     let iri = entity.value;
     // Use relative IRIs if requested and possible

--- a/test/N3Writer-test.js
+++ b/test/N3Writer-test.js
@@ -58,6 +58,13 @@ describe('Writer', () => {
       expect(writer.quadsToString(triples)).toBe('<a> <b> <c> .\n<d> <e> <f> .\n');
     });
 
+    it('should serialize a variable from another library through its term type', () => {
+      const writer = new Writer();
+      const variable = { termType: 'Variable', value: 'v' };
+      expect(
+        writer.quadToString(variable, new NamedNode('b'), variable),
+      ).toBe('?v <b> ?v .\n');
+    });
 
     it('should serialize 0 triples', shouldSerialize(''));
 


### PR DESCRIPTION
Split out of #664 per review (the `Variable` case is a separate change from the blank-node fix).

`N3Writer._encodeIriOrBlank` serializes a non-`NamedNode` term by probing for an `id` property, so a `Variable` term from another RDF/JS implementation — which has no N3.js-internal `id`, or uses `id` for its own purposes — produces corrupt output (`_:v`, or whatever the foreign `id` holds) instead of `?v`. This dispatches `Variable` on `termType`, so any spec-compliant RDF/JS variable serializes as `?value`, exactly matching the existing output for this library's own variable terms (whose internal `id` is `?value`). All other terms are unchanged.

Independent of #664 (both changes are strictly additive over the existing probe) — whichever lands second is a trivial one-line rebase onto the shared `termType` chain.

Tests: one new case in `test/N3Writer-test.js`; full suite green at 100% coverage.
