### PR TITLE
fix: parse triple terms nested inside lists

### DIFF
--- a/src/N3Parser.js
+++ b/src/N3Parser.js
@@ -508,6 +508,11 @@ export default class N3Parser {
       this._saveContext('formula', this._graph, this._subject, this._predicate,
                         this._graph = this._factory.blankNode());
       return this._readSubject;
+    case '<<(':
+      this._saveContext('<<(', this._graph, null, null, null);
+      this._graph = null;
+      next = this._readSubject;
+      break;
     case '<<':
       this._saveContext('<<', this._graph, null, null, null);
       this._graph = null;
@@ -522,8 +527,8 @@ export default class N3Parser {
     if (list === null)
       this._subject = list = this._factory.blankNode();
 
-    // When reading a reified triple, store the list as subject in the stack, as this will be overridden when reading the triple.
-    if (token.type === '<<')
+    // When reading a reified triple or triple term, store the list as subject in the stack, as this will be overridden when reading the triple.
+    if (token.type === '<<' || token.type === '<<(')
       stack[stack.length - 1].subject = this._subject;
 
     // Is this the first element of the list?
@@ -972,6 +977,12 @@ export default class N3Parser {
         this._graph || this.DEFAULTGRAPH);
     this._restoreContext('<<(', token);
 
+    // If we're in a list, continue processing that list
+    const stack = this._contextStack, parent = stack.length && stack[stack.length - 1];
+    if (parent && parent.type === 'list') {
+      this._emit(this._subject, this.RDF_FIRST, quad, this._graph);
+      return this._getContextEndReader();
+    }
     // If the triple was the subject, continue by reading the predicate.
     if (this._subject === null) {
       this._subject = quad;

--- a/test/N3Parser-test.js
+++ b/test/N3Parser-test.js
@@ -811,6 +811,22 @@ describe('Parser', () => {
             ['_:b3', reifies, ['a2', 'b2', 'c2']]),
     );
 
+    it(
+        'should parse statements with a subject list containing a triple term',
+        shouldParse('(<<(<a1> <b1> <c1>)>>) <a> <b>.',
+            ['_:b0', 'a', 'b'],
+            ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', ['a1', 'b1', 'c1']],
+            ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil']),
+    );
+
+    it(
+        'should parse statements with an object list containing a triple term',
+        shouldParse('<a> <b> (<<(<a1> <b1> <c1>)>>).',
+            ['a', 'b', '_:b0'],
+            ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', ['a1', 'b1', 'c1']],
+            ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil']),
+    );
+
     it('should not parse an invalid list', shouldNotParse('<a> <b> (]).',
                    'Expected entity but got ] on line 1.'));
 


### PR DESCRIPTION
The list-item reader did not handle the <<( token, so a triple term appearing as a list element (e.g. as subject/object) failed to parse.