### PR TITLE
feat(parser): support N3 expression predicates

### DIFF
--- a/src/N3Parser.js
+++ b/src/N3Parser.js
@@ -303,6 +303,7 @@ export default class N3Parser {
   // ### `_readPredicate` reads a quad's predicate
   _readPredicate(token) {
     const type = token.type;
+    let pathable = false;
     switch (type) {
     case 'inverse':
       this._inversePredicate = true;
@@ -334,6 +335,7 @@ export default class N3Parser {
       else
         this._predicate = this._factory.literal(token.value, this._factory.namedNode(token.prefix));
 
+      pathable = true;
       break;
     case '(':
       // In N3, a list can be a predicate
@@ -347,16 +349,26 @@ export default class N3Parser {
                           this._subject = this._factory.blankNode(), null);
         return this._readBlankNodeHead;
       }
+      return this._error('Disallowed blank node as predicate', token);
+    case '{':
+      // In N3, a formula can be a predicate
+      if (this._n3Mode) {
+        this._saveContext('formula', this._graph, this._subject,
+                          this._graph = this._factory.blankNode(), null);
+        return this._readSubject;
+      }
+      return this._readEntity(token);
     case 'blank':
       if (!this._n3Mode)
         return this._error('Disallowed blank node as predicate', token);
     default:
       if ((this._predicate = this._readEntity(token)) === undefined)
         return;
+      pathable = this._n3Mode;
     }
     this._validAnnotation = true;
     // The next token must be an object
-    return this._readObject;
+    return pathable ? this._getPathReader(this._readObject, 'predicate') : this._readObject;
   }
 
   // ### `_readObject` reads a quad's object
@@ -456,7 +468,7 @@ export default class N3Parser {
       return this._getContextEndReader();
     // If the blank node was the predicate, continue reading the object
     else if (this._predicate !== null)
-      return this._readObject;
+      return this._getPathReader(this._readObject, 'predicate');
     // If the blank node was the subject, continue reading the predicate
     else
       // If the blank node was empty, it could be a named graph label
@@ -529,7 +541,7 @@ export default class N3Parser {
       // Was this list the parent's predicate?
       else if (this._object === null) {
         // The next token is the object
-        next = this._readObject;
+        next = this._getPathReader(this._readObject, 'predicate');
         // No list tail if this was an empty list
         if (this._predicate === this.RDF_NIL)
           return next;
@@ -706,13 +718,12 @@ export default class N3Parser {
       token = null;
     }
 
-    if (component === 'subject') {
-      // A subject literal implies N3 mode, so the literal might start a path
-      const reader = this._getPathEndReader(token, this._readPredicateOrNamedGraph);
-      return reader || this._readPredicateOrNamedGraph(token);
+    if (component === 'subject' || component === 'predicate') {
+      // A subject or predicate literal implies N3 mode, so it might start a path
+      const next = component === 'subject' ? this._readPredicateOrNamedGraph : this._readObject;
+      const reader = this._getPathEndReader(token, next, component);
+      return reader || next.call(this, token);
     }
-    if (component === 'predicate')
-      return token === null ? this._readObject : this._readObject(token);
     return this._completeObjectLiteralPost(token, listItem);
   }
 
@@ -739,16 +750,13 @@ export default class N3Parser {
       return this._readDirCode;
     }
 
-    // A subject literal implies N3 mode, so it might start a path.
-    if (component === 'subject') {
-      const reader = this._getPathEndReader(completed.token, next);
-      if (reader)
-        return reader;
-    }
+    // A subject or predicate literal implies N3 mode, so it might start a path.
+    const reader = this._getPathEndReader(completed.token, next, component);
+    if (reader)
+      return reader;
 
-    // If the token was consumed as a datatype, continue with the next component;
-    // otherwise, consume the token now
-    return completed.token === null ? next : next.call(this, completed.token);
+    // Consume the non-path token now
+    return next.call(this, completed.token);
   }
 
   // Completes a literal in subject position
@@ -823,13 +831,18 @@ export default class N3Parser {
     if (empty && this._emptyFormulaAsTrue) {
       if (this._subject === formula)
         this._subject = this.N3_TRUE;
+      else if (this._predicate === formula)
+        this._predicate = this.N3_TRUE;
       else
         this._object = this.N3_TRUE;
     }
 
-    // If the formula was the subject, continue reading the predicate.
-    // If the formula was the object, read punctuation.
-    return this._object === null ? this._readPredicate : this._getContextEndReader();
+    // Continue according to the formula's position in the enclosing statement
+    if (this._object !== null)
+      return this._getPathReader(this._getContextEndReader(), 'object');
+    if (this._predicate !== null)
+      return this._getPathReader(this._readObject, 'predicate');
+    return this._getPathReader(this._readPredicate, 'subject');
   }
 
   // ### `_readPunctuation` reads punctuation between quads or quad parts
@@ -1078,18 +1091,19 @@ export default class N3Parser {
   }
 
   // ### `_getPathReader` reads a potential path and then resumes with the given function
-  _getPathReader(afterPath) {
+  _getPathReader(afterPath, position) {
     this._afterPath = afterPath;
+    this._pathPosition = position || (this._predicate === null ? 'subject' : 'object');
     return this._readPath;
   }
 
   // ### `_getPathEndReader` continues reading after a term that might start a path,
   // given the pending token that follows the term (or `null` if it was consumed)
-  _getPathEndReader(token, afterPath) {
+  _getPathEndReader(token, afterPath, position) {
     // Other pending tokens are not handled here
     if (token !== null && token.type !== '!' && token.type !== '^')
       return null;
-    const reader = this._getPathReader(afterPath);
+    const reader = this._getPathReader(afterPath, position);
     // If no token is pending, wait for the next one; otherwise, consume it now
     return token === null ? reader : reader.call(this, token);
   }
@@ -1103,6 +1117,7 @@ export default class N3Parser {
     case '^': return this._readBackwardPath;
     // Not a path; resume reading where we left off
     default:
+      const afterPath = this._afterPath;
       const stack = this._contextStack, parent = stack.length && stack[stack.length - 1];
       // If we were reading a list item, we still need to output it
       if (parent && parent.type === 'item') {
@@ -1113,7 +1128,9 @@ export default class N3Parser {
         // Output the list item
         this._emit(this._subject, this.RDF_FIRST, item, this._graph);
       }
-      return this._afterPath(token);
+      this._afterPath = null;
+      this._pathPosition = null;
+      return afterPath.call(this, token);
     }
   }
 
@@ -1124,10 +1141,11 @@ export default class N3Parser {
     // The next token is the predicate
     if ((predicate = this._readEntity(token)) === undefined)
       return;
-    // If we were reading a subject, replace the subject by the path's object
-    if (this._predicate === null)
+    // Replace the path expression with the generated object in its current position
+    if (this._pathPosition === 'subject')
       subject = this._subject, this._subject = object;
-    // If we were reading an object, replace the subject by the path's object
+    else if (this._pathPosition === 'predicate')
+      subject = this._predicate, this._predicate = object;
     else
       subject = this._object,  this._object  = object;
     // Emit the path's current quad and read its next section
@@ -1142,10 +1160,11 @@ export default class N3Parser {
     // The next token is the predicate
     if ((predicate = this._readEntity(token)) === undefined)
       return;
-    // If we were reading a subject, replace the subject by the path's subject
-    if (this._predicate === null)
+    // Replace the path expression with the generated subject in its current position
+    if (this._pathPosition === 'subject')
       object = this._subject, this._subject = subject;
-    // If we were reading an object, replace the subject by the path's subject
+    else if (this._pathPosition === 'predicate')
+      object = this._predicate, this._predicate = subject;
     else
       object = this._object,  this._object  = subject;
     // Emit the path's current quad and read its next section

--- a/test/N3Parser-test.js
+++ b/test/N3Parser-test.js
@@ -2676,7 +2676,7 @@ describe('Parser', () => {
 
     it(
       'should not parse a named graph',
-      shouldNotParse(parser, '<g> {}', 'Expected entity but got { on line 1.'),
+      shouldNotParse(parser, '<g> {}', 'Expected entity but got eof on line 1.'),
     );
 
     it(
@@ -2704,6 +2704,56 @@ describe('Parser', () => {
       shouldParse(parser, '<a> [<p> <o>] <c>.',
                   ['a', '_:b0', 'c'],
                   ['_:b0', 'p', 'o']),
+    );
+
+    it(
+      'should parse a formula in predicate position',
+      shouldParse(parser, '<s> { <a> <b> <c>. } <o>.',
+                  ['s', '_:b0', 'o'], ['a', 'b', 'c', '_:b0']),
+    );
+
+    it(
+      'should parse a forward path in predicate position',
+      shouldParse(parser, '<s> <p>!<q> <o>.',
+                  ['p', 'q', '_:b0'], ['s', '_:b0', 'o']),
+    );
+
+    it(
+      'should parse a backward path in predicate position',
+      shouldParse(parser, '<s> <p>^<q> <o>.',
+                  ['_:b0', 'q', 'p'], ['s', '_:b0', 'o']),
+    );
+
+    it(
+      'should parse a path after a formula predicate',
+      shouldParse(parser, '<s> { <a> <b> <c>. }!<q> <o>.',
+                  ['a', 'b', 'c', '_:b0'], ['_:b0', 'q', '_:b1'], ['s', '_:b1', 'o']),
+    );
+
+    it(
+      'should parse a path after a list predicate',
+      shouldParse(parser, '<s> (<a>)!<q> <o>.',
+                  ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first', 'a'],
+                  ['_:b0', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil'],
+                  ['_:b0', 'q', '_:b1'], ['s', '_:b1', 'o']),
+    );
+
+    it(
+      'should parse a path after a literal predicate',
+      shouldParse(parser, '<s> "p"^<q> <o>.',
+                  ['_:b0', 'q', '"p"'], ['s', '_:b0', 'o']),
+    );
+
+    it(
+      'should parse a path after a directional language-tagged literal predicate',
+      shouldParse(parser, '<s> "p"@en--ltr!<q> <o>.',
+                  ['"p"@en--ltr', 'q', '_:b0'], ['s', '_:b0', 'o']),
+    );
+
+    it(
+      'should parse a path after a blank node property list predicate',
+      shouldParse(parser, '<s> [<inner-p> <inner-o>]!<q> <o>.',
+                  ['_:b0', 'inner-p', 'inner-o'], ['_:b0', 'q', '_:b1'], ['s', '_:b1', 'o']),
     );
 
     it(
@@ -4030,6 +4080,12 @@ describe('Parser', () => {
       'should parse an empty formula in the object position as the boolean literal true',
       shouldParse(parser, '<a> <b> {}.',
                   ['a', 'b', '"true"^^http://www.w3.org/2001/XMLSchema#boolean']),
+    );
+
+    it(
+      'should parse an empty formula in the predicate position as the boolean literal true',
+      shouldParse(parser, '<a> {} <c>.',
+                  ['a', '"true"^^http://www.w3.org/2001/XMLSchema#boolean', 'c']),
     );
 
     it(


### PR DESCRIPTION
Closes #691.

Allows formulas and every already-supported N3 expression type in predicate position, including forward and backward property paths. Path state now tracks whether it is replacing a subject, predicate, or object.

Validation:
- `npm test -- --runInBand` (6,821 tests, 100% coverage)
- `npm run lint -- --no-fix`
- W3C parser suite: `bad-preds-formula` now passes; `path2` parses and reaches the known stale expected-IRI mismatch tracked upstream in w3c-cg/N3#234.