### PR TITLE
fix: emit rdf:reifies into the enclosing graph

### DIFF
--- a/src/N3Parser.js
+++ b/src/N3Parser.js
@@ -1092,7 +1092,7 @@ export default class N3Parser {
     const reifier = this._reifier || this._factory.blankNode();
     this._reifier = null;
     this._tripleTerm = this._tripleTerm || this._factory.quad(this._subject, this._predicate, this._object);
-    this._emit(reifier, this.RDF_REIFIES, this._tripleTerm, parentGraph || this.DEFAULTGRAPH);
+    this._emit(reifier, this.RDF_REIFIES, this._tripleTerm, parentGraph || this._graph || this.DEFAULTGRAPH);
     return reifier;
   }
 

--- a/test/N3Parser-test.js
+++ b/test/N3Parser-test.js
@@ -1832,7 +1832,22 @@ describe('Parser', () => {
         shouldParse('<G> { <a> <b> <c> {| <b> <c> |}. }',
             ['a', 'b', 'c', 'G'],
             ['_:b0', 'b', 'c', 'G'],
-            ['_:b0', reifies, ['a', 'b', 'c']]),
+            ['_:b0', reifies, ['a', 'b', 'c'], 'G']),
+    );
+
+    it(
+        'should parse a reified triple in a graph using annotation syntax with an explicit reifier',
+        shouldParse('<G> { <a> <b> <c> ~ <r> {| <b> <c> |}. }',
+            ['a', 'b', 'c', 'G'],
+            ['r', reifies, ['a', 'b', 'c'], 'G'],
+            ['r', 'b', 'c', 'G']),
+    );
+
+    it(
+        'should parse a reified triple in a graph using << >> syntax',
+        shouldParse('<G> { <<<a> <b> <c>>> <p> <o> . }',
+            ['_:b0', reifies, ['a', 'b', 'c'], 'G'],
+            ['_:b0', 'p', 'o', 'G']),
     );
 
     it(


### PR DESCRIPTION
Fixes #676.

In TriG, the `rdf:reifies` quad produced by annotation syntax (`{| |}`) or a reifier (`~`) was emitted into the default graph, while the triple it reifies and the annotation body landed in the enclosing named graph.

`_readTripleTerm` takes the graph from `_contextStack`, but a TriG graph block is not a context — `_readGraph` only assigns `this._graph`. Annotations and reifiers are reached with an empty stack, so `parentGraph` was `undefined` and the emit fell back to `DEFAULTGRAPH`. Reified triples written as `<< >>` were unaffected, because `_readReifiedTripleTail` calls `_readTripleTerm()` *before* `_restoreContext('<<')`, when the graph is only on the stack.

Falling back to `this._graph` before `DEFAULTGRAPH` keeps the `<< >>` path untouched — its `parentGraph` is still found first, and `this._graph` is `null` there in any case.

One existing expectation encoded the asymmetry and is updated:

```js
shouldParse('<G> { <a> <b> <c> {| <b> <c> |}. }',
    ['a', 'b', 'c', 'G'],
    ['_:b0', 'b', 'c', 'G'],
    ['_:b0', reifies, ['a', 'b', 'c']]),   // <- no graph
```

Tests added for the annotation, reifier and `<< >>` forms in a named graph. Full suite passes at 100 % coverage.
