### PR TITLE
fix: assert the triple term of a reifier with no annotation block

### DIFF
--- a/src/N3Parser.js
+++ b/src/N3Parser.js
@@ -1078,12 +1078,40 @@ export default class N3Parser {
     // If next token is a reifier, read it as such.
     if (token.type === 'IRI' || token.type === 'typeIRI' || token.type === 'type' || token.type === 'prefixed' || token.type === 'blank' || token.type === 'var') {
       this._reifier = this._readEntity(token);
-      return this._readPunctuation;
+      return this._readAnnotationBlockOrPunctuation;
     }
     // Otherwise, emit and assert triple term.
     this._readTripleTerm();
     this._subject = null;
     return this._readPunctuation(token);
+  }
+
+  // ### `_readAnnotationBlockOrPunctuation` reads what follows an explicit reifier:
+  // either an annotation block, which reuses the reifier as its subject,
+  // or punctuation, in which case the reifier stands alone and its triple
+  // term still needs to be asserted here.
+  _readAnnotationBlockOrPunctuation(token) {
+    if (token.type === '{|')
+      return this._readPunctuation(token);
+
+    this._readTripleTerm();
+    this._annotation = false;
+    // A shared subject or predicate goes on to reify a *different* triple,
+    // so the term just asserted must not be reused for the next one.
+    this._tripleTerm = null;
+    // The annotated triple was already emitted when the tilde was read,
+    // so continue without letting `_readPunctuation` emit it a second time.
+    switch (token.type) {
+    // The subject stays shared with the next predicate-object pair
+    case ';':
+      return this._readPredicate;
+    // The subject and predicate stay shared with the next object
+    case ',':
+      return this._readObject;
+    default:
+      this._subject = null;
+      return this._readPunctuation(token);
+    }
   }
 
   _readTripleTerm() {

--- a/src/N3Parser.js
+++ b/src/N3Parser.js
@@ -1083,7 +1083,7 @@ export default class N3Parser {
     // Otherwise, emit and assert triple term.
     this._readTripleTerm();
     this._subject = null;
-    return this._readPunctuation(token);
+    return this._getContextEndReader().call(this, token);
   }
 
   // ### `_readAnnotationBlockOrPunctuation` reads what follows an explicit reifier:
@@ -1110,7 +1110,9 @@ export default class N3Parser {
       return this._readObject;
     default:
       this._subject = null;
-      return this._readPunctuation(token);
+      // Resume in the enclosing context, which is top-level punctuation
+      // unless the reified triple sits inside a blank node property list
+      return this._getContextEndReader().call(this, token);
     }
   }
 

--- a/test/N3Parser-test.js
+++ b/test/N3Parser-test.js
@@ -1752,6 +1752,45 @@ describe('Parser', () => {
     );
 
     it(
+        'should parse a reifier that is not followed by an annotation block',
+        shouldParse('<a> <b> <c> ~ <iri>.',
+            ['a', 'b', 'c'],
+            ['iri', reifies, ['a', 'b', 'c']]),
+    );
+
+    it(
+        'should parse a blank node reifier that is not followed by an annotation block',
+        shouldParse('<a> <b> <c> ~ _:r.',
+            ['a', 'b', 'c'],
+            ['_:b0_r', reifies, ['a', 'b', 'c']]),
+    );
+
+    it(
+        'should parse a lone reifier followed by a shared subject',
+        shouldParse('<a> <b> <c> ~ <iri>; <b2> <c2>.',
+            ['a', 'b', 'c'],
+            ['iri', reifies, ['a', 'b', 'c']],
+            ['a', 'b2', 'c2']),
+    );
+
+    it(
+        'should parse a lone reifier followed by a shared subject and predicate',
+        shouldParse('<a> <b> <c> ~ <iri>, <c2>.',
+            ['a', 'b', 'c'],
+            ['iri', reifies, ['a', 'b', 'c']],
+            ['a', 'b', 'c2']),
+    );
+
+    it(
+        'should reify the correct triple when lone reifiers follow a shared subject',
+        shouldParse('<a> <b> <c> ~ <iri1>; <b2> <c2> ~ <iri2>.',
+            ['a', 'b', 'c'],
+            ['iri1', reifies, ['a', 'b', 'c']],
+            ['a', 'b2', 'c2'],
+            ['iri2', reifies, ['a', 'b2', 'c2']]),
+    );
+
+    it(
         'should parse two reified triples using annotation syntax with one predicate-object',
         shouldParse('<a> <b> <c> {| <b> <c> |}. <a2> <b2> <c2> {| <b2> <c2> |}.',
             ['a', 'b', 'c'],


### PR DESCRIPTION
`<a> <b> <c> ~ <r> .` emitted the asserted triple **twice** and never emitted `<r> rdf:reifies <<( <a> <b> <c> )>>`.

`_readReifierInAnnotation` defers `_readTripleTerm()` when an explicit reifier is present, so a following `{|` can adopt the reifier as its subject. Nothing flushed that pending reifier when no annotation block followed, and because the subject was still set, the trailing punctuation emitted the base triple a second time. (An *anonymous* reifier, `~ .`, was already correct — it asserts immediately.)

This reads the token after the reifier: `{|` behaves exactly as before, anything else asserts the triple term and continues without re-emitting the base triple, which was already emitted when `~` was read. A shared subject (`;`) or subject and predicate (`,`) go on to reify a *different* triple, so the asserted term is cleared rather than reused — without that, `<a> <b> <c> ~ <r1>; <b2> <c2> ~ <r2>.` had `<r2>` reifying `<a> <b> <c>`.

The standalone path resumes through `_getContextEndReader()` rather than `_readPunctuation`. Today that always resolves to `_readPunctuation`, since a reifier is only reachable outside a blank node property list; it lets the same code serve a reified triple inside `[ ]` once #681 allows it.

### One behaviour change to be aware of

A reifier at the end of an annotation block, `<a> <b> <c> {| <d> <e> ~ <r> |} .`, currently parses while silently discarding `<r>`. With this patch it raises `Unexpected annotation syntax closing` instead.

Emitting there rather than erroring would produce `<r> rdf:reifies <<( <a> <b> <c> )>>` — the outer triple cached in `_tripleTerm`, not `_:b0 <d> <e>` — so it would trade a silent omission for a silently wrong quad. That construct needs the nested-annotation state fix described in #678, so I chose to fail loudly. Happy to drop the behaviour change if you would rather keep the silent form until #678 is addressed.

Tests added for the lone reifier (IRI and blank node), for `;` and `,` continuations, and for the shared-subject case that exposed the stale triple term. Full suite passes at 100 % coverage.
