### PR TITLE
Use slice in lexer hot paths

### DIFF
--- a/src/N3Lexer.js
+++ b/src/N3Lexer.js
@@ -102,13 +102,13 @@ export default class N3Lexer {
         if (this.comments && (comment = this._comment.exec(whiteSpaceMatch[0])))
           emitToken('comment', comment[1], '', this._line, whiteSpaceMatch[0].length);
         // Advance the input
-        input = input.substr(whiteSpaceMatch[0].length, input.length);
+        input = input.slice(whiteSpaceMatch[0].length);
         currentLineLength = input.length;
         this._line++;
       }
       // Skip whitespace on current line
       if (!whiteSpaceMatch && (whiteSpaceMatch = this._whitespace.exec(input)))
-        input = input.substr(whiteSpaceMatch[0].length, input.length);
+        input = input.slice(whiteSpaceMatch[0].length);
 
       // Stop for now if we're at the end
       if (this._endOfFile.test(input)) {
@@ -136,7 +136,7 @@ export default class N3Lexer {
         else if (input[1] === '^') {
           this._previousMarker = '^^';
           // Move to type IRI or prefixed name
-          input = input.substr(2);
+          input = input.slice(2);
           if (input[0] !== '<') {
             inconclusive = true;
             break;
@@ -425,7 +425,7 @@ export default class N3Lexer {
       this._previousMarker = type;
 
       // Advance to next part to tokenize
-      input = input.substr(length, input.length);
+      input = input.slice(length);
     }
 
     // Emits the token through the callback
@@ -525,7 +525,7 @@ export default class N3Lexer {
 
   // ### Strips off any starting UTF BOM mark.
   _readStartingBom(input) {
-    return input.startsWith('\ufeff') ? input.substr(1) : input;
+    return input.startsWith('\ufeff') ? input.slice(1) : input;
   }
 
   // ## Public methods


### PR DESCRIPTION
## Summary

- replace deprecated substr calls in lexer hot paths with slice
- omit redundant length arguments while preserving the same non-negative offsets and results

## Performance

Measured on Node 25.1.0 by streaming an 810,000-quad TriG corpus containing 4,860,001 tokens. After warm-up, the median of 9 runs improved from 1,010.20 ms to 993.62 ms, a 1.6% end-to-end lexer speedup.

CPU profiles showed tokenization dominating parser time on this corpus, so this also benefits normal parsing without changing parser behavior.

## Verification

- complete Jest suite: 6,847 tests passed
- 100% statement, branch, function, and line coverage
- ESLint passed