### PR TITLE
feat(store): share entity identifiers through a global registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,6 +417,7 @@ for (const quad of store.match(namedNode('http://ex.org/Mickey'), null, null))
 Stores created by the same N3.js module automatically share numeric entity identifiers.
 They retain separate internal ownership scopes, factories, and blank-node allocation state, while set operations can work directly on their aligned internal keys.
 The shared registry is internal: an identifier is retained while at least one live scope owns it, then incrementally released after those scopes are collected.
+When the final registered scope is collected, the registry resets its tables directly instead of releasing identifiers individually.
 Identifiers increase monotonically until the safe-integer limit, then allocation wraps to ID 2 and scans for the next identifier that is not in use.
 Released identifiers are not retained in a free list; they become allocation candidates only after that wrap.
 Every `EntityIndex` created by that module uses the same registry; the registry cannot be replaced or isolated.

--- a/README.md
+++ b/README.md
@@ -416,7 +416,9 @@ for (const quad of store.match(namedNode('http://ex.org/Mickey'), null, null))
 
 Stores created by the same N3.js module automatically share numeric entity identifiers.
 They retain separate internal ownership scopes, factories, and blank-node allocation state, while set operations can work directly on their aligned internal keys.
-The shared registry is internal: an identifier is retained while at least one live scope owns it, then incrementally released and recycled after those scopes are collected.
+The shared registry is internal: an identifier is retained while at least one live scope owns it, then incrementally released after those scopes are collected.
+Identifiers increase monotonically until the safe-integer limit, then allocation wraps to ID 2 and scans for the next identifier that is not in use.
+Released identifiers are not retained in a free list; they become allocation candidates only after that wrap.
 Every `EntityIndex` created by that module uses the same registry; the registry cannot be replaced or isolated.
 Separately loaded copies of N3.js retain separate registries so different package versions do not share private encodings.
 

--- a/README.md
+++ b/README.md
@@ -414,12 +414,14 @@ for (const quad of store.match(namedNode('http://ex.org/Mickey'), null, null))
   console.log(quad);
 ```
 
-If you are using multiple stores, you can reduce memory consumption by allowing them to share an entity index:
-```JavaScript
-const entityIndex = new N3.EntityIndex();
-const store1 = new N3.Store([], { entityIndex });
-const store2 = new N3.Store([], { entityIndex });
-```
+Stores created by the same N3.js module automatically share numeric entity identifiers.
+They retain separate entity indices, factories, and blank-node allocation state, while set operations can work directly on their aligned internal keys.
+The shared registry is internal: an identifier is retained while at least one live entity index owns it, then incrementally released and recycled after those indices are collected.
+Every `EntityIndex` created by that module uses the same registry; the registry cannot be replaced or isolated.
+Separately loaded copies of N3.js retain separate registries so different package versions do not share private encodings.
+
+The `EntityIndex` export and `entityIndex` store option remain as compatibility façades, but are deprecated.
+New code should let each `Store` manage its own entity index.
 
 ### [`Dataset` Interface](https://rdf.js.org/dataset-spec/#dataset-interface)
 This store adheres to the `Dataset` interface which exposes the following properties

--- a/README.md
+++ b/README.md
@@ -415,13 +415,17 @@ for (const quad of store.match(namedNode('http://ex.org/Mickey'), null, null))
 ```
 
 Stores created by the same N3.js module automatically share numeric entity identifiers.
-They retain separate entity indices, factories, and blank-node allocation state, while set operations can work directly on their aligned internal keys.
-The shared registry is internal: an identifier is retained while at least one live entity index owns it, then incrementally released and recycled after those indices are collected.
+They retain separate internal ownership scopes, factories, and blank-node allocation state, while set operations can work directly on their aligned internal keys.
+The shared registry is internal: an identifier is retained while at least one live scope owns it, then incrementally released and recycled after those scopes are collected.
 Every `EntityIndex` created by that module uses the same registry; the registry cannot be replaced or isolated.
 Separately loaded copies of N3.js retain separate registries so different package versions do not share private encodings.
 
+Operations that enumerate their output, such as `filter` and `map`, create an independent scope containing only the output entities.
+Operations that copy aligned indexes, such as `match`, `intersection`, and `difference`, select a scope based on entity cardinality: sparse and empty results retain only their own entities, while dense results share their source scope to avoid a full extra scan.
+Importing another store likewise retains only entities referenced by the imported graph, rather than everything owned by its scope.
+
 The `EntityIndex` export and `entityIndex` store option remain as compatibility façades, but are deprecated.
-New code should let each `Store` manage its own entity index.
+New code should let each `Store` manage its own entity ownership scope.
 
 ### [`Dataset` Interface](https://rdf.js.org/dataset-spec/#dataset-interface)
 This store adheres to the `Dataset` interface which exposes the following properties

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "streamify-string": "^1.0.1"
       },
       "engines": {
-        "node": ">=12.0"
+        "node": ">=18.0"
       }
     },
     "node_modules/@babel/cli": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "module": "./src/index.js",
   "sideEffects": false,
   "engines": {
-    "node": ">=12.0"
+    "node": ">=18.0"
   },
   "files": [
     ".babelrc",

--- a/perf/LegacyEntityIndex.js
+++ b/perf/LegacyEntityIndex.js
@@ -1,0 +1,75 @@
+// Benchmark-only copy of the isolated entity index used before the global registry.
+const N3 = require('..');
+
+const { DataFactory, termFromId, termToId } = N3;
+const { isDefaultGraph } = N3.Util;
+
+class LegacyEntityIndex extends N3.EntityIndex {
+  constructor(options = {}) {
+    super(options);
+    this._legacyId = 1;
+    this._ids = Object.create(null);
+    this._ids[''] = 1;
+    this._entities = Object.create(null);
+    this._entities[1] = '';
+    this._blankNodeIndex = 0;
+    this._factory = options.factory || DataFactory;
+  }
+
+  _termFromId(id) {
+    if (id[0] === '.') {
+      const entities = this._entities;
+      const terms = id.split('.');
+      return this._factory.quad(
+        this._termFromId(entities[terms[1]]),
+        this._termFromId(entities[terms[2]]),
+        this._termFromId(entities[terms[3]]),
+        terms[4] && this._termFromId(entities[terms[4]]),
+      );
+    }
+    return termFromId(id, this._factory);
+  }
+
+  _termToNumericId(term) {
+    if (term.termType === 'Quad') {
+      const s = this._termToNumericId(term.subject),
+          p = this._termToNumericId(term.predicate),
+          o = this._termToNumericId(term.object);
+      let g;
+
+      return s && p && o && (isDefaultGraph(term.graph) || (g = this._termToNumericId(term.graph))) &&
+        this._ids[g ? `.${s}.${p}.${o}.${g}` : `.${s}.${p}.${o}`];
+    }
+    return this._ids[termToId(term)];
+  }
+
+  _termToNewNumericId(term) {
+    const value = term && term.termType === 'Quad' ?
+      `.${this._termToNewNumericId(term.subject)}.${this._termToNewNumericId(term.predicate)}.${
+        this._termToNewNumericId(term.object)}${
+        isDefaultGraph(term.graph) ? '' : `.${this._termToNewNumericId(term.graph)}`
+      }`
+      : termToId(term);
+
+    return this._ids[value] ||
+      (this._ids[this._entities[++this._legacyId] = value] = this._legacyId);
+  }
+
+  createBlankNode(suggestedName) {
+    let name, index;
+    if (suggestedName) {
+      name = suggestedName = `_:${suggestedName}`, index = 1;
+      while (this._ids[name])
+        name = suggestedName + index++;
+    }
+    else {
+      do { name = `_:b${this._blankNodeIndex++}`; }
+      while (this._ids[name]);
+    }
+    this._ids[name] = ++this._legacyId;
+    this._entities[this._legacyId] = name;
+    return this._factory.blankNode(name.substr(2));
+  }
+}
+
+module.exports = LegacyEntityIndex;

--- a/perf/N3EntityRegistry-perf.js
+++ b/perf/N3EntityRegistry-perf.js
@@ -118,14 +118,14 @@ function createCollectableStore(count, useRegistry) {
   const registry = store._entityIndex._registry;
   return {
     registry,
-    expectedFreeIds: registry._freeIds.length + count + 2,
+    expectedRegistrySize: registry._ids.size - count - 2,
   };
 }
 
 async function garbageCollection(count, useRegistry) {
   collect();
   const before = process.memoryUsage().heapUsed;
-  const { registry, expectedFreeIds } = createCollectableStore(count, useRegistry);
+  const { registry, expectedRegistrySize } = createCollectableStore(count, useRegistry);
   const allocated = process.memoryUsage().heapUsed;
   let maxBatch = 0;
   let drainReleases;
@@ -144,10 +144,10 @@ async function garbageCollection(count, useRegistry) {
 
   start = performance.now();
   if (registry) {
-    for (let turn = 0; registry._freeIds.length !== expectedFreeIds && turn < 10_000; turn++)
+    for (let turn = 0; registry._ids.size !== expectedRegistrySize && turn < 10_000; turn++)
       await immediate();
-    if (registry._freeIds.length !== expectedFreeIds)
-      throw new Error(`Freed ${registry._freeIds.length} of ${expectedFreeIds} identifiers`);
+    if (registry._ids.size !== expectedRegistrySize)
+      throw new Error(`Registry contains ${registry._ids.size} rather than ${expectedRegistrySize} identifiers`);
     registry._drainReleases = drainReleases;
   }
   else

--- a/perf/N3EntityRegistry-perf.js
+++ b/perf/N3EntityRegistry-perf.js
@@ -71,6 +71,23 @@ function intersection(shared, rightSize = size) {
   return duration;
 }
 
+function scopeSelection() {
+  const source = fill(new N3.Store(), 'high');
+  const sparseSource = fill(new N3.Store(), 'high', size / 2, Math.max(1, Math.floor(size / 100)));
+  const dense = source.intersection(source);
+  const sparse = source.intersection(sparseSource);
+  const empty = source.difference(source);
+  return {
+    sourceIdentifiers: source._entityScope._ownership.length,
+    denseIdentifiers: dense._entityScope._ownership.length,
+    denseSharesScope: dense._entityScope === source._entityScope,
+    sparseIdentifiers: sparse._entityScope._ownership.length,
+    sparseSharesScope: sparse._entityScope === source._entityScope,
+    emptyIdentifiers: empty._entityScope._ownership.length,
+    emptySharesScope: empty._entityScope === source._entityScope,
+  };
+}
+
 function compare(callback) {
   callback(false);
   callback(true);
@@ -212,6 +229,7 @@ async function main() {
     addHighCardinality: compare(shared => add(shared, 'high')),
     intersection: compare(shared => intersection(shared)),
     asymmetricIntersection: compare(shared => intersection(shared, Math.max(1, Math.floor(size / 100)))),
+    scopeSelection: scopeSelection(),
     garbageCollection: gc,
   }, null, 2));
 }

--- a/perf/N3EntityRegistry-perf.js
+++ b/perf/N3EntityRegistry-perf.js
@@ -1,0 +1,231 @@
+#!/usr/bin/env node
+const { performance } = require('perf_hooks');
+const { isMainThread, parentPort, Worker, workerData } = require('worker_threads');
+const N3 = require('..');
+const LegacyEntityIndex = require('./LegacyEntityIndex');
+
+// Arguments: operation size, rounds, and garbage-collection comparison size.
+const size = Number.parseInt(process.argv[2], 10) || 50_000;
+const rounds = Number.parseInt(process.argv[3], 10) || 11;
+const cleanupSize = Number.parseInt(process.argv[4], 10) || size;
+
+function median(values) {
+  return [...values].sort((left, right) => left - right)[Math.floor(values.length / 2)];
+}
+
+function collect() {
+  if (global.gc) {
+    for (let attempt = 0; attempt < 3; attempt++)
+      global.gc();
+  }
+}
+
+function immediate() {
+  return new Promise(resolve => setImmediate(resolve));
+}
+
+function createOptions(shared) {
+  if (shared)
+    return [{}, {}];
+  return [
+    { entityIndex: new LegacyEntityIndex() },
+    { entityIndex: new LegacyEntityIndex() },
+  ];
+}
+
+function fill(store, cardinality, offset = 0, count = size) {
+  for (let index = 0; index < count; index++) {
+    const entity = index + offset;
+    const subject = cardinality === 'low' ? entity % 1_000 : entity;
+    const predicate = cardinality === 'low' ? Math.floor(entity / 1_000) : entity % 31;
+    const object = cardinality === 'low' ? entity % 100 : entity % 10_000;
+    store.addQuad(`s${subject}`, `p${predicate}`, `o${object}`);
+  }
+  return store;
+}
+
+function add(shared, cardinality) {
+  collect();
+  const [options] = createOptions(shared);
+  const store = new N3.Store([], options);
+  const start = performance.now();
+  fill(store, cardinality);
+  const duration = performance.now() - start;
+  if (store.size !== size)
+    throw new Error(`Unexpected store size ${store.size}`);
+  return duration;
+}
+
+function intersection(shared, rightSize = size) {
+  const [leftOptions, rightOptions] = createOptions(shared);
+  const left = fill(new N3.Store([], leftOptions), 'high');
+  const right = fill(new N3.Store([], rightOptions), 'high', size / 2, rightSize);
+  collect();
+  const start = performance.now();
+  // Force the pre-registry per-quad path for the benchmark-only isolated indices.
+  const result = shared ? left.intersection(right) : left.intersection({ has: right.has.bind(right) });
+  const duration = performance.now() - start;
+  const expectedSize = Math.min(size / 2, rightSize);
+  if (result.size !== expectedSize)
+    throw new Error(`Unexpected intersection size ${result.size}`);
+  return duration;
+}
+
+function compare(callback) {
+  callback(false);
+  callback(true);
+  const isolated = [], shared = [];
+  for (let round = 0; round < rounds; round++) {
+    const order = round % 2 ? [true, false] : [false, true];
+    for (const useRegistry of order)
+      (useRegistry ? shared : isolated).push(callback(useRegistry));
+  }
+  const isolatedMedian = median(isolated), sharedMedian = median(shared);
+  return {
+    isolated: isolatedMedian,
+    registry: sharedMedian,
+    ratio: sharedMedian / isolatedMedian,
+  };
+}
+
+function createCollectableStore(count, useRegistry) {
+  const options = useRegistry ? {} : { entityIndex: new LegacyEntityIndex() };
+  const store = new N3.Store([], options);
+  for (let index = 0; index < count; index++)
+    store.addQuad(`subject${index}`, 'predicate', 'object');
+  if (store.size !== count)
+    throw new Error(`Unexpected store size ${store.size}`);
+  if (!useRegistry)
+    return {};
+
+  const registry = store._entityIndex._registry;
+  return {
+    registry,
+    expectedFreeIds: registry._freeIds.length + count + 2,
+  };
+}
+
+async function garbageCollection(count, useRegistry) {
+  collect();
+  const before = process.memoryUsage().heapUsed;
+  const { registry, expectedFreeIds } = createCollectableStore(count, useRegistry);
+  const allocated = process.memoryUsage().heapUsed;
+  let maxBatch = 0;
+  let drainReleases;
+  if (registry) {
+    drainReleases = registry._drainReleases;
+    registry._drainReleases = () => {
+      const start = performance.now();
+      drainReleases.call(registry);
+      maxBatch = Math.max(maxBatch, performance.now() - start);
+    };
+  }
+  const totalStart = performance.now();
+  let start = performance.now();
+  global.gc();
+  const firstGc = performance.now() - start;
+
+  start = performance.now();
+  if (registry) {
+    for (let turn = 0; registry._freeIds.length !== expectedFreeIds && turn < 10_000; turn++)
+      await immediate();
+    if (registry._freeIds.length !== expectedFreeIds)
+      throw new Error(`Freed ${registry._freeIds.length} of ${expectedFreeIds} identifiers`);
+    registry._drainReleases = drainReleases;
+  }
+  else
+    await immediate();
+  const cleanup = performance.now() - start;
+  const afterCleanup = process.memoryUsage().heapUsed;
+
+  start = performance.now();
+  global.gc();
+  const secondGc = performance.now() - start;
+  await immediate();
+  const afterSecondGc = process.memoryUsage().heapUsed;
+
+  return {
+    allocationHeapDeltaMegabytes: (allocated - before) / 1024 / 1024,
+    cleanupHeapDeltaMegabytes: (afterCleanup - before) / 1024 / 1024,
+    retainedHeapDeltaMegabytes: (afterSecondGc - before) / 1024 / 1024,
+    firstGcMilliseconds: firstGc,
+    cleanupMilliseconds: cleanup,
+    secondGcMilliseconds: secondGc,
+    maxBatchMilliseconds: maxBatch,
+    totalMilliseconds: performance.now() - totalStart,
+  };
+}
+
+function garbageCollectionInWorker(count, useRegistry) {
+  return new Promise((resolve, reject) => {
+    let completed = false;
+    const worker = new Worker(__filename, { workerData: { count, useRegistry } });
+    worker.once('message', message => {
+      completed = true;
+      if (message.error)
+        reject(Object.assign(new Error(message.error.message), { stack: message.error.stack }));
+      else
+        resolve(message.result);
+    });
+    worker.once('error', reject);
+    worker.once('exit', code => {
+      if (!completed)
+        reject(new Error(`Garbage-collection worker exited before returning a result (code ${code})`));
+    });
+  });
+}
+
+async function compareGarbageCollection(count) {
+  if (!global.gc)
+    return { skipped: 'Run with --expose-gc to compare garbage collection' };
+
+  await garbageCollectionInWorker(Math.min(count, 10_000), false);
+  await garbageCollectionInWorker(Math.min(count, 10_000), true);
+  const measurements = { isolated: [], registry: [] };
+  const measurementRounds = Math.min(rounds, 7);
+  for (let round = 0; round < measurementRounds; round++) {
+    const order = round % 2 ? [true, false] : [false, true];
+    for (const useRegistry of order)
+      measurements[useRegistry ? 'registry' : 'isolated'].push(
+        await garbageCollectionInWorker(count, useRegistry),
+      );
+  }
+
+  const result = { identifiers: count + 2 };
+  for (const scenario of ['isolated', 'registry']) {
+    result[scenario] = {};
+    for (const field of [
+      'allocationHeapDeltaMegabytes', 'cleanupHeapDeltaMegabytes', 'retainedHeapDeltaMegabytes',
+      'firstGcMilliseconds', 'cleanupMilliseconds', 'secondGcMilliseconds',
+      'maxBatchMilliseconds', 'totalMilliseconds',
+    ])
+      result[scenario][field] = median(measurements[scenario].map(value => value[field]));
+  }
+  result.ratio = result.registry.totalMilliseconds / result.isolated.totalMilliseconds;
+  return result;
+}
+
+async function main() {
+  const gc = await compareGarbageCollection(cleanupSize);
+  console.log(JSON.stringify({
+    addLowCardinality: compare(shared => add(shared, 'low')),
+    addHighCardinality: compare(shared => add(shared, 'high')),
+    intersection: compare(shared => intersection(shared)),
+    asymmetricIntersection: compare(shared => intersection(shared, Math.max(1, Math.floor(size / 100)))),
+    garbageCollection: gc,
+  }, null, 2));
+}
+
+if (isMainThread) {
+  main().catch(error => {
+    console.error(error);
+    process.exitCode = 1;
+  });
+}
+else {
+  garbageCollection(workerData.count, workerData.useRegistry)
+    .then(
+      result => parentPort.postMessage({ result }),
+      error => parentPort.postMessage({ error: { message: error.message, stack: error.stack } }),
+    );
+}

--- a/src/N3EntityRegistry.js
+++ b/src/N3EntityRegistry.js
@@ -1,4 +1,4 @@
-// Assigns shared numeric identifiers while an entity index owns them.
+// Assigns shared numeric identifiers while an entity scope owns them.
 // Bound finalizer cleanup so large stores do not monopolize the event loop.
 const RELEASE_BATCH_SIZE = 4096;
 
@@ -25,7 +25,7 @@ export default class N3EntityRegistry {
     this._pendingReleases = [];
     this._releaseScheduled = false;
 
-    // One registration per entity index releases all of its identifiers together.
+    // One registration per entity scope releases all of its identifiers together.
     this._finalizer = new FinalizationRegistry(ownership => this._enqueueRelease(ownership));
   }
 

--- a/src/N3EntityRegistry.js
+++ b/src/N3EntityRegistry.js
@@ -21,7 +21,8 @@ export default class N3EntityRegistry {
     this._entities[1] = '';
     this._references = Object.create(null);
     this._references[1] = Infinity;
-    this._freeIds = [];
+    this._maxId = Number.MAX_SAFE_INTEGER;
+    this._wrapped = false;
     this._pendingReleases = [];
     this._releaseScheduled = false;
 
@@ -39,16 +40,26 @@ export default class N3EntityRegistry {
     return this._ids.get(value);
   }
 
+  _nextId() {
+    if (!this._wrapped && this._id < this._maxId)
+      return ++this._id;
+
+    this._wrapped = true;
+    const first = this._id >= this._maxId ? 2 : this._id + 1;
+    let id = first;
+    do {
+      if (!(id in this._references))
+        return this._id = id;
+      id = id >= this._maxId ? 2 : id + 1;
+    }
+    while (id !== first);
+    throw new RangeError('Entity identifier limit exceeded');
+  }
+
   _intern(value) {
     let id = this._ids.get(value);
     if (!id) {
-      if (this._freeIds.length)
-        id = this._freeIds.pop();
-      else {
-        if (this._id >= Number.MAX_SAFE_INTEGER)
-          throw new RangeError('Entity identifier limit exceeded');
-        id = ++this._id;
-      }
+      id = this._nextId();
       this._ids.set(value, id);
       this._entities[id] = value;
       this._references[id] = 0;
@@ -89,7 +100,6 @@ export default class N3EntityRegistry {
           this._ids.delete(this._entities[id]);
           delete this._entities[id];
           delete this._references[id];
-          this._freeIds.push(id);
         }
       }
       if (!ownership.length)

--- a/src/N3EntityRegistry.js
+++ b/src/N3EntityRegistry.js
@@ -1,0 +1,105 @@
+// Assigns shared numeric identifiers while an entity index owns them.
+// Bound finalizer cleanup so large stores do not monopolize the event loop.
+const RELEASE_BATCH_SIZE = 4096;
+
+function scheduleTask(callback) {
+  /* istanbul ignore else */
+  if (typeof setImmediate === 'function')
+    return setImmediate(callback);
+  /* istanbul ignore next */
+  return setTimeout(callback, 0);
+}
+
+export default class N3EntityRegistry {
+  constructor() {
+    if (typeof FinalizationRegistry !== 'function')
+      throw new Error('EntityRegistry requires FinalizationRegistry support');
+
+    this._id = 1;
+    this._ids = new Map([['', 1]]);
+    this._entities = Object.create(null);
+    this._entities[1] = '';
+    this._references = Object.create(null);
+    this._references[1] = Infinity;
+    this._freeIds = [];
+    this._pendingReleases = [];
+    this._releaseScheduled = false;
+
+    // One registration per entity index releases all of its identifiers together.
+    this._finalizer = new FinalizationRegistry(ownership => this._enqueueRelease(ownership));
+  }
+
+  _createOwnership(target) {
+    const ownership = [];
+    this._finalizer.register(target, ownership);
+    return ownership;
+  }
+
+  _lookup(value) {
+    return this._ids.get(value);
+  }
+
+  _intern(value) {
+    let id = this._ids.get(value);
+    if (!id) {
+      if (this._freeIds.length)
+        id = this._freeIds.pop();
+      else {
+        if (this._id >= Number.MAX_SAFE_INTEGER)
+          throw new RangeError('Entity identifier limit exceeded');
+        id = ++this._id;
+      }
+      this._ids.set(value, id);
+      this._entities[id] = value;
+      this._references[id] = 0;
+    }
+    return id;
+  }
+
+  _retain(id, ownership) {
+    ownership.push(id);
+    this._references[id]++;
+  }
+
+  _enqueueRelease(ownership) {
+    this._pendingReleases.push(ownership);
+    if (!this._releaseScheduled)
+      this._scheduleRelease();
+  }
+
+  _scheduleRelease() {
+    this._releaseScheduled = true;
+    const task = scheduleTask(() => this._drainReleases());
+    // Do not keep Node.js processes alive solely to clean an unreachable store.
+    /* istanbul ignore next */
+    task.unref?.();
+  }
+
+  _drainReleases() {
+    this._releaseScheduled = false;
+    let remaining = RELEASE_BATCH_SIZE;
+
+    while (remaining > 0 && this._pendingReleases.length) {
+      const ownership = this._pendingReleases[this._pendingReleases.length - 1];
+      while (remaining > 0 && ownership.length) {
+        const id = ownership.pop();
+        remaining--;
+
+        if (--this._references[id] === 0) {
+          this._ids.delete(this._entities[id]);
+          delete this._entities[id];
+          delete this._references[id];
+          this._freeIds.push(id);
+        }
+      }
+      if (!ownership.length)
+        this._pendingReleases.pop();
+    }
+
+    if (this._pendingReleases.length)
+      this._scheduleRelease();
+  }
+}
+
+// Align identifiers between all stores from this module instance.
+export const entityRegistry = new N3EntityRegistry();

--- a/src/N3EntityRegistry.js
+++ b/src/N3EntityRegistry.js
@@ -15,24 +15,31 @@ export default class N3EntityRegistry {
     if (typeof FinalizationRegistry !== 'function')
       throw new Error('EntityRegistry requires FinalizationRegistry support');
 
+    this._maxId = Number.MAX_SAFE_INTEGER;
+    this._pendingReleases = [];
+    this._releaseScheduled = false;
+    this._activeScopes = 0;
+    this._reset();
+
+    // One registration per entity scope releases all of its identifiers together.
+    this._finalizer = new FinalizationRegistry(ownership => this._releaseScope(ownership));
+  }
+
+  _reset() {
     this._id = 1;
     this._ids = new Map([['', 1]]);
     this._entities = Object.create(null);
     this._entities[1] = '';
     this._references = Object.create(null);
     this._references[1] = Infinity;
-    this._maxId = Number.MAX_SAFE_INTEGER;
     this._wrapped = false;
-    this._pendingReleases = [];
-    this._releaseScheduled = false;
-
-    // One registration per entity scope releases all of its identifiers together.
-    this._finalizer = new FinalizationRegistry(ownership => this._enqueueRelease(ownership));
+    this._pendingReleases.length = 0;
   }
 
   _createOwnership(target) {
     const ownership = [];
     this._finalizer.register(target, ownership);
+    this._activeScopes++;
     return ownership;
   }
 
@@ -70,6 +77,13 @@ export default class N3EntityRegistry {
   _retain(id, ownership) {
     ownership.push(id);
     this._references[id]++;
+  }
+
+  _releaseScope(ownership) {
+    if (--this._activeScopes === 0)
+      this._reset();
+    else
+      this._enqueueRelease(ownership);
   }
 
   _enqueueRelease(ownership) {

--- a/src/N3Store.js
+++ b/src/N3Store.js
@@ -7,6 +7,7 @@ import { isDefaultGraph } from './N3Util';
 import N3Writer from './N3Writer';
 
 const ITERATOR = Symbol('iter');
+const ENTITY_SCOPE = Symbol('entityScope');
 // Keep common lookups local without duplicating every registry entry per store.
 const ENTITY_CACHE_SIZE = 4096;
 const SIZE = Symbol('size');
@@ -110,8 +111,49 @@ function difference(s1, s2, depth = 4) {
   return target;
 }
 
+// Collect the entities referenced by one graph index, stopping once sharing the
+// source scope is cheaper than creating a narrower one.
+function collectGraphEntityIds(graphs, entities, limit) {
+  const ids = new Set();
+  function add(id) {
+    id = Number(id);
+    if (id === 1 || ids.has(id))
+      return true;
+    ids.add(id);
+    if (ids.size >= limit)
+      return false;
+
+    const value = entities[id];
+    if (value[0] === '.') {
+      for (const component of value.split('.').slice(1))
+        if (!add(component))
+          return false;
+    }
+    return true;
+  }
+
+  for (const graphId in graphs) {
+    if (!add(graphId))
+      return null;
+    const subjects = graphs[graphId].subjects;
+    for (const subjectId in subjects) {
+      if (!add(subjectId))
+        return null;
+      const predicates = subjects[subjectId];
+      for (const predicateId in predicates) {
+        if (!add(predicateId))
+          return null;
+        for (const objectId in predicates[predicateId])
+          if (!add(objectId))
+            return null;
+      }
+    }
+  }
+  return ids;
+}
+
 // ## Constructor
-export class N3EntityIndex {
+class N3EntityScope {
   constructor(options = {}) {
     this._registry = entityRegistry;
     Object.defineProperty(this, '_id', {
@@ -145,9 +187,26 @@ export class N3EntityIndex {
     return id;
   }
 
-  _import(entityIndex) {
-    for (const id of entityIndex._ownership)
-      this._retain(id);
+  _importGraphs(graphs) {
+    const ids = collectGraphEntityIds(graphs, this._entities, Infinity);
+    for (const id of ids)
+      this._retain(id, this._entities[id]);
+  }
+
+  _scopeForGraphs(graphs) {
+    // Reuse the scope when the result needs at least half of its entities.
+    const ids = collectGraphEntityIds(
+      graphs,
+      this._entities,
+      Math.ceil(this._ownership.length / 2),
+    );
+    if (ids === null)
+      return this;
+
+    const scope = new N3EntityScope({ factory: this._factory });
+    for (const id of ids)
+      scope._retain(id, this._entities[id]);
+    return scope;
   }
 
   _owns(value) {
@@ -222,6 +281,9 @@ export class N3EntityIndex {
   }
 }
 
+// Deprecated compatibility façade. Stores use internal ownership scopes.
+export class N3EntityIndex extends N3EntityScope {}
+
 // ## Constructor
 export default class N3Store {
   constructor(quads, options) {
@@ -237,11 +299,14 @@ export default class N3Store {
     this._factory = options.factory || N3DataFactory;
     if (options.entityIndex && !(options.entityIndex instanceof N3EntityIndex))
       throw new TypeError('entityIndex must be an EntityIndex');
-    this._entityIndex = options.entityIndex || new N3EntityIndex({ factory: this._factory });
-    this._entities = this._entityIndex._entities;
-    this._termFromId = this._entityIndex._termFromId.bind(this._entityIndex);
-    this._termToNumericId = this._entityIndex._termToNumericId.bind(this._entityIndex);
-    this._termToNewNumericId = this._entityIndex._termToNewNumericId.bind(this._entityIndex);
+    this._entityScope = options[ENTITY_SCOPE] || options.entityIndex ||
+      new N3EntityScope({ factory: this._factory });
+    // Retain the old private name for integrations that inspected it.
+    this._entityIndex = this._entityScope;
+    this._entities = this._entityScope._entities;
+    this._termFromId = this._entityScope._termFromId.bind(this._entityScope);
+    this._termToNumericId = this._entityScope._termToNumericId.bind(this._entityScope);
+    this._termToNewNumericId = this._entityScope._termToNewNumericId.bind(this._entityScope);
 
     // Add quads if passed
     if (quads)
@@ -269,6 +334,18 @@ export default class N3Store {
   }
 
   // ## Private methods
+
+  _newStore(entityScope = new N3EntityScope({ factory: this._entityScope._factory })) {
+    return new N3Store({ factory: this._factory, [ENTITY_SCOPE]: entityScope });
+  }
+
+  _resultStore(graphs, size = null) {
+    graphs = graphs || Object.create(null);
+    const store = this._newStore(this._entityScope._scopeForGraphs(graphs));
+    store._graphs = graphs;
+    store._size = size;
+    return store;
+  }
 
   // ### `_addToIndex` adds a quad to a three-layered index.
   // Returns if the index has changed, if the entry did not already exist.
@@ -649,7 +726,7 @@ export default class N3Store {
   // Setting any field to `undefined` or `null` indicates a wildcard.
   // For backwards compatibility, the object return also implements the Readable stream interface.
   match(subject, predicate, object, graph) {
-    return new DatasetCoreAndReadableStream(this, subject, predicate, object, graph, { entityIndex: this._entityIndex });
+    return new DatasetCoreAndReadableStream(this, subject, predicate, object, graph);
   }
 
   // ### `countQuads` returns the number of quads matching a pattern.
@@ -863,7 +940,7 @@ export default class N3Store {
 
   // ### `createBlankNode` creates a new blank node, returning its name
   createBlankNode(suggestedName) {
-    return this._entityIndex.createBlankNode(suggestedName);
+    return this._entityScope.createBlankNode(suggestedName);
   }
 
   // ### `extractLists` finds and removes all list triples
@@ -981,8 +1058,8 @@ export default class N3Store {
       this.addQuads(quads);
     else if (quads instanceof N3Store) {
       if (quads._size !== 0) {
-        if (quads._entityIndex !== this._entityIndex)
-          this._entityIndex._import(quads._entityIndex);
+        if (quads._entityScope !== this._entityScope)
+          this._entityScope._importGraphs(quads._graphs);
         this._graphs = merge(this._graphs, quads._graphs);
         this._size = null; // Invalidate the cached size
       }
@@ -1052,16 +1129,11 @@ export default class N3Store {
       other = other.filtered;
 
     if (other === this)
-      return new N3Store({ entityIndex: this._entityIndex });
+      return this._newStore();
 
     if (other instanceof N3Store) {
-      const store = new N3Store({ entityIndex: this._entityIndex });
       const graphs = difference(this._graphs, other._graphs);
-      if (graphs) {
-        store._graphs = graphs;
-        store._size = null;
-      }
-      return store;
+      return this._resultStore(graphs);
     }
 
     return this.filter(quad => !other.has(quad));
@@ -1085,7 +1157,7 @@ export default class N3Store {
    * This method is aligned with Array.prototype.filter() in ECMAScript-262.
    */
   filter(iteratee) {
-    const store = new N3Store({ entityIndex: this._entityIndex });
+    const store = this._newStore();
     for (const quad of this)
       if (iteratee(quad, this))
         store.add(quad);
@@ -1100,19 +1172,11 @@ export default class N3Store {
       other = other.filtered;
 
     if (other === this) {
-      const store = new N3Store({ entityIndex: this._entityIndex });
-      store._graphs = merge(Object.create(null), this._graphs);
-      store._size = this._size;
-      return store;
+      return this._resultStore(merge(Object.create(null), this._graphs), this._size);
     }
     else if (other instanceof N3Store) {
-      const store = new N3Store({ entityIndex: this._entityIndex });
       const graphs = intersect(other._graphs, this._graphs);
-      if (graphs) {
-        store._graphs = graphs;
-        store._size = null;
-      }
-      return store;
+      return this._resultStore(graphs);
     }
 
     return this.filter(quad => other.has(quad));
@@ -1122,7 +1186,7 @@ export default class N3Store {
    * Returns a new dataset containing all quads returned by applying `iteratee` to each quad in the current dataset.
    */
   map(iteratee) {
-    const store = new N3Store({ entityIndex: this._entityIndex });
+    const store = this._newStore();
     for (const quad of this)
       store.add(iteratee(quad, this));
     return store;
@@ -1184,9 +1248,7 @@ export default class N3Store {
    * Returns a new `Dataset` that is a concatenation of this dataset and the quads given as an argument.
    */
   union(quads) {
-    const store = new N3Store({ entityIndex: this._entityIndex });
-    store._graphs = merge(Object.create(null), this._graphs);
-    store._size = this._size;
+    const store = this._resultStore(merge(Object.create(null), this._graphs), this._size);
 
     store.addAll(quads);
     return store;
@@ -1232,24 +1294,24 @@ function indexMatch(index, ids, depth = 0) {
  * A class that implements both DatasetCore and Readable.
  */
 class DatasetCoreAndReadableStream extends Readable {
-  constructor(n3Store, subject, predicate, object, graph, options) {
+  constructor(n3Store, subject, predicate, object, graph) {
     super({ objectMode: true });
-    Object.assign(this, { n3Store, subject, predicate, object, graph, options });
+    Object.assign(this, { n3Store, subject, predicate, object, graph });
   }
 
   get filtered() {
     if (!this._filtered) {
       const { n3Store, graph, object, predicate, subject } = this;
-      const newStore = this._filtered = new N3Store({ factory: n3Store._factory, entityIndex: this.options.entityIndex });
 
       let subjectId, predicateId, objectId;
 
       // Translate IRIs to internal index keys.
-      if (subject   && !(subjectId   = newStore._termToNumericId(subject))   ||
-          predicate && !(predicateId = newStore._termToNumericId(predicate)) ||
-          object    && !(objectId    = newStore._termToNumericId(object)))
-        return newStore;
+      if (subject   && !(subjectId   = n3Store._termToNumericId(subject))   ||
+          predicate && !(predicateId = n3Store._termToNumericId(predicate)) ||
+          object    && !(objectId    = n3Store._termToNumericId(object)))
+        return this._filtered = n3Store._newStore();
 
+      const matchedGraphs = Object.create(null);
       const graphs = n3Store._getGraphs(graph);
       for (const graphKey in graphs) {
         let subjects, predicates, objects, content;
@@ -1272,10 +1334,10 @@ class DatasetCoreAndReadableStream extends Readable {
           }
 
           if (subjects)
-            newStore._graphs[graphKey] = { subjects, predicates, objects };
+            matchedGraphs[graphKey] = { subjects, predicates, objects };
         }
       }
-      newStore._size = null;
+      this._filtered = n3Store._resultStore(matchedGraphs);
     }
     return this._filtered;
   }

--- a/src/N3Store.js
+++ b/src/N3Store.js
@@ -1,11 +1,14 @@
 // **N3Store** objects store N3 quads by graph in memory.
 import { Readable } from 'readable-stream';
 import { default as N3DataFactory, termToId, termFromId } from './N3DataFactory';
+import { entityRegistry } from './N3EntityRegistry';
 import namespaces from './IRIs';
 import { isDefaultGraph } from './N3Util';
 import N3Writer from './N3Writer';
 
 const ITERATOR = Symbol('iter');
+// Keep common lookups local without duplicating every registry entry per store.
+const ENTITY_CACHE_SIZE = 4096;
 const SIZE = Symbol('size');
 
 function hasInIndex(index0, key0, key1, key2) {
@@ -33,7 +36,7 @@ function merge(target, source, depth = 4) {
 
 /**
  * Determines the intersection of the `_graphs` index s1 and s2.
- * s1 and s2 *must* belong to Stores that share an `_entityIndex`.
+ * s1 and s2 *must* belong to Stores with aligned entity identifiers.
  *
  * False is returned when there is no intersection; this should
  * *not* be set as the value for an index.
@@ -69,7 +72,7 @@ function intersect(s1, s2, depth = 4) {
 
 /**
  * Determines the difference of the `_graphs` index s1 and s2.
- * s1 and s2 *must* belong to Stores that share an `_entityIndex`.
+ * s1 and s2 *must* belong to Stores with aligned entity identifiers.
  *
  * False is returned when there is no difference; this should
  * *not* be set as the value for an index.
@@ -110,17 +113,45 @@ function difference(s1, s2, depth = 4) {
 // ## Constructor
 export class N3EntityIndex {
   constructor(options = {}) {
-    this._id = 1;
+    this._registry = entityRegistry;
+    Object.defineProperty(this, '_id', {
+      enumerable: true,
+      get: () => this._registry._id,
+    });
+    this._ownership = this._registry._createOwnership(this);
+    this._owned = Object.create(null);
+    this._owned[1] = true;
+
     // `_ids` maps entities such as `http://xmlns.com/foaf/0.1/name` to numbers,
     // saving memory by using only numbers as keys in `_graphs`
     this._ids = Object.create(null);
     this._ids[''] = 1;
-     // inverse of `_ids`
-    this._entities = Object.create(null);
-    this._entities[1] = '';
+    this._entities = this._registry._entities;
+    this._cacheSize = 1;
     // `_blankNodeIndex` is the index of the last automatically named blank node
     this._blankNodeIndex = 0;
     this._factory = options.factory || N3DataFactory;
+  }
+
+  _retain(id, value) {
+    if (!this._owned[id]) {
+      this._registry._retain(id, this._ownership);
+      this._owned[id] = true;
+    }
+    if (value !== undefined && this._cacheSize < ENTITY_CACHE_SIZE && this._ids[value] === undefined) {
+      this._ids[value] = id;
+      this._cacheSize++;
+    }
+    return id;
+  }
+
+  _import(entityIndex) {
+    for (const id of entityIndex._ownership)
+      this._retain(id);
+  }
+
+  _owns(value) {
+    return this._owned[this._registry._lookup(value)];
   }
 
   _termFromId(id) {
@@ -145,21 +176,31 @@ export class N3EntityIndex {
           o = this._termToNumericId(term.object);
       let g;
 
-      return s && p && o && (isDefaultGraph(term.graph) || (g = this._termToNumericId(term.graph))) &&
-        this._ids[g ? `.${s}.${p}.${o}.${g}` : `.${s}.${p}.${o}`];
+      if (!(s && p && o && (isDefaultGraph(term.graph) || (g = this._termToNumericId(term.graph)))))
+        return undefined;
+      const value = g ? `.${s}.${p}.${o}.${g}` : `.${s}.${p}.${o}`;
+      return this._ids[value] || this._registry._lookup(value);
     }
-    return this._ids[termToId(term)];
+
+    const value = termToId(term);
+    return this._ids[value] || this._registry._lookup(value);
   }
 
   _termToNewNumericId(term) {
-    // This assumes that no graph term is present - we may wish to error if there is one
-    const str = term && term.termType === 'Quad' ?
-      `.${this._termToNewNumericId(term.subject)}.${this._termToNewNumericId(term.predicate)}.${this._termToNewNumericId(term.object)}${
-        isDefaultGraph(term.graph) ? '' : `.${this._termToNewNumericId(term.graph)}`
-      }`
-      : termToId(term);
+    let value;
+    if (term && term.termType === 'Quad') {
+      const s = this._termToNewNumericId(term.subject),
+          p = this._termToNewNumericId(term.predicate),
+          o = this._termToNewNumericId(term.object),
+          g = isDefaultGraph(term.graph) ? undefined : this._termToNewNumericId(term.graph);
+      value = g ? `.${s}.${p}.${o}.${g}` : `.${s}.${p}.${o}`;
+    }
+    else
+      value = termToId(term);
 
-    return this._ids[str] || (this._ids[this._entities[++this._id] = str] = this._id);
+    if (this._ids[value])
+      return this._ids[value];
+    return this._retain(this._registry._intern(value), value);
   }
 
   createBlankNode(suggestedName) {
@@ -167,17 +208,16 @@ export class N3EntityIndex {
     // Generate a name based on the suggested name
     if (suggestedName) {
       name = suggestedName = `_:${suggestedName}`, index = 1;
-      while (this._ids[name])
+      while (this._owns(name))
         name = suggestedName + index++;
     }
     // Generate a generic blank node name
     else {
       do { name = `_:b${this._blankNodeIndex++}`; }
-      while (this._ids[name]);
+      while (this._owns(name));
     }
     // Add the blank node to the entities, avoiding the generation of duplicates
-    this._ids[name] = ++this._id;
-    this._entities[this._id] = name;
+    this._retain(this._registry._intern(name), name);
     return this._factory.blankNode(name.substr(2));
   }
 }
@@ -195,6 +235,8 @@ export default class N3Store {
       options = quads, quads = null;
     options = options || {};
     this._factory = options.factory || N3DataFactory;
+    if (options.entityIndex && !(options.entityIndex instanceof N3EntityIndex))
+      throw new TypeError('entityIndex must be an EntityIndex');
     this._entityIndex = options.entityIndex || new N3EntityIndex({ factory: this._factory });
     this._entities = this._entityIndex._entities;
     this._termFromId = this._entityIndex._termFromId.bind(this._entityIndex);
@@ -855,8 +897,6 @@ export default class N3Store {
           quad = subjectQuads[i];
           if (!quad.graph.equals(graph))
             malformed = onError(current, 'not confined to single graph');
-          else if (head)
-            malformed = onError(current, 'has non-list arcs out');
 
           // one rdf:first
           else if (quad.predicate.value === namespaces.rdf.first) {
@@ -873,6 +913,9 @@ export default class N3Store {
             else
               toRemove.push(rest = quad);
           }
+
+          else if (head)
+            malformed = onError(current, 'has non-list arcs out');
 
           // alien triple
           else if (objectQuads.length)
@@ -936,8 +979,10 @@ export default class N3Store {
 
     if (Array.isArray(quads))
       this.addQuads(quads);
-    else if (quads instanceof N3Store && quads._entityIndex === this._entityIndex) {
+    else if (quads instanceof N3Store) {
       if (quads._size !== 0) {
+        if (quads._entityIndex !== this._entityIndex)
+          this._entityIndex._import(quads._entityIndex);
         this._graphs = merge(this._graphs, quads._graphs);
         this._size = null; // Invalidate the cached size
       }
@@ -962,7 +1007,7 @@ export default class N3Store {
     if (other === this)
       return true;
 
-    if (!(other instanceof N3Store) || this._entityIndex !== other._entityIndex)
+    if (!(other instanceof N3Store))
       return other.every(quad => this.has(quad));
 
     const g1 = this._graphs, g2 = other._graphs;
@@ -1009,7 +1054,7 @@ export default class N3Store {
     if (other === this)
       return new N3Store({ entityIndex: this._entityIndex });
 
-    if ((other instanceof N3Store) && other._entityIndex === this._entityIndex) {
+    if (other instanceof N3Store) {
       const store = new N3Store({ entityIndex: this._entityIndex });
       const graphs = difference(this._graphs, other._graphs);
       if (graphs) {
@@ -1060,7 +1105,7 @@ export default class N3Store {
       store._size = this._size;
       return store;
     }
-    else if ((other instanceof N3Store) && this._entityIndex === other._entityIndex) {
+    else if (other instanceof N3Store) {
       const store = new N3Store({ entityIndex: this._entityIndex });
       const graphs = intersect(other._graphs, this._graphs);
       if (graphs) {

--- a/test/N3Store-test.js
+++ b/test/N3Store-test.js
@@ -2908,10 +2908,64 @@ describe('shared entity registry', () => {
     const left = new Store([quad(namedNode('s'), namedNode('p'), namedNode('o'))]);
     const right = new Store([quad(namedNode('other'), namedNode('p'), namedNode('o'))]);
 
+    expect(left._entityIndex).toBe(left._entityScope);
+    expect(left._entityScope).not.toBeInstanceOf(EntityIndex);
     expect(left._entityIndex).not.toBe(right._entityIndex);
     expect(left._entityIndex._registry).toBe(right._entityIndex._registry);
     expect(left._entityIndex._termToNumericId(namedNode('p')))
       .toBe(right._entityIndex._termToNumericId(namedNode('p')));
+  });
+
+  it('should isolate empty and entity-sparse result scopes', () => {
+    const nested = quad(namedNode('nested-s'), namedNode('nested-p'), namedNode('nested-o'));
+    const shared = quad(nested, namedNode('outer-p'), namedNode('outer-o'));
+    const extras = Array.from({ length: 10 }, (_, index) =>
+      quad(namedNode(`s${index}`), namedNode(`p${index}`), namedNode(`o${index}`)));
+    const source = new Store([shared, ...extras]);
+    const other = new Store([shared]);
+
+    const sparse = source.intersection(other);
+    expect(sparse.equals(other)).toBe(true);
+    expect(sparse._entityScope).not.toBe(source._entityScope);
+    // The quoted subject and its components must all remain owned.
+    expect(sparse._entityScope._ownership).toHaveLength(6);
+
+    for (const empty of [
+      source.difference(source),
+      source.intersection(new Store([quad(namedNode('x'), namedNode('y'), namedNode('z'))])),
+      source.match(namedNode('missing')).filtered,
+    ]) {
+      expect(empty._entityScope).not.toBe(source._entityScope);
+      expect(empty._entityScope._ownership).toHaveLength(0);
+    }
+  });
+
+  it('should share dense result scopes and selectively retain imported graphs', () => {
+    const entityIndex = new EntityIndex();
+    const shared = quad(namedNode('s'), namedNode('p'), namedNode('o'));
+    const source = new Store([shared], { entityIndex });
+
+    expect(source.intersection(source)._entityScope).toBe(entityIndex);
+
+    // Pollute the compatibility scope without adding those entities to source.
+    const unrelated = new Store(Array.from({ length: 10 }, (_, index) =>
+      quad(namedNode(`other-s${index}`), namedNode(`other-p${index}`), namedNode(`other-o${index}`))),
+    { entityIndex });
+    const target = new Store();
+    target.addAll(source);
+
+    expect(unrelated.size).toBe(10);
+    expect(target._entityScope._ownership).toHaveLength(3);
+    expect(target._entityScope._ownership.length).toBeLessThan(entityIndex._ownership.length);
+    expect(source.union(new Store())._entityScope).not.toBe(entityIndex);
+    expect(source.match().filtered._entityScope).not.toBe(entityIndex);
+  });
+
+  it('should give enumerated filter and map results independent scopes', () => {
+    const source = new Store([quad(namedNode('s'), namedNode('p'), namedNode('o'))]);
+
+    expect(source.filter(() => true)._entityScope).not.toBe(source._entityScope);
+    expect(source.map(value => value)._entityScope).not.toBe(source._entityScope);
   });
 
   it('should always bind entity indices to the module registry', () => {

--- a/test/N3Store-test.js
+++ b/test/N3Store-test.js
@@ -2991,19 +2991,24 @@ describe('shared entity registry', () => {
       await new Promise(resolve => setImmediate(resolve));
       expect(registry._lookup('shared')).toBeUndefined();
       expect(registry._entities[leftId]).toBeUndefined();
-      expect(registry._freeIds).toEqual([leftId]);
+      expect(registry._references[leftId]).toBeUndefined();
+      expect(registry._freeIds).toBeUndefined();
+      const replacement = registry._createOwnership({});
+      expect(retain(registry, replacement, 'replacement')).toBe(leftId + 1);
     });
   });
 
-  it('should recycle released identifiers', async () => {
+  it('should recycle released identifiers after wrapping and skip live identifiers', async () => {
     await withFinalizationRegistry(async (ownerships, finalize) => {
       const registry = new EntityRegistry();
-      const released = registry._createOwnership({});
       const retained = registry._createOwnership({});
-      const releasedId = retain(registry, released, 'released');
+      const released = registry._createOwnership({});
+      registry._maxId = 4;
       const retainedId = retain(registry, retained, 'retained');
+      const releasedId = retain(registry, released, 'released');
+      const otherRetainedId = retain(registry, retained, 'other-retained');
 
-      finalize(ownerships[0]);
+      finalize(ownerships[1]);
       await new Promise(resolve => setImmediate(resolve));
       const replacement = registry._createOwnership({});
       const replacementId = retain(registry, replacement, 'replacement');
@@ -3012,6 +3017,8 @@ describe('shared entity registry', () => {
       expect(registry._lookup('released')).toBeUndefined();
       expect(registry._lookup('replacement')).toBe(releasedId);
       expect(registry._lookup('retained')).toBe(retainedId);
+      expect(registry._lookup('other-retained')).toBe(otherRetainedId);
+      expect(() => registry._intern('overflow')).toThrow('Entity identifier limit exceeded');
     });
   });
 
@@ -3025,12 +3032,12 @@ describe('shared entity registry', () => {
       finalize(ownerships[0]);
       await new Promise(resolve => setImmediate(resolve));
 
-      expect(registry._freeIds).toHaveLength(4096);
+      expect(registry._ids.size).toBe(2);
       expect(registry._pendingReleases).toHaveLength(1);
 
       await new Promise(resolve => setImmediate(resolve));
 
-      expect(registry._freeIds).toHaveLength(4097);
+      expect(registry._ids.size).toBe(1);
       expect(registry._pendingReleases).toHaveLength(0);
     });
   });
@@ -3049,7 +3056,7 @@ describe('shared entity registry', () => {
       expect(registry._pendingReleases).toHaveLength(2);
       await new Promise(resolve => setImmediate(resolve));
       expect(registry._pendingReleases).toHaveLength(0);
-      expect(registry._freeIds).toHaveLength(2);
+      expect(registry._ids.size).toBe(1);
     });
   });
 
@@ -3067,18 +3074,18 @@ describe('shared entity registry', () => {
 
       expect(registry._lookup('shared')).toBe(id);
       expect(registry._references[id]).toBe(1);
-      expect(registry._freeIds).toHaveLength(0);
+      expect(registry._ids.size).toBe(2);
     });
   });
 
   it('should reject allocation after exhausting safe integer identifiers', () => {
     const registry = new EntityRegistry();
-    registry._id = Number.MAX_SAFE_INTEGER;
+    const ownership = registry._createOwnership({});
+    registry._maxId = 3;
+    retain(registry, ownership, 'second');
+    retain(registry, ownership, 'third');
 
     expect(() => registry._intern('overflow')).toThrow('Entity identifier limit exceeded');
-
-    registry._freeIds.push(2);
-    expect(registry._intern('recycled')).toBe(2);
   });
 
   it('should align equal terms in separate entity indices', () => {

--- a/test/N3Store-test.js
+++ b/test/N3Store-test.js
@@ -2973,7 +2973,7 @@ describe('shared entity registry', () => {
     expect(new EntityIndex({ registry: {} })._registry).toBe(entityRegistry);
   });
 
-  it('should release identifiers after all owning indices are finalized', async () => {
+  it('should release identifiers and reset after all owning scopes are finalized', async () => {
     await withFinalizationRegistry(async (ownerships, finalize) => {
       const registry = new EntityRegistry();
       const left = registry._createOwnership({});
@@ -2981,20 +2981,48 @@ describe('shared entity registry', () => {
       const leftId = retain(registry, left, 'shared');
       const rightId = retain(registry, right, 'shared');
 
+      expect(registry._activeScopes).toBe(2);
       expect(rightId).toBe(leftId);
       expect(registry._references[leftId]).toBe(2);
       finalize(ownerships[0]);
       await new Promise(resolve => setImmediate(resolve));
+      expect(registry._activeScopes).toBe(1);
       expect(registry._references[leftId]).toBe(1);
       expect(registry._lookup('shared')).toBe(leftId);
+      registry._id = registry._maxId;
+      registry._wrapped = true;
       finalize(ownerships[1]);
-      await new Promise(resolve => setImmediate(resolve));
+      expect(registry._activeScopes).toBe(0);
       expect(registry._lookup('shared')).toBeUndefined();
       expect(registry._entities[leftId]).toBeUndefined();
       expect(registry._references[leftId]).toBeUndefined();
       expect(registry._freeIds).toBeUndefined();
+      expect(registry._id).toBe(1);
+      expect(registry._wrapped).toBe(false);
       const replacement = registry._createOwnership({});
-      expect(retain(registry, replacement, 'replacement')).toBe(leftId + 1);
+      expect(retain(registry, replacement, 'replacement')).toBe(leftId);
+    });
+  });
+
+  it('should not let a scheduled release affect a scope created after reset', async () => {
+    await withFinalizationRegistry(async (ownerships, finalize) => {
+      const registry = new EntityRegistry();
+      const first = registry._createOwnership({});
+      const second = registry._createOwnership({});
+      retain(registry, first, 'first');
+      retain(registry, second, 'second');
+
+      finalize(ownerships[0]);
+      expect(registry._pendingReleases).toHaveLength(1);
+      finalize(ownerships[1]);
+      expect(registry._pendingReleases).toHaveLength(0);
+
+      const replacement = registry._createOwnership({});
+      const replacementId = retain(registry, replacement, 'replacement');
+      await new Promise(resolve => setImmediate(resolve));
+
+      expect(registry._lookup('replacement')).toBe(replacementId);
+      expect(registry._references[replacementId]).toBe(1);
     });
   });
 
@@ -3025,19 +3053,21 @@ describe('shared entity registry', () => {
   it('should release identifiers in bounded batches', async () => {
     await withFinalizationRegistry(async (ownerships, finalize) => {
       const registry = new EntityRegistry();
+      const retained = registry._createOwnership({});
       const ownership = registry._createOwnership({});
+      retain(registry, retained, 'retained');
       for (let id = 0; id < 4097; id++)
         retain(registry, ownership, `entity${id}`);
 
-      finalize(ownerships[0]);
+      finalize(ownerships[1]);
       await new Promise(resolve => setImmediate(resolve));
 
-      expect(registry._ids.size).toBe(2);
+      expect(registry._ids.size).toBe(3);
       expect(registry._pendingReleases).toHaveLength(1);
 
       await new Promise(resolve => setImmediate(resolve));
 
-      expect(registry._ids.size).toBe(1);
+      expect(registry._ids.size).toBe(2);
       expect(registry._pendingReleases).toHaveLength(0);
     });
   });
@@ -3047,8 +3077,10 @@ describe('shared entity registry', () => {
       const registry = new EntityRegistry();
       const first = registry._createOwnership({});
       const second = registry._createOwnership({});
+      const retained = registry._createOwnership({});
       retain(registry, first, 'first');
       retain(registry, second, 'second');
+      retain(registry, retained, 'retained');
 
       finalize(ownerships[0]);
       finalize(ownerships[1]);
@@ -3056,7 +3088,7 @@ describe('shared entity registry', () => {
       expect(registry._pendingReleases).toHaveLength(2);
       await new Promise(resolve => setImmediate(resolve));
       expect(registry._pendingReleases).toHaveLength(0);
-      expect(registry._ids.size).toBe(1);
+      expect(registry._ids.size).toBe(2);
     });
   });
 
@@ -3064,10 +3096,10 @@ describe('shared entity registry', () => {
     await withFinalizationRegistry(async (ownerships, finalize) => {
       const registry = new EntityRegistry();
       const finalized = registry._createOwnership({});
+      const retained = registry._createOwnership({});
       const id = retain(registry, finalized, 'shared');
 
       finalize(ownerships[0]);
-      const retained = registry._createOwnership({});
       expect(retain(registry, retained, 'shared')).toBe(id);
 
       await new Promise(resolve => setImmediate(resolve));

--- a/test/N3Store-test.js
+++ b/test/N3Store-test.js
@@ -1,10 +1,11 @@
 import { makeRng, pick } from './util';
-import {
+import N3, {
   Store,
   termFromId, termToId,
   EntityIndex,
   DataFactory,
 } from '../src';
+import EntityRegistry, { entityRegistry } from '../src/N3EntityRegistry';
 import {
   NamedNode,
   Literal,
@@ -2236,26 +2237,34 @@ describe('Store', () => {
     );
   });
 
-  const matrix = [true, false, 'instantiated'].flatMap(match => [true, false].map(share => [match, share]));
+  const matrix = [true, false, 'instantiated'].flatMap(match =>
+    ['default', 'compatibility-shared', 'compatibility-separate'].map(sharing => [match, sharing]));
 
-  describe.each(matrix)('RDF/JS Dataset Methods [DatasetCoreAndReadableStream: %s] [sharedIndex: %s]', (match, shareIndex) => {
-    let q, store, store1, store2, store3, store4, storeg, storeb, empty, options;
+  describe.each(matrix)('RDF/JS Dataset Methods [DatasetCoreAndReadableStream: %s] [identifiers: %s]', (match, sharing) => {
+    let q, store, store1, store2, store3, store4, storeg, storeb, empty, createOptions;
 
     beforeEach(() => {
-      options = shareIndex ? { entityIndex: new EntityIndex() } : {};
+      if (sharing === 'compatibility-shared') {
+        const entityIndex = new EntityIndex();
+        createOptions = () => ({ entityIndex });
+      }
+      else if (sharing === 'compatibility-separate')
+        createOptions = () => ({ entityIndex: new EntityIndex() });
+      else
+        createOptions = () => ({});
       q = [new Quad(new NamedNode('s1'), new NamedNode('p1'), new NamedNode('o1')),
         new Quad(new NamedNode('s1'), new NamedNode('p1'), new NamedNode('o2')),
         new Quad(new NamedNode('s2'), new NamedNode('p2'), new NamedNode('o3')),
         new Quad(new NamedNode('s1'), new NamedNode('p2'), new NamedNode('o3'))];
       q = [...q, ...q.map(quad => new Quad(quad.subject, quad.predicate, quad.object, new NamedNode('c4')))];
-      empty = new Store([], options);
-      store = new Store([q[0]], options);
-      storeg = new Store([q[4]], options);
-      storeb = new Store([q[0], q[4]], options);
-      store1 = new Store([q[0], q[1]], options);
-      store2 = new Store([q[0], q[2]], options);
-      store3 = new Store([q[0], q[3]], options);
-      store4 = new Store([new Quad(new NamedNode('a'), new NamedNode('b'), new NamedNode('c'))], options);
+      empty = new Store([], createOptions());
+      store = new Store([q[0]], createOptions());
+      storeg = new Store([q[4]], createOptions());
+      storeb = new Store([q[0], q[4]], createOptions());
+      store1 = new Store([q[0], q[1]], createOptions());
+      store2 = new Store([q[0], q[2]], createOptions());
+      store3 = new Store([q[0], q[3]], createOptions());
+      store4 = new Store([new Quad(new NamedNode('a'), new NamedNode('b'), new NamedNode('c'))], createOptions());
 
       if (match) {
         empty = store2.match(new NamedNode('sn'));
@@ -2608,39 +2617,66 @@ describe('EntityIndex', () => {
     expect(entityIndex).toBeInstanceOf(EntityIndex);
   });
 
-  it('custom index should be used when instantiated with store', () => {
-    const index = {
-      '': 1,
-      's1': 2,
-      'p1': 3,
-      'o0': 4,
-      's2': 5,
-      'p2': 6,
-      'o2': 7,
-    };
+  it('should reject a non-EntityIndex store option', () => {
+    expect(() => new Store({ entityIndex: {} })).toThrow('entityIndex must be an EntityIndex');
+  });
 
+  it('custom index should be used when instantiated with store', () => {
     const store = new Store([
       new Quad(new NamedNode('s1'), new NamedNode('p1'), new NamedNode('o0')),
     ], { entityIndex });
     expect(store.size).toBe(1);
-    expect(entityIndex._id).toEqual(4);
+    expect(store._entityIndex).toBe(entityIndex);
 
     const substore = store.match();
     substore.add(new Quad(new NamedNode('s2'), new NamedNode('p2'), new NamedNode('o2')));
     expect(store.size).toBe(1);
     expect(substore.size).toBe(2);
-    expect(entityIndex._id).toEqual(7);
-    expect(entityIndex._ids).toEqual(index);
+    expect(substore.filtered._entityIndex).toBe(entityIndex);
 
     const store2 = new Store([
       new Quad(new NamedNode('s1'), new NamedNode('p1'), new NamedNode('o5')),
     ], { entityIndex });
     expect(store2.size).toBe(1);
-    expect(entityIndex._id).toEqual(8);
-    expect(entityIndex._ids).toEqual({
-      ...index,
-      o5: 8,
-    });
+    expect(store2._entityIndex).toBe(entityIndex);
+    for (const value of ['', 's1', 'p1', 'o0', 's2', 'p2', 'o2', 'o5'])
+      expect(entityIndex._ids[value]).toBe(entityRegistry._lookup(value));
+  });
+
+  it('should index and query nested terms', () => {
+    const tripleTerm = quad(namedNode('s'), namedNode('p'), namedNode('o'));
+    const graphTerm = quad(namedNode('s'), namedNode('p'), namedNode('o'), namedNode('g'));
+    const tripleId = entityIndex._termToNewNumericId(tripleTerm);
+    const graphId = entityIndex._termToNewNumericId(graphTerm);
+
+    expect(entityIndex._termToNewNumericId(null)).toBe(1);
+    expect(entityIndex._termToNumericId(quad(namedNode('s'), namedNode('p'), namedNode('o'))))
+      .toBe(tripleId);
+    expect(entityIndex._termToNumericId(
+      quad(namedNode('s'), namedNode('p'), namedNode('o'), namedNode('g')),
+    )).toBe(graphId);
+    expect(entityIndex._termToNumericId(
+      quad(namedNode('missing'), namedNode('p'), namedNode('o')),
+    )).toBeUndefined();
+    expect(entityIndex._termToNumericId(
+      quad(namedNode('s'), namedNode('missing'), namedNode('o')),
+    )).toBeUndefined();
+    expect(entityIndex._termToNumericId(
+      quad(namedNode('s'), namedNode('p'), namedNode('missing')),
+    )).toBeUndefined();
+    expect(entityIndex._termToNumericId(
+      quad(namedNode('s'), namedNode('p'), namedNode('o'), namedNode('missing')),
+    )).toBeUndefined();
+  });
+
+  it('should allocate blank nodes and reject missing predicate queries', () => {
+    expect(entityIndex.createBlankNode().value).toBe('b0');
+    expect(entityIndex.createBlankNode('b0').value).toBe('b01');
+
+    const store = new Store([quad(namedNode('s'), namedNode('p'), namedNode('o'))], { entityIndex });
+    const callback = jest.fn();
+    store.forPredicates(callback, namedNode('missing'));
+    expect(callback).not.toHaveBeenCalled();
   });
 });
 
@@ -2820,6 +2856,297 @@ describe('Store under randomized mutation', () => {
       expectConsistentCounters(store);
     });
   }
+});
+
+describe('shared entity registry', () => {
+  function retain(registry, ownership, value) {
+    const id = registry._intern(value);
+    registry._retain(id, ownership);
+    return id;
+  }
+
+  async function withFinalizationRegistry(callback) {
+    const implementation = global.FinalizationRegistry;
+    const ownerships = [];
+    let finalize;
+    try {
+      global.FinalizationRegistry = class FinalizationRegistry {
+        constructor(callback) {
+          finalize = callback;
+        }
+        register(_target, ownership) {
+          ownerships.push(ownership);
+        }
+      };
+      await callback(ownerships, ownership => finalize(ownership));
+    }
+    finally {
+      global.FinalizationRegistry = implementation;
+    }
+  }
+
+  it('should keep the registry out of the public API', () => {
+    expect(N3.EntityRegistry).toBeUndefined();
+  });
+
+  it('should construct the internal registry', () => {
+    expect(new EntityRegistry()).toBeInstanceOf(EntityRegistry);
+  });
+
+  it('should require FinalizationRegistry support', () => {
+    const implementation = global.FinalizationRegistry;
+    try {
+      global.FinalizationRegistry = undefined;
+      expect(() => new EntityRegistry()).toThrow('EntityRegistry requires FinalizationRegistry support');
+    }
+    finally {
+      global.FinalizationRegistry = implementation;
+    }
+  });
+
+  it('should share identifiers between stores by default', () => {
+    const left = new Store([quad(namedNode('s'), namedNode('p'), namedNode('o'))]);
+    const right = new Store([quad(namedNode('other'), namedNode('p'), namedNode('o'))]);
+
+    expect(left._entityIndex).not.toBe(right._entityIndex);
+    expect(left._entityIndex._registry).toBe(right._entityIndex._registry);
+    expect(left._entityIndex._termToNumericId(namedNode('p')))
+      .toBe(right._entityIndex._termToNumericId(namedNode('p')));
+  });
+
+  it('should always bind entity indices to the module registry', () => {
+    expect(new EntityIndex()._registry).toBe(entityRegistry);
+    expect(new EntityIndex({ registry: {} })._registry).toBe(entityRegistry);
+  });
+
+  it('should release identifiers after all owning indices are finalized', async () => {
+    await withFinalizationRegistry(async (ownerships, finalize) => {
+      const registry = new EntityRegistry();
+      const left = registry._createOwnership({});
+      const right = registry._createOwnership({});
+      const leftId = retain(registry, left, 'shared');
+      const rightId = retain(registry, right, 'shared');
+
+      expect(rightId).toBe(leftId);
+      expect(registry._references[leftId]).toBe(2);
+      finalize(ownerships[0]);
+      await new Promise(resolve => setImmediate(resolve));
+      expect(registry._references[leftId]).toBe(1);
+      expect(registry._lookup('shared')).toBe(leftId);
+      finalize(ownerships[1]);
+      await new Promise(resolve => setImmediate(resolve));
+      expect(registry._lookup('shared')).toBeUndefined();
+      expect(registry._entities[leftId]).toBeUndefined();
+      expect(registry._freeIds).toEqual([leftId]);
+    });
+  });
+
+  it('should recycle released identifiers', async () => {
+    await withFinalizationRegistry(async (ownerships, finalize) => {
+      const registry = new EntityRegistry();
+      const released = registry._createOwnership({});
+      const retained = registry._createOwnership({});
+      const releasedId = retain(registry, released, 'released');
+      const retainedId = retain(registry, retained, 'retained');
+
+      finalize(ownerships[0]);
+      await new Promise(resolve => setImmediate(resolve));
+      const replacement = registry._createOwnership({});
+      const replacementId = retain(registry, replacement, 'replacement');
+
+      expect(replacementId).toBe(releasedId);
+      expect(registry._lookup('released')).toBeUndefined();
+      expect(registry._lookup('replacement')).toBe(releasedId);
+      expect(registry._lookup('retained')).toBe(retainedId);
+    });
+  });
+
+  it('should release identifiers in bounded batches', async () => {
+    await withFinalizationRegistry(async (ownerships, finalize) => {
+      const registry = new EntityRegistry();
+      const ownership = registry._createOwnership({});
+      for (let id = 0; id < 4097; id++)
+        retain(registry, ownership, `entity${id}`);
+
+      finalize(ownerships[0]);
+      await new Promise(resolve => setImmediate(resolve));
+
+      expect(registry._freeIds).toHaveLength(4096);
+      expect(registry._pendingReleases).toHaveLength(1);
+
+      await new Promise(resolve => setImmediate(resolve));
+
+      expect(registry._freeIds).toHaveLength(4097);
+      expect(registry._pendingReleases).toHaveLength(0);
+    });
+  });
+
+  it('should coalesce releases scheduled in the same turn', async () => {
+    await withFinalizationRegistry(async (ownerships, finalize) => {
+      const registry = new EntityRegistry();
+      const first = registry._createOwnership({});
+      const second = registry._createOwnership({});
+      retain(registry, first, 'first');
+      retain(registry, second, 'second');
+
+      finalize(ownerships[0]);
+      finalize(ownerships[1]);
+
+      expect(registry._pendingReleases).toHaveLength(2);
+      await new Promise(resolve => setImmediate(resolve));
+      expect(registry._pendingReleases).toHaveLength(0);
+      expect(registry._freeIds).toHaveLength(2);
+    });
+  });
+
+  it('should retain an identifier reacquired before its release batch runs', async () => {
+    await withFinalizationRegistry(async (ownerships, finalize) => {
+      const registry = new EntityRegistry();
+      const finalized = registry._createOwnership({});
+      const id = retain(registry, finalized, 'shared');
+
+      finalize(ownerships[0]);
+      const retained = registry._createOwnership({});
+      expect(retain(registry, retained, 'shared')).toBe(id);
+
+      await new Promise(resolve => setImmediate(resolve));
+
+      expect(registry._lookup('shared')).toBe(id);
+      expect(registry._references[id]).toBe(1);
+      expect(registry._freeIds).toHaveLength(0);
+    });
+  });
+
+  it('should reject allocation after exhausting safe integer identifiers', () => {
+    const registry = new EntityRegistry();
+    registry._id = Number.MAX_SAFE_INTEGER;
+
+    expect(() => registry._intern('overflow')).toThrow('Entity identifier limit exceeded');
+
+    registry._freeIds.push(2);
+    expect(registry._intern('recycled')).toBe(2);
+  });
+
+  it('should align equal terms in separate entity indices', () => {
+    const leftQuad = quad(quad(namedNode('s'), namedNode('p'), namedNode('o')), namedNode('p2'), namedNode('o2'));
+    const rightQuad = quad(quad(namedNode('s'), namedNode('p'), namedNode('o')), namedNode('p2'), namedNode('o2'));
+    const left = new Store([leftQuad]);
+    const right = new Store([rightQuad]);
+
+    expect(left._entityIndex).not.toBe(right._entityIndex);
+    expect(left._entityIndex._id).toBe(right._entityIndex._id);
+    expect(left._entityIndex._termToNumericId(leftQuad.subject))
+      .toBe(right._entityIndex._termToNumericId(rightQuad.subject));
+    expect(left._entityIndex._termToNumericId(
+      quad(namedNode('s'), namedNode('p'), namedNode('o')),
+    )).toBe(left._entityIndex._termToNumericId(leftQuad.subject));
+    expect(left._entityIndex._termToNumericId(
+      quad(namedNode('missing'), namedNode('p'), namedNode('o')),
+    )).toBeUndefined();
+    expect(left._entityIndex._termToNumericId(
+      quad(namedNode('s'), namedNode('missing'), namedNode('o')),
+    )).toBeUndefined();
+    expect(left._entityIndex._termToNumericId(
+      quad(namedNode('s'), namedNode('p'), namedNode('missing')),
+    )).toBeUndefined();
+    expect(left._entityIndex._termToNumericId(
+      quad(namedNode('s'), namedNode('p'), namedNode('o2')),
+    )).toBeUndefined();
+    const registryOnlyTerm = quad(namedNode('s'), namedNode('p'), namedNode('o2'));
+    const registryOnlyId = right._entityIndex._termToNewNumericId(registryOnlyTerm);
+    expect(left._entityIndex._termToNumericId(
+      quad(namedNode('s'), namedNode('p'), namedNode('o2')),
+    )).toBe(registryOnlyId);
+    const graphTerm = quad(namedNode('s'), namedNode('p'), namedNode('o'), namedNode('g'));
+    const graphTermId = left._entityIndex._termToNewNumericId(graphTerm);
+    expect(left._entityIndex._termToNumericId(
+      quad(namedNode('s'), namedNode('p'), namedNode('o'), namedNode('g')),
+    )).toBe(graphTermId);
+    expect(left._entityIndex._termToNumericId(
+      quad(namedNode('s'), namedNode('p'), namedNode('o'), namedNode('missing')),
+    )).toBeUndefined();
+    expect(left.contains(right)).toBe(true);
+    expect(left.intersection(right).equals(left)).toBe(true);
+  });
+
+  it('should preserve set-operation correctness across compatibility entity indices', () => {
+    const sharedQuad = quad(namedNode('s'), namedNode('p'), namedNode('o'));
+    const extraQuad = quad(namedNode('extra-s'), namedNode('extra-p'), namedNode('extra-o'));
+    const left = new Store([extraQuad, sharedQuad], { entityIndex: new EntityIndex() });
+    const right = new Store([sharedQuad], { entityIndex: new EntityIndex() });
+
+    expect(left._entityIndex._registry).toBe(entityRegistry);
+    expect(right._entityIndex._registry).toBe(entityRegistry);
+    expect(left._entityIndex._termToNumericId(sharedQuad.subject))
+      .toBe(right._entityIndex._termToNumericId(sharedQuad.subject));
+    expect(left.contains(right)).toBe(true);
+    expect(left.intersection(right).equals(right)).toBe(true);
+    expect(left.difference(right).equals(new Store([extraQuad]))).toBe(true);
+  });
+
+  it('should preserve generic DatasetCore fallbacks', () => {
+    const sharedQuad = quad(namedNode('s'), namedNode('p'), namedNode('o'));
+    const extraQuad = quad(namedNode('extra-s'), namedNode('extra-p'), namedNode('extra-o'));
+    const quads = [sharedQuad];
+    const dataset = {
+      *[Symbol.iterator]() {
+        yield* quads;
+      },
+      every: callback => quads.every(callback),
+      has: value => quads.some(quad => quad.equals(value)),
+    };
+    const source = new Store([sharedQuad, extraQuad]);
+    const target = new Store();
+
+    target.addAll(dataset);
+
+    expect(target.equals(new Store(quads))).toBe(true);
+    expect(source.contains(dataset)).toBe(true);
+    expect(source.difference(dataset).equals(new Store([extraQuad]))).toBe(true);
+    expect(source.intersection(dataset).equals(new Store(quads))).toBe(true);
+  });
+
+  it('should extract lists independently of globally assigned predicate order', () => {
+    const seed = new Store([quad(namedNode('seed'), namedNode('p'), namedNode('value'))], {
+      entityIndex: new EntityIndex(),
+    });
+    const store = new Store([], { entityIndex: new EntityIndex() });
+    const [head] = addList(store, namedNode('item'));
+    store.addQuad(head, namedNode('p'), namedNode('value'));
+
+    expect(seed.size).toBe(1);
+    expect(store.extractLists()).toEqual({ b0: [namedNode('item')] });
+  });
+
+  it('should retain imported entities in the target factory', () => {
+    const sourceQuad = quad(namedNode('s'), namedNode('p'), namedNode('o'));
+    const source = new Store([sourceQuad]);
+    const factory = {
+      ...DataFactory,
+      namedNode: jest.fn(DataFactory.namedNode),
+      quad: jest.fn(DataFactory.quad),
+    };
+    const target = new Store([], { factory });
+
+    target.addAll(source);
+
+    expect(target.getQuads()).toEqual([sourceQuad]);
+    expect(factory.namedNode).toHaveBeenCalledTimes(3);
+    expect(factory.quad).toHaveBeenCalledTimes(1);
+  });
+
+  it('should keep blank node allocation local to each entity index', () => {
+    const left = new Store();
+    const right = new Store();
+
+    const leftBlank = left.createBlankNode();
+    const rightBlank = right.createBlankNode();
+
+    expect(leftBlank.value).toBe('b0');
+    expect(rightBlank.value).toBe('b0');
+    expect(left._entityIndex._termToNumericId(leftBlank))
+      .toBe(right._entityIndex._termToNumericId(rightBlank));
+  });
 });
 
 function alwaysTrue()  { return true;  }

--- a/test/browser-bundle-support.js
+++ b/test/browser-bundle-support.js
@@ -12,6 +12,7 @@ export function expectBrowserBundleMembers(N3) {
   expect(N3).toBeDefined();
   for (const name of browserBundleMembers)
     expect(N3[name]).toBeDefined();
+  expect(N3.EntityRegistry).toBeUndefined();
 }
 
 export function expectBrowserBundleParser(N3) {


### PR DESCRIPTION
## Summary

- give all stores and `EntityIndex` instances from the same evaluated N3.js module one internal numeric identifier registry
- separate that global identifier namespace from store-local ownership by introducing an internal entity scope
- keep `EntityIndex`, the `entityIndex` store option, and the private `_entityIndex` field as deprecated compatibility facades
- make default stores use internal scopes rather than public `EntityIndex` instances
- retain only graph-referenced identifiers when importing another store
- give `filter` and `map` independent scopes containing only their output entities
- adaptively select scopes for direct-index `match`, `intersection`, `difference`, and `union` results: entity-sparse and empty results get narrow scopes, while entity-dense results reuse the source scope
- retain factories, blank-node allocation, bounded hot caches, and identifier ownership locally rather than placing them in the global registry
- release registry entries through one `FinalizationRegistry` registration per scope, resetting the tables directly when the final scope is collected and otherwise processing at most 4,096 identifiers per event-loop turn
- avoid retaining released IDs in a free list; allocate monotonically to the safe-integer ceiling, then wrap to ID 2 and scan for an unused slot
- keep the previous isolated implementation only as a benchmark fixture
- make `extractLists` independent of globally assigned predicate order

This supersedes the cross-index remapping approach in #601 for ordinary stores. Same-module stores now always have aligned identifiers and can take the direct set-operation paths. Generic RDF/JS datasets retain the existing per-quad fallbacks.

## Registry and scope model

There is one internal registry per evaluated N3.js module, because splitting registries would make numeric identifiers incomparable and reintroduce remapping. A scope is different: it records which registry identifiers must stay alive for a store or related group of stores.

The registry counts scopes whose finalization callbacks have not yet run. When that count reaches zero, it replaces the entity, identifier, and reference tables and restarts allocation at ID 2 instead of walking every released identifier. The count is conservative when finalization is delayed, so delayed callbacks can only postpone this optimization; they cannot reset a registry that still has a live scope. Any release task queued before the reset observes the cleared queue safely.

Scope selection is based on distinct referenced entities, not quad count:

- empty direct-index results receive an empty scope and therefore pin no source entities
- results using fewer than half of their source scope's owned entities receive a new scope containing only the result's identifiers
- results using at least half reuse the source scope, avoiding a complete extra result scan and duplicate reference bookkeeping
- RDF-star quoted terms retain both the composite identifier and every component identifier
- `filter` and `map` already enumerate their output, so they always build a narrow independent scope at no additional traversal cost
- `addAll` retains only entities present in the imported graph, not unrelated entities that happen to share its compatibility scope

The result deliberately does not borrow the right-hand operand's scope. A scope also carries term-factory and blank-node allocation state, so doing that could silently change left-hand result semantics. If those concerns are separated from ownership in a future refactor, choosing the smaller compatible operand scope could become another optimization.

## Compatibility and review points

This is intentionally a draft and should be treated as semver-major:

- the Node.js engine floor moves from 12 to 18 because the registry depends on `FinalizationRegistry`
- numeric IDs, and therefore otherwise unspecified iteration order, can differ from previous releases
- `EntityIndex` remains exported and accepted during a deprecation cycle; existing callers that share one across stores continue to work
- arbitrary custom objects passed as `entityIndex` are now rejected because they could violate the aligned-ID invariant
- the registry is internal and cannot be configured or isolated
- separately evaluated N3.js module copies have separate registries, so different package versions never share private encodings
- ID `1` remains reserved for the default graph; IDs `2` through `Number.MAX_SAFE_INTEGER` are available, allowing 9,007,199,254,740,990 simultaneously retained entity identifiers before an explicit `RangeError`

Released IDs are removed from the registry without being retained in a free-ID array. They become allocation candidates after the cursor reaches the safe-integer ceiling and wraps to ID 2. The ceiling therefore applies to identifiers retained at the same time; available memory imposes a much lower practical limit.

A public custom-registry option is deliberately omitted. It can be added later if a concrete isolation requirement appears, without carrying that complexity in the initial design.

## Public usage audit

An exact public GitHub search for `N3.EntityIndex` found one genuine external consumer: [`lblod/vendor-data-distribution-service`](https://github.com/lblod/vendor-data-distribution-service/blob/ee5e36569ecbf900273175f06b34e53a2a950fbb/util/data-manager.js#L381). It shares an `EntityIndex` across related stores, which remains supported; its eventual migration is simply to remove the explicit index and options.

Some projects directly access underscore-prefixed store/index fields. Those private integrations can be affected by the new numeric-ID lifecycle, but no public consumer requiring isolated entity registries was found. This audit covers indexed public GitHub repositories, not private or unindexed code.

## Performance

Reproduce the insertion, set-operation, scope-selection, and matched garbage-collection comparison with:

    node --expose-gc perf/N3EntityRegistry-perf.js 50000 11 500000

Medians from interleaved runs on Node 25.1.0 / Apple M1 (GC timings are environment-sensitive):

| scenario | isolated legacy indices | internal global registry | change |
|---|---:|---:|---:|
| low-cardinality insertion | 86.98 ms | 89.11 ms | +2.4% |
| high-cardinality insertion | 153.79 ms | 165.51 ms | +7.6% |
| equal-size intersection | 151.06 ms | 112.72 ms | 25.4% faster |
| intersection with a 1%-sized store | 116.00 ms | 6.20 ms | 18.7x faster |

The same run reports the scope decision directly:

| result | identifiers owned | shares the 60,031-ID source scope |
|---|---:|---:|
| dense intersection | 60,031 | yes |
| sparse 1% intersection | 1,031 | no |
| empty difference | 0 | no |

Each teardown sample runs in a disposable worker realm so it starts with a fresh module-scoped registry. It creates a store containing 500,002 unique identifiers, drops it, forces collection and finalization, then forces collection again. Because the collected store owns the final registered scope, the registry discards its tables directly; if another scope remains live, cleanup still uses bounded 4,096-ID batches:

| garbage-collection phase | isolated legacy index | internal global registry |
|---|---:|---:|
| allocation heap delta | 526.70 MiB | 489.36 MiB |
| first forced GC | 14.37 ms | 31.04 ms |
| finalizer cleanup | 2.32 ms | 1.17 ms |
| second forced GC | 2.03 ms | 13.91 ms |
| total teardown | 19.14 ms | 46.34 ms |
| longest cleanup batch | n/a | n/a |
| retained heap after second GC | 0.031 MiB | 0.036 MiB |

Compared with the preceding incremental-only implementation on the same workload, the zero-scope reset reduces measured registry cleanup from 79.20 ms to 1.17 ms and total teardown from 113.68 ms to 46.34 ms. Resetting the table references is constant-time registry work; reclaiming those tables remains ordinary garbage-collector work. When any registered scope survives, reference-count cleanup remains O(n) but is spread over bounded turns. Removing the free-ID pool also keeps retained registry heap near zero after the second collection.

A separate 200k-quad high-cardinality heap measurement was about +6.7% (1,607 to 1,715 bytes/quad). A forced-GC lifetime check over 20 stores and 300,000 distinct entities reduced the registry mappings to the single default-graph entry after the stores were collected. Focused allocator tests confirm that IDs remain monotonic before the ceiling, wrap to ID 2, skip live slots, reuse released slots, and throw after a fully occupied cycle.

These results support strong reference-counted entries plus one finalizer registration per scope rather than a `WeakRef` and finalizer registration per entity. The registry is not zero-cost; the draft keeps the trade-off measurable and reviewable.

## Verification

- 6,967 Jest tests with 100% statements, branches, functions, and lines
- ESLint
- Node and browser builds
- IIFE and ESM bundles in Chromium, Firefox, and WebKit
- zero-scope table reset, stale scheduled-drain safety, deterministic reference-count cleanup with surviving scopes, bounded/coalesced releases, reacquisition-before-release safety, monotonic and wrapping allocation, live-slot skipping, safe-integer exhaustion, RDF-star identifiers, sparse/dense/empty scope decisions, selective imports, predicate-order behavior, compatibility-facade behavior, and generic DatasetCore fallbacks
- fresh-worker teardown and scope-selection benchmarks plus public API export checks
