### PR TITLE
feat(parser): add opt-in implicit N3 empty prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,16 @@ This is done by passing a `baseIRI` argument upon creation:
 const parser = new N3.Parser({ baseIRI: 'http://example.org/' });
 ```
 
+In N3 mode, `implicitEmptyPrefix` can bind an undeclared empty prefix to the
+document IRI with a `#` fragment:
+```JavaScript
+const parser = new N3.Parser({
+  format: 'text/n3',
+  baseIRI: 'http://example.org/document',
+  implicitEmptyPrefix: true,
+});
+```
+
 By default, `N3.Parser` will prefix blank node labels with a `b{digit}_` prefix.
 This is done to prevent collisions of unrelated blank nodes having identical
 labels. The `blankNodePrefix` constructor argument can be used to modify the

--- a/spec/parser.js
+++ b/spec/parser.js
@@ -5,6 +5,10 @@ const { StreamParser } = require('..');
 module.exports = {
   parse: function (data, baseIRI, options) {
     return require('arrayify-stream').arrayifyStream(require('streamify-string')(data).pipe(
-      new StreamParser(Object.assign({ baseIRI: baseIRI, parseUnsupportedVersions: true }, options))));
+      new StreamParser(Object.assign({
+        baseIRI: baseIRI,
+        implicitEmptyPrefix: true,
+        parseUnsupportedVersions: true,
+      }, options))));
   },
 };

--- a/src/N3Parser.js
+++ b/src/N3Parser.js
@@ -1439,6 +1439,9 @@ export default class N3Parser {
     this._prefixes = Object.create(null);
     this._prefixes._ = this._blankNodePrefix ? this._blankNodePrefix.substr(2)
                                              : `b${blankNodePrefix++}_`;
+    // N3 historically binds the empty prefix to the document's local namespace
+    if (this._n3Mode && this._base)
+      this._prefixes[''] = this._resolveIRI('#');
     this._prefixCallback = onPrefix || noop;
     this._versionCallback = onVersion || noop;
     this._inversePredicate = false;

--- a/src/N3Parser.js
+++ b/src/N3Parser.js
@@ -29,6 +29,8 @@ export default class N3Parser {
     this._supportsQuads = !(isTurtle || isTriG || isNTriples || isN3);
     // Whether the log:isImpliedBy predicate is supported
     this._isImpliedBy = options.isImpliedBy;
+    // Whether an undeclared empty prefix resolves against the document IRI
+    this._implicitEmptyPrefix = !!options.implicitEmptyPrefix;
     // Whether an empty formula is read as the boolean literal true,
     // as in the N3 spec tests (opt-in until the next major version)
     this._emptyFormulaAsTrue = !!options.emptyFormulaAsTrue;
@@ -1439,8 +1441,8 @@ export default class N3Parser {
     this._prefixes = Object.create(null);
     this._prefixes._ = this._blankNodePrefix ? this._blankNodePrefix.substr(2)
                                              : `b${blankNodePrefix++}_`;
-    // N3 historically binds the empty prefix to the document's local namespace
-    if (this._n3Mode && this._base)
+    // Optionally bind the N3 empty prefix to the document's local namespace
+    if (this._n3Mode && this._implicitEmptyPrefix && this._base)
       this._prefixes[''] = this._resolveIRI('#');
     this._prefixCallback = onPrefix || noop;
     this._versionCallback = onVersion || noop;

--- a/test/N3Parser-test.js
+++ b/test/N3Parser-test.js
@@ -2662,29 +2662,40 @@ describe('Parser', () => {
 
   describe('A Parser instance for the N3 format', () => {
     function parser() { return new Parser({ baseIRI: BASE_IRI, format: 'N3' }); }
-    function parserWithFragment() { return new Parser({ baseIRI: 'http://example.com/doc#old', format: 'N3' }); }
+    function implicitEmptyPrefixParser() {
+      return new Parser({ baseIRI: BASE_IRI, format: 'N3', implicitEmptyPrefix: true });
+    }
+    function parserWithFragment() {
+      return new Parser({ baseIRI: 'http://example.com/doc#old', format: 'N3', implicitEmptyPrefix: true });
+    }
     function parserIsImpliedBy() { return new Parser({ baseIRI: BASE_IRI, format: 'N3', isImpliedBy: true }); }
 
     it(
       'should bind the empty prefix to the document local namespace',
-      shouldParse(parser, ':a :b :c .',
+      shouldParse(implicitEmptyPrefixParser, ':a :b :c .',
                   ['http://example.org/#a', 'http://example.org/#b', 'http://example.org/#c']),
     );
 
     it(
       'should let an explicit empty prefix override the implicit binding',
-      shouldParse(parser, '@prefix : <http://example.com/>. :a :b :c .',
+      shouldParse(implicitEmptyPrefixParser, '@prefix : <http://example.com/>. :a :b :c .',
                   ['http://example.com/a', 'http://example.com/b', 'http://example.com/c']),
     );
 
+    // RFC 3986 section 5.2 resolves "#" after removing the base IRI fragment.
     it(
       'should replace a document IRI fragment in the implicit binding',
       shouldParse(parserWithFragment, ':a :b :c .',
                   ['http://example.com/doc#a', 'http://example.com/doc#b', 'http://example.com/doc#c']),
     );
 
+    it(
+      'should require an explicit empty prefix by default',
+      shouldNotParse(parser, ':a :b :c .', 'Undefined prefix ":" on line 1.'),
+    );
+
     it('should require an explicit empty prefix without a document IRI', () => {
-      expect(() => new Parser({ format: 'N3' }).parse(':a :b :c .'))
+      expect(() => new Parser({ format: 'N3', implicitEmptyPrefix: true }).parse(':a :b :c .'))
         .toThrow('Undefined prefix ":" on line 1.');
     });
 

--- a/test/N3Parser-test.js
+++ b/test/N3Parser-test.js
@@ -2662,7 +2662,31 @@ describe('Parser', () => {
 
   describe('A Parser instance for the N3 format', () => {
     function parser() { return new Parser({ baseIRI: BASE_IRI, format: 'N3' }); }
+    function parserWithFragment() { return new Parser({ baseIRI: 'http://example.com/doc#old', format: 'N3' }); }
     function parserIsImpliedBy() { return new Parser({ baseIRI: BASE_IRI, format: 'N3', isImpliedBy: true }); }
+
+    it(
+      'should bind the empty prefix to the document local namespace',
+      shouldParse(parser, ':a :b :c .',
+                  ['http://example.org/#a', 'http://example.org/#b', 'http://example.org/#c']),
+    );
+
+    it(
+      'should let an explicit empty prefix override the implicit binding',
+      shouldParse(parser, '@prefix : <http://example.com/>. :a :b :c .',
+                  ['http://example.com/a', 'http://example.com/b', 'http://example.com/c']),
+    );
+
+    it(
+      'should replace a document IRI fragment in the implicit binding',
+      shouldParse(parserWithFragment, ':a :b :c .',
+                  ['http://example.com/doc#a', 'http://example.com/doc#b', 'http://example.com/doc#c']),
+    );
+
+    it('should require an explicit empty prefix without a document IRI', () => {
+      expect(() => new Parser({ format: 'N3' }).parse(':a :b :c .'))
+        .toThrow('Undefined prefix ":" on line 1.');
+    });
 
     it(
       'should parse a single triple',


### PR DESCRIPTION
Adds an opt-in `implicitEmptyPrefix` parser option for the historical N3 convention where an undeclared `:` prefix means `<#>` relative to the document IRI. The conformance adapter enables the option; normal parser behavior is unchanged in this major version. An explicit `@prefix : ...` still overrides it, and N3 input without a document IRI remains strict.

The binding uses the existing IRI resolver. Resolving `#` replaces a fragment on the supplied document IRI in accordance with RFC 3986 section 5.2: https://www.rfc-editor.org/rfc/rfc3986#section-5.2

This makes 26 additional parser-manifest cases and two additional extended-manifest cases pass in #640. The normative test/spec alignment is being clarified in w3c-cg/N3#235, and changing the option default in the next major release is tracked in #699.

Tests: full Jest suite (6,817 tests, 100% coverage); ESLint; focused W3C manifests.

Closes #687