### PR TITLE
feat(parser): support N3 IRI property lists

### DIFF
--- a/src/N3Lexer.js
+++ b/src/N3Lexer.js
@@ -57,6 +57,7 @@ export default class N3Lexer {
     this._boolean = /^(?:true|false)(?=[.,;!\^\s#()\[\]\{\}"'<>])/;
     this._atKeyword = /^@[a-z]+(?=[\s#<:])/i;
     this._keyword = /^(?:PREFIX|BASE|VERSION|GRAPH)(?=[\s#<])/i;
+    this._n3Id = /^id(?=[\s#<])/;
     this._shortPredicates = /^a(?=[\s#()\[\]\{\}"'<>])/;
     this._newline = /^[ \t]*(?:#[^\n\r]*)?(?:\r\n|\n|\r)[ \t]*/;
     this._comment = /#([^\n\r]*)/;
@@ -314,6 +315,14 @@ export default class N3Lexer {
         // Try to find an abbreviated predicate
         if (match = this._shortPredicates.exec(input))
           type = 'abbreviation', value = 'a';
+        else
+          inconclusive = true;
+        break;
+
+      case 'i':
+        // Try to find the IRI property list identifier
+        if (this._n3Mode && (match = this._n3Id.exec(input)))
+          type = 'id';
         else
           inconclusive = true;
         break;

--- a/src/N3Parser.js
+++ b/src/N3Parser.js
@@ -490,7 +490,7 @@ export default class N3Parser {
   // ### `_readIriPropertyListId` replaces a property list's blank node with its IRI
   _readIriPropertyListId(token) {
     const iri = this._readEntity(token);
-    if (!iri)
+    if (iri === undefined)
       return;
     if (iri.termType !== 'NamedNode')
       return this._error(`Expected IRI after id but got ${token.type}`, token);

--- a/src/N3Parser.js
+++ b/src/N3Parser.js
@@ -480,9 +480,39 @@ export default class N3Parser {
       if (parentParent.type === '<<') {
         return this._error('Unexpected compound blank node expression in reified triple', token);
       }
+      if (token.type === 'id')
+        return this._readIriPropertyListId;
       this._predicate = null;
       return this._readPredicate(token);
     }
+  }
+
+  // ### `_readIriPropertyListId` replaces a property list's blank node with its IRI
+  _readIriPropertyListId(token) {
+    const iri = this._readEntity(token);
+    if (!iri)
+      return;
+    if (iri.termType !== 'NamedNode')
+      return this._error(`Expected IRI after id but got ${token.type}`, token);
+
+    const placeholder = this._subject;
+    this._subject = iri;
+    const context = this._contextStack[this._contextStack.length - 1];
+    if (context.subject === placeholder)
+      context.subject = iri;
+    if (context.predicate === placeholder)
+      context.predicate = iri;
+    if (context.object === placeholder)
+      context.object = iri;
+    this._predicate = null;
+    return this._readIriPropertyListPredicate;
+  }
+
+  // ### `_readIriPropertyListPredicate` requires properties after an IRI property list ID
+  _readIriPropertyListPredicate(token) {
+    if (token.type === ';' || token.type === ']' || token.type === '.' || token.type === '}')
+      return this._error(`Expected predicate but got ${token.type}`, token);
+    return this._readPredicate(token);
   }
 
   // ### `_readBlankNodeTail` reads the end of a blank node

--- a/test/N3Lexer-test.js
+++ b/test/N3Lexer-test.js
@@ -1014,6 +1014,48 @@ describe('Lexer', () => {
                    { type: 'eof', line: 1 }));
 
     it(
+      'should tokenize IRI property list identifiers',
+      shouldTokenize('[ id <s> <p> <o> ] [id<s> <p> <o>]',
+                     { type: '[', line: 1 },
+                     { type: 'id', line: 1 },
+                     { type: 'IRI', value: 's', line: 1 },
+                     { type: 'IRI', value: 'p', line: 1 },
+                     { type: 'IRI', value: 'o', line: 1 },
+                     { type: ']', line: 1 },
+                     { type: '[', line: 1 },
+                     { type: 'id', line: 1 },
+                     { type: 'IRI', value: 's', line: 1 },
+                     { type: 'IRI', value: 'p', line: 1 },
+                     { type: 'IRI', value: 'o', line: 1 },
+                     { type: ']', line: 1 },
+                     { type: 'eof', line: 1 }),
+    );
+
+    it(
+      'should tokenize an IRI property list identifier split across chunks',
+      shouldTokenize(streamOf('[ i', 'd <s> <p> <o> ]'),
+                     { type: '[', line: 1 },
+                     { type: 'id', line: 1 },
+                     { type: 'IRI', value: 's', line: 1 },
+                     { type: 'IRI', value: 'p', line: 1 },
+                     { type: 'IRI', value: 'o', line: 1 },
+                     { type: ']', line: 1 },
+                     { type: 'eof', line: 1 }),
+    );
+
+    it(
+      'should keep an id prefix as a prefixed name',
+      shouldTokenize('id:p',
+                     { type: 'prefixed', prefix: 'id', value: 'p', line: 1 },
+                     { type: 'eof', line: 1 }),
+    );
+
+    it(
+      'should not tokenize IRI property list identifiers outside N3 mode',
+      shouldNotTokenize(new Lexer({ n3: false }), 'id ', 'Unexpected "id" on line 1.'),
+    );
+
+    it(
       'should tokenize the "a" predicate without spacing',
       shouldTokenize('[a<>].\n[a[]].\n[a()].\n<>a<>.\n<>a[].\n<>a().\n',
                      { type: '[', line: 1 },

--- a/test/N3Parser-test.js
+++ b/test/N3Parser-test.js
@@ -2799,6 +2799,54 @@ describe('Parser', () => {
     );
 
     it(
+      'should parse a bare IRI property list',
+      shouldParse(parser, '[id <s> <p> <o>].', ['s', 'p', 'o']),
+    );
+
+    it(
+      'should parse an IRI property list in object position',
+      shouldParse(parser, '<s> <p> [id <o> <inner-p> <inner-o>].',
+                  ['s', 'p', 'o'], ['o', 'inner-p', 'inner-o']),
+    );
+
+    it(
+      'should parse an IRI property list in predicate position',
+      shouldParse(parser, '<s> [id <p> <inner-p> <inner-o>] <o>.',
+                  ['s', 'p', 'o'], ['p', 'inner-p', 'inner-o']),
+    );
+
+    it(
+      'should parse nested IRI property lists',
+      shouldParse(parser, '<s> <p> [id <o> <q> [id <inner> <r> "value"]].',
+                  ['s', 'p', 'o'], ['o', 'q', 'inner'], ['inner', 'r', '"value"']),
+    );
+
+    it(
+      'should require an IRI after id',
+      shouldNotParse(parser, '[id _:s <p> <o>].', 'Expected IRI after id but got blank on line 1.'),
+    );
+
+    it(
+      'should require an entity after id',
+      shouldNotParse(parser, '[id ; <p> <o>].', 'Expected entity but got ; on line 1.'),
+    );
+
+    it(
+      'should require properties after an IRI property list ID',
+      shouldNotParse(parser, '[id <s>].', 'Expected predicate but got ] on line 1.'),
+    );
+
+    it(
+      'should reject a semicolon after an IRI property list ID',
+      shouldNotParse(parser, '[id <s>; <p> <o>].', 'Expected predicate but got ; on line 1.'),
+    );
+
+    it(
+      'should reject multiple IRI property list IDs',
+      shouldNotParse(parser, '[id <s1>, <s2> <p> <o>].', 'Expected entity but got , on line 1.'),
+    );
+
+    it(
       'should parse a variable',
       shouldParse(parser, '?a ?b ?c.', ['?a', '?b', '?c']),
     );


### PR DESCRIPTION
Implements the current N3 `iriPropertyList` production used by the W3C parser manifest:

```n3
:s :p [id :identified :name "value"] .
```

The supplied IRI replaces the provisional blank node in the enclosing subject, predicate, or object context before properties are emitted. Nested IRI property lists therefore preserve both inner and outer references. The parser requires an actual IRI after `id`, requires a predicate-object list, and keeps the suite's illegal-semicolon, multiple-ID, and blank-node-ID cases negative.

The lexer recognizes `id` only in N3 mode, waits across stream chunks, and preserves `id:p` as a normal prefixed name.

This makes all five positive IRI-property-list cases in #640 pass.

Tests: full Jest suite (6,825 tests, 100% coverage); ESLint; W3C parser manifest improves from 173/222 to 178/222 on this branch alone.

Closes #689