### PR TITLE
fix: avoid reusing a stale reified-triple cache in annotations

### DIFF
--- a/src/N3Parser.js
+++ b/src/N3Parser.js
@@ -741,12 +741,19 @@ export default class N3Parser {
       break;
     // ~ is allowed in the annotation syntax
     case '~':
+      // Only invalidate the cache for a genuinely new triple - chained annotation blocks on the
+      // same triple (subject already null from a preceding annotation) must keep reusing it.
+      if (subject !== null)
+        this._tripleTerm = null;
       next = this._readReifierInAnnotation;
       startingAnnotation = true;
       break;
     // {| means that the current triple is annotated with predicate-object pairs.
     case '{|':
       // Continue using the last triple as reified triple subject for the predicate-object pairs.
+      // Same staleness rule as ~ above.
+      if (subject !== null)
+        this._tripleTerm = null;
       this._subject = this._readTripleTerm();
       this._validAnnotation = false;
       startingAnnotation = true;

--- a/test/N3Parser-test.js
+++ b/test/N3Parser-test.js
@@ -1579,6 +1579,40 @@ describe('Parser', () => {
     );
 
     it(
+        'should parse an annotation on a triple with a nested reified triple as subject',
+        shouldParse('<<<a> <b> <c>>> <d> <e> {| <f> <g> |}.',
+            ['_:b0', reifies, ['a', 'b', 'c']],
+            ['_:b1', reifies, ['_:b0', 'd', 'e']],
+            ['_:b0', 'd', 'e'],
+            ['_:b1', 'f', 'g']),
+    );
+
+    it(
+        'should parse an annotation on a triple with a nested reified triple as object',
+        shouldParse('<d> <e> <<<a> <b> <c>>> {| <f> <g> |}.',
+            ['_:b0', reifies, ['a', 'b', 'c']],
+            ['_:b1', reifies, ['d', 'e', '_:b0']],
+            ['d', 'e', '_:b0'],
+            ['_:b1', 'f', 'g']),
+    );
+
+    it(
+        'should parse a bare annotation reifier on a triple with a nested reified triple as subject',
+        shouldParse('<<<a> <b> <c>>> <d> <e> ~ .',
+            ['_:b0', reifies, ['a', 'b', 'c']],
+            ['_:b0', 'd', 'e'],
+            ['_:b1', reifies, ['_:b0', 'd', 'e']]),
+    );
+
+    it(
+        'should parse a bare annotation reifier on a triple with a nested reified triple as object',
+        shouldParse('<d> <e> <<<a> <b> <c>>> ~ .',
+            ['_:b0', reifies, ['a', 'b', 'c']],
+            ['d', 'e', '_:b0'],
+            ['_:b1', reifies, ['d', 'e', '_:b0']]),
+    );
+
+    it(
       'should not parse nested triple terms that are partially closed',
       shouldNotParse('<d> <e> <<(<<(<a> <b> <c>)>> <f> <g>.',
         'Disallowed triple term as subject on line 1.',


### PR DESCRIPTION
_tripleTerm memoizes the triple being reified by {|...|} and bare ~ annotations, but was only cleared on . or when closing a nested <<...>> triple term. When a statement's subject is itself such a nested triple term, the cache stays populated with the inner triple, so a trailing annotation on the outer statement wrongly reified the inner one. Reset the cache whenever a genuinely new triple was just completed, while still reusing it across chained annotation blocks on the same triple.