### PR TITLE
feat(parser): support directives in formulas

### DIFF
--- a/src/N3Parser.js
+++ b/src/N3Parser.js
@@ -83,14 +83,21 @@ export default class N3Parser {
       this._contextStack.push({ type, subject, predicate, object, graph });
       return;
     }
-    this._contextStack.push({
+    const context = {
       type,
       subject, predicate, object, graph,
       inverse: this._inversePredicate,
       blankPrefix: this._prefixes._,
       quantified: this._quantified,
       emptyFormula: this._emptyFormula,
-    });
+    };
+    // Prefix and base declarations are scoped to their formula
+    if (type === 'formula') {
+      context.prefixes = this._prefixes;
+      context.base = [this._base, this._basePath, this._baseRoot, this._baseScheme];
+      this._prefixes = Object.create(this._prefixes);
+    }
+    this._contextStack.push(context);
     // Every new scope resets the predicate direction
     this._inversePredicate = false;
     // In N3, blank nodes are scoped to a formula
@@ -122,7 +129,12 @@ export default class N3Parser {
     // Restore N3 context settings
     if (this._n3Mode) {
       this._inversePredicate = context.inverse;
-      this._prefixes._ = context.blankPrefix;
+      if (type === 'formula') {
+        this._prefixes = context.prefixes;
+        [this._base, this._basePath, this._baseRoot, this._baseScheme] = context.base;
+      }
+      else
+        this._prefixes._ = context.blankPrefix;
       this._quantified = context.quantified;
       this._emptyFormula = context.emptyFormula;
     }
@@ -173,6 +185,28 @@ export default class N3Parser {
     default:
       return this._readSubject(token);
     }
+  }
+
+  // ### `_readInFormulaContext` reads a token at the statement level of a formula
+  _readInFormulaContext(token) {
+    switch (token.type) {
+    case 'PREFIX':
+      this._sparqlStyle = true;
+    case '@prefix':
+      return this._readPrefix;
+    case 'BASE':
+      this._sparqlStyle = true;
+    case '@base':
+      return this._readBaseIRI;
+    default:
+      return this._readSubject(token);
+    }
+  }
+
+  // ### `_getStatementReader` returns the reader for the current statement scope
+  _getStatementReader() {
+    const context = this._contextStack[this._contextStack.length - 1];
+    return context && context.type === 'formula' ? this._readInFormulaContext : this._readInTopContext;
   }
 
   // ### `_readEntity` reads an IRI, prefixed name, blank node, or variable
@@ -245,7 +279,7 @@ export default class N3Parser {
         return this._error('Unexpected graph', token);
       this._saveContext('formula', this._graph,
                         this._graph = this._factory.blankNode(), null, null);
-      return this._readSubject;
+      return this._readInFormulaContext;
     case '}':
        // No subject; the graph in which we are reading is closed instead
       return this._readPunctuation(token);
@@ -389,7 +423,7 @@ export default class N3Parser {
         return this._error('Unexpected graph', token);
       this._saveContext('formula', this._graph, this._subject, this._predicate,
                         this._graph = this._factory.blankNode());
-      return this._readSubject;
+      return this._readInFormulaContext;
     case '<<(':
       this._saveContext('<<(', this._graph, this._subject, this._predicate, null);
       this._graph = null;
@@ -585,7 +619,7 @@ export default class N3Parser {
       this._saveContext('formula', this._graph, list, this.RDF_FIRST,
                         this._graph = item);
       this._subject = null;
-      return this._readSubject;
+      return this._readInFormulaContext;
     case '<<(':
       this._saveContext('<<(', this._graph, null, null, null);
       this._graph = null;
@@ -848,7 +882,7 @@ export default class N3Parser {
     case '.':
       this._subject = null;
       this._tripleTerm = null;
-      next = this._contextStack.length ? this._readSubject : this._readInTopContext;
+      next = this._getStatementReader();
       if (inversePredicate) this._inversePredicate = false;
       break;
     // Semicolon means the subject is shared; predicate and object are different
@@ -1021,12 +1055,12 @@ export default class N3Parser {
     // SPARQL-style declarations don't have punctuation
     if (this._sparqlStyle) {
       this._sparqlStyle = false;
-      return this._readInTopContext(token);
+      return this._getStatementReader().call(this, token);
     }
 
     if (token.type !== '.')
       return this._error('Expected declaration to end with a dot', token);
-    return this._readInTopContext;
+    return this._getStatementReader();
   }
 
   // Reads a list of quantified symbols from a @forSome or @forAll statement

--- a/test/N3Parser-test.js
+++ b/test/N3Parser-test.js
@@ -2690,6 +2690,48 @@ describe('Parser', () => {
     );
 
     it(
+      'should scope prefix declarations to their formula',
+      shouldParse(parser,
+                  '@prefix ex: <http://outer.example/>.\n' +
+                  '<s> <p> { @prefix ex: <http://inner.example/>. ex:s ex:p ex:o. }.\n' +
+                  'ex:s ex:p ex:o.',
+                  ['http://inner.example/s', 'http://inner.example/p', 'http://inner.example/o', '_:b0'],
+                  ['s', 'p', '_:b0'],
+                  ['http://outer.example/s', 'http://outer.example/p', 'http://outer.example/o']),
+    );
+
+    it(
+      'should restore prefix declarations between sibling formulas',
+      shouldParse(parser,
+                  '@prefix ex: <http://outer.example/>.\n' +
+                  '<s1> <p> { PREFIX ex: <http://first.example/> ex:s ex:p ex:o. }.\n' +
+                  '<s2> <p> { ex:s ex:p ex:o. }.\n',
+                  ['http://first.example/s', 'http://first.example/p', 'http://first.example/o', '_:b0'],
+                  ['s1', 'p', '_:b0'],
+                  ['http://outer.example/s', 'http://outer.example/p', 'http://outer.example/o', '_:b1'],
+                  ['s2', 'p', '_:b1']),
+    );
+
+    it(
+      'should scope base declarations to their formula',
+      shouldParse(parser,
+                  '@base <http://outer.example/>.\n' +
+                  '<s> <p> { @base <http://inner.example/>. <s> <p> <o>. }.\n' +
+                  '<s> <p> <o>.',
+                  ['http://inner.example/s', 'http://inner.example/p', 'http://inner.example/o', '_:b0'],
+                  ['http://outer.example/s', 'http://outer.example/p', '_:b0'],
+                  ['http://outer.example/s', 'http://outer.example/p', 'http://outer.example/o']),
+    );
+
+    it(
+      'should parse a SPARQL-style base declaration in a formula',
+      shouldParse(parser,
+                  '<s> <p> { BASE <http://inner.example/> <s> <p> <o>. }.',
+                  ['http://inner.example/s', 'http://inner.example/p', 'http://inner.example/o', '_:b0'],
+                  ['s', 'p', '_:b0']),
+    );
+
+    it(
       'allows a blank node in predicate position',
       shouldParse(parser, '<a> [] <c>.', ['a', '_:b0', 'c']),
     );

--- a/test/N3StreamParser-test.js
+++ b/test/N3StreamParser-test.js
@@ -62,6 +62,16 @@ describe('StreamParser', () => {
     );
 
     it(
+      'should parse a formula prefix declaration split across chunks',
+      shouldParse(['<s> <p> { @pre', 'fix ex: <http://example.org/>. ex:s ex:p ex:o. }.'], 2,
+                  triples => {
+                    expect(triples[0].subject.value).toEqual('http://example.org/s');
+                    expect(triples[0].predicate.value).toEqual('http://example.org/p');
+                    expect(triples[0].object.value).toEqual('http://example.org/o');
+                  }, { format: 'N3', baseIRI: 'http://base.example/' }),
+    );
+
+    it(
       "doesn't parse an invalid stream",
       shouldNotParse(['z.'], 'Unexpected "z." on line 1.'),
       { token: undefined, line: 1, previousToken: undefined },
@@ -117,11 +127,11 @@ describe('StreamParser', () => {
 });
 
 
-function shouldParse(chunks, expectedLength, validateTriples) {
+function shouldParse(chunks, expectedLength, validateTriples, options) {
   return function (done) {
     const triples = [],
         inputStream = new ArrayReader(chunks),
-        parser = new StreamParser(),
+        parser = new StreamParser(options),
         outputStream = new ArrayWriter(triples);
     expect(parser.import(inputStream)).toBe(parser);
     parser.pipe(outputStream);


### PR DESCRIPTION
Closes #692.

Accepts `@prefix`/`PREFIX` and `@base`/`BASE` declarations at formula statement boundaries. Prefix and base changes inherit from the parent formula, remain local to the formula that declares them, and are restored for sibling and parent scopes.

Validation:
- `npm test -- --runInBand` (6,817 tests, 100% coverage)
- `npm run lint -- --no-fix`
- stream test with `@prefix` split across chunks
- W3C extended suite: 976/978 on this branch, with `michaelE` and `sethE` fixed (the remaining two failures require #693).