### PR TITLE
fix: return a null-prototype map from extractLists

### DIFF
--- a/src/N3Store.js
+++ b/src/N3Store.js
@@ -759,7 +759,9 @@ export default class N3Store {
   // ### `extractLists` finds and removes all list triples
   // and returns the items per list.
   extractLists({ remove = false, ignoreErrors = false } = {}) {
-    const lists = {}; // has scalar keys so could be a simple Object
+    // Keys are the list heads' term values, so a null-prototype map keeps
+    // them from colliding with inherited Object members such as `toString`
+    const lists = Object.create(null);
     const onError = ignoreErrors ? (() => true) :
                   ((node, message) => { throw new Error(`${node.value} ${message}`); });
 

--- a/test/N3Store-test.js
+++ b/test/N3Store-test.js
@@ -1846,6 +1846,27 @@ describe('Store', () => {
     });
   });
 
+  describe('A Store containing an rdf:Collection whose head value is an inherited Object member', () => {
+    const store = new Store();
+    expect(
+      store.addQuad(new NamedNode('constructor'), new NamedNode(namespaces.rdf.first), new NamedNode('element1')),
+    ).toBe(true);
+    expect(
+      store.addQuad(new NamedNode('constructor'), new NamedNode(namespaces.rdf.rest), new NamedNode(namespaces.rdf.nil)),
+    ).toBe(true);
+    expect(
+      store.addQuad(new NamedNode('s'), new NamedNode('p'), new NamedNode('constructor')),
+    ).toBe(true);
+
+    it('extractLists returns a null-prototype map without inherited members', () => {
+      const lists = store.extractLists();
+      expect(Object.getPrototypeOf(lists)).toBe(null);
+      expect(Object.keys(lists)).toEqual(['constructor']);
+      expect(lists.constructor.map(member => member.value)).toEqual(['element1']);
+      expect('toString' in lists).toBe(false);
+    });
+  });
+
   describe('A Store containing an rdf:Collection with multiple rdf:first arcs on head', () => {
     const store = new Store();
     const listElements = addList(store, store.createBlankNode(), store.createBlankNode());


### PR DESCRIPTION
Split out of #654 per review; that PR now carries only the `termFromId` JSON-parse guard.

`extractLists()` returns an object keyed by each list head's term value (`lists[head.value] = items`), so data-derived IRIs and blank-node labels become property keys of a plain `{}`. That lets list-head values collide with inherited `Object.prototype` members: `'toString' in lists` is true even when no such list exists, `lists.constructor` for an absent key returns a function instead of `undefined`, and a head value of `__proto__` assigns through the prototype setter — silently dropping that list and polluting the returned object's prototype (CWE-1321).

This switches the map to `Object.create(null)` so the only observable keys are actual list heads. Note the returned object consequently no longer inherits `Object.prototype` methods: callers doing `lists.hasOwnProperty(x)` directly should use `Object.hasOwn(lists, x)` / `Object.keys(lists)`; property reads and enumeration are unaffected.

Tests: a new `describe` block in `test/N3Store-test.js` exercising a list whose head value is `constructor`. Full suite green at 100% coverage.
