### PR TITLE
fix: allow annotation syntax inside blank node property lists

### DIFF
--- a/src/N3Parser.js
+++ b/src/N3Parser.js
@@ -760,7 +760,7 @@ export default class N3Parser {
         return this._error('Annotation block can not be empty', token);
       this._subject = null;
       this._annotation = false;
-      next = this._readPunctuation;
+      next = this._getContextEndReader();
       break;
     default:
       // An entity means this is a quad (only allowed if not already inside a graph)
@@ -796,9 +796,21 @@ export default class N3Parser {
     case ',':
       next = this._readObject;
       break;
+    // Annotation syntax applies to the quad just read, exactly as it does
+    // outside of a blank node property list.  `|}` arrives here too, because
+    // the objects inside the annotation block are themselves read within the
+    // enclosing blank node context.
+    case '~':
+    case '{|':
+    case '|}':
+      return this._readPunctuation(token);
     default:
       return this._error(`Expected punctuation to follow "${this._object.id}"`, token);
     }
+    // An annotation block consumes the subject it annotates, so there is
+    // nothing left to share with a following predicate-object pair
+    if (this._subject === null)
+      return this._error('Expected ] to follow annotation', token);
     // A quad has been completed now, so return it
     this._emit(this._subject, this._predicate, this._object, this._graph);
     return next;

--- a/test/N3Parser-test.js
+++ b/test/N3Parser-test.js
@@ -1744,6 +1744,49 @@ describe('Parser', () => {
     );
 
     it(
+        'should parse an annotation inside a blank node property list',
+        shouldParse('<s> <p> [ <b> <c> {| <d> <e> |} ].',
+            ['_:b1', reifies, ['_:b0', 'b', 'c']],
+            ['_:b0', 'b', 'c'],
+            ['_:b1', 'd', 'e'],
+            ['s', 'p', '_:b0']),
+    );
+
+    it(
+        'should parse an annotation inside a blank node property list in subject position',
+        shouldParse('[ <b> <c> {| <d> <e> |} ] <p> <o>.',
+            ['_:b1', reifies, ['_:b0', 'b', 'c']],
+            ['_:b0', 'b', 'c'],
+            ['_:b1', 'd', 'e'],
+            ['_:b0', 'p', 'o']),
+    );
+
+    it(
+        'should parse an annotation inside a nested blank node property list',
+        shouldParse('<s> <p> [ <b> [ <c> <d> {| <e> <f> |} ] ].',
+            ['_:b2', reifies, ['_:b1', 'c', 'd']],
+            ['_:b1', 'c', 'd'],
+            ['_:b2', 'e', 'f'],
+            ['_:b0', 'b', '_:b1'],
+            ['s', 'p', '_:b0']),
+    );
+
+    it(
+        'should parse an annotation with a reifier inside a blank node property list',
+        shouldParse('<s> <p> [ <b> <c> ~ <r> {| <d> <e> |} ].',
+            ['_:b0', 'b', 'c'],
+            ['r', reifies, ['_:b0', 'b', 'c']],
+            ['r', 'd', 'e'],
+            ['s', 'p', '_:b0']),
+    );
+
+    it(
+        'should not parse a predicate-object pair after an annotation inside a blank node property list',
+        shouldNotParse('<s> <p> [ <b> <c> {| <d> <e> |} ; <f> <g> ].',
+            'Expected ] to follow annotation on line 1.'),
+    );
+
+    it(
       'should parse a reified triple using annotation syntax with reifier and one predicate-object',
       shouldParse('<a> <b> <c> ~ <iri> {| <b> <c> |}.',
           ['a', 'b', 'c'],


### PR DESCRIPTION
Annotations were not accepted inside blank node property lists.

`<s> <p> [ <b> <c> {| <d> <e> |} ].` was rejected with `Expected punctuation to follow "http://ex/c"`, even though `objectList ::= object annotation? …` allows an annotation after every object and `blankNodePropertyList ::= '[' predicateObjectList ']'` contains a `predicateObjectList`. The same syntax parses at the top level and after a collection.

Two routing gaps caused it:

- `_readBlankNodePunctuation` only knew `;` and `,`.
- Once inside the property list, the objects of the annotation block are themselves read in the enclosing blank node context, so `|}` reached `_readBlankNodePunctuation` too.

Both are handled by delegating those tokens to `_readPunctuation`, which already implements them, and by letting `|}` resume through `_getContextEndReader()` so it returns to the blank node tail instead of always to top-level punctuation. Outside a blank node the context stack is empty there and `_getContextEndReader()` yields `_readPunctuation`, so top-level parsing is byte-for-byte unchanged.

A predicate-object pair *after* an annotation block — `[ <b> <c> {| <d> <e> |} ; <f> <g> ]` — is still not supported, because the block consumes the subject it annotates (#677). Before this patch that input dereferenced a null subject and threw a `TypeError`; it now reports a syntax error. Once #677 is fixed the guard can go.

Tests added for an annotation in object and subject position, nested property lists, a reifier plus annotation block inside `[ ]`, and the unsupported continuation. Full suite passes at 100 % coverage.
