### PR TITLE
Optimize bound quad reads

### DIFF
--- a/src/N3Store.js
+++ b/src/N3Store.js
@@ -274,54 +274,38 @@ export default class N3Store {
   // (for instance: _subject_, _predicate_, and _object_).
   // Finally, `graphId` will be the graph of the created quads.
   *_findInIndex(index0, key0, key1, key2, name0, name1, name2, graphId) {
-    let index1, index2;
     const entityKeys = this._entities;
     const graph = this._termFromId(entityKeys[graphId]);
     const parts = { subject: null, predicate: null, object: null };
 
-    // Bound outer keys can be looked up directly.
-    if (key0) {
-      if (!(index1 = index0[key0]))
+    // Exact matches avoid allocating key arrays or entering generic loops.
+    if (key2) {
+      const index1 = index0[key0];
+      const index2 = index1 && index1[key1];
+      if (!index2 || !(key2 in index2))
         return;
       parts[name0] = this._termFromId(entityKeys[key0]);
-
-      if (key1) {
-        if (!(index2 = index1[key1]))
-          return;
-        parts[name1] = this._termFromId(entityKeys[key1]);
-        if (key2) {
-          if (!(key2 in index2))
-            return;
-          parts[name2] = this._termFromId(entityKeys[key2]);
-          yield this._factory.quad(parts.subject, parts.predicate, parts.object, graph);
-        }
-        else {
-          const values = Object.keys(index2);
-          for (let l = 0; l < values.length; l++) {
-            parts[name2] = this._termFromId(entityKeys[values[l]]);
-            yield this._factory.quad(parts.subject, parts.predicate, parts.object, graph);
-          }
-        }
-      }
-      else {
-        for (const value1 in index1) {
-          index2 = index1[value1];
-          parts[name1] = this._termFromId(entityKeys[value1]);
-          const values = Object.keys(index2);
-          for (let l = 0; l < values.length; l++) {
-            parts[name2] = this._termFromId(entityKeys[values[l]]);
-            yield this._factory.quad(parts.subject, parts.predicate, parts.object, graph);
-          }
-        }
-      }
+      parts[name1] = this._termFromId(entityKeys[key1]);
+      parts[name2] = this._termFromId(entityKeys[key2]);
+      yield this._factory.quad(parts.subject, parts.predicate, parts.object, graph);
       return;
     }
 
-    for (const value0 in index0) {
-      index1 = index0[value0];
+    if (key0 && !(key0 in index0))
+      return;
+    // A null key list stops after visiting a bound key, avoiding a one-item array.
+    const keys0 = key0 ? null : Object.keys(index0);
+    for (let i0 = 0, value0 = key0 || keys0[0]; value0;
+         value0 = keys0 && keys0[++i0]) {
+      const index1 = index0[value0];
       parts[name0] = this._termFromId(entityKeys[value0]);
-      for (const value1 in index1) {
-        index2 = index1[value1];
+
+      if (key1 && !(key1 in index1))
+        return;
+      const keys1 = key1 ? null : Object.keys(index1);
+      for (let i1 = 0, value1 = key1 || keys1[0]; value1;
+           value1 = keys1 && keys1[++i1]) {
+        const index2 = index1[value1];
         parts[name1] = this._termFromId(entityKeys[value1]);
         const values = Object.keys(index2);
         for (let l = 0; l < values.length; l++) {

--- a/src/N3Store.js
+++ b/src/N3Store.js
@@ -268,7 +268,7 @@ export default class N3Store {
 
   // ### `_findInIndex` finds a set of quads in a three-layered index.
   // The index base is `index0` and the keys at each level are `key0`, `key1`, and `key2`.
-  // A key and any keys after it can be undefined, which is interpreted as a wildcard.
+  // A key and any keys after it can be null or undefined, which is interpreted as a wildcard.
   // `name0`, `name1`, and `name2` are the names of the keys at each level,
   // used when reconstructing the resulting quad
   // (for instance: _subject_, _predicate_, and _object_).

--- a/src/N3Store.js
+++ b/src/N3Store.js
@@ -268,35 +268,65 @@ export default class N3Store {
 
   // ### `_findInIndex` finds a set of quads in a three-layered index.
   // The index base is `index0` and the keys at each level are `key0`, `key1`, and `key2`.
-  // Any of these keys can be undefined, which is interpreted as a wildcard.
+  // A key and any keys after it can be undefined, which is interpreted as a wildcard.
   // `name0`, `name1`, and `name2` are the names of the keys at each level,
   // used when reconstructing the resulting quad
   // (for instance: _subject_, _predicate_, and _object_).
   // Finally, `graphId` will be the graph of the created quads.
   *_findInIndex(index0, key0, key1, key2, name0, name1, name2, graphId) {
-    let tmp, index1, index2;
+    let index1, index2;
     const entityKeys = this._entities;
     const graph = this._termFromId(entityKeys[graphId]);
     const parts = { subject: null, predicate: null, object: null };
 
-    // If a key is specified, use only that part of index 0.
-    if (key0) (tmp = index0, index0 = {})[key0] = tmp[key0];
-    for (const value0 in index0) {
-      if (index1 = index0[value0]) {
-        parts[name0] = this._termFromId(entityKeys[value0]);
-        // If a key is specified, use only that part of index 1.
-        if (key1) (tmp = index1, index1 = {})[key1] = tmp[key1];
-        for (const value1 in index1) {
-          if (index2 = index1[value1]) {
-            parts[name1] = this._termFromId(entityKeys[value1]);
-            // If a key is specified, use only that part of index 2, if it exists.
-            const values = key2 ? (key2 in index2 ? [key2] : []) : Object.keys(index2);
-            // Create quads for all items found in index 2.
-            for (let l = 0; l < values.length; l++) {
-              parts[name2] = this._termFromId(entityKeys[values[l]]);
-              yield this._factory.quad(parts.subject, parts.predicate, parts.object, graph);
-            }
+    // Bound outer keys can be looked up directly.
+    if (key0) {
+      if (!(index1 = index0[key0]))
+        return;
+      parts[name0] = this._termFromId(entityKeys[key0]);
+
+      if (key1) {
+        if (!(index2 = index1[key1]))
+          return;
+        parts[name1] = this._termFromId(entityKeys[key1]);
+        if (key2) {
+          if (!(key2 in index2))
+            return;
+          parts[name2] = this._termFromId(entityKeys[key2]);
+          yield this._factory.quad(parts.subject, parts.predicate, parts.object, graph);
+        }
+        else {
+          const values = Object.keys(index2);
+          for (let l = 0; l < values.length; l++) {
+            parts[name2] = this._termFromId(entityKeys[values[l]]);
+            yield this._factory.quad(parts.subject, parts.predicate, parts.object, graph);
           }
+        }
+      }
+      else {
+        for (const value1 in index1) {
+          index2 = index1[value1];
+          parts[name1] = this._termFromId(entityKeys[value1]);
+          const values = Object.keys(index2);
+          for (let l = 0; l < values.length; l++) {
+            parts[name2] = this._termFromId(entityKeys[values[l]]);
+            yield this._factory.quad(parts.subject, parts.predicate, parts.object, graph);
+          }
+        }
+      }
+      return;
+    }
+
+    for (const value0 in index0) {
+      index1 = index0[value0];
+      parts[name0] = this._termFromId(entityKeys[value0]);
+      for (const value1 in index1) {
+        index2 = index1[value1];
+        parts[name1] = this._termFromId(entityKeys[value1]);
+        const values = Object.keys(index2);
+        for (let l = 0; l < values.length; l++) {
+          parts[name2] = this._termFromId(entityKeys[values[l]]);
+          yield this._factory.quad(parts.subject, parts.predicate, parts.object, graph);
         }
       }
     }


### PR DESCRIPTION
## Summary

- keep a dedicated direct-lookup path for exact matches
- share one traversal for all wildcard query shapes
- avoid one-item arrays for bound keys
- remove the repeated quad-construction loops from the initial implementation

## Performance

The final PR head (`a27daa1`) was benchmarked directly against its `main` base (`20d2d5f`) on Node 25.1.0 / V8 14.1, Apple M1 with 16 GB RAM, using one default graph. Variants were warmed up and run in alternating order; the tables report median elapsed time. Lower is better.

### Selective reads

On a 50,000-quad sparse store, consuming the first (and only) matching quad through `match()`:

| Query | Base | PR | Lower elapsed time |
| --- | ---: | ---: | ---: |
| subject + predicate + object | 1.149 µs | 0.696 µs | 39.4% |
| subject + predicate | 1.465 µs | 1.107 µs | 24.4% |
| subject | 1.107 µs | 0.851 µs | 23.1% |
| predicate | 1.068 µs | 0.858 µs | 19.6% |
| object | 1.086 µs | 0.858 µs | 21.0% |

The selective paths stay approximately constant-time as the store grows. On a 500,000-quad sparse store:

| Query returning one quad | Base | PR | Lower elapsed time |
| --- | ---: | ---: | ---: |
| exact subject + predicate + object | 1.876 µs | 1.378 µs | 26.5% |
| subject with one matching quad | 1.848 µs | 1.536 µs | 16.9% |

### Partial versus complete iteration

On that same 500,000-quad store:

| Operation through `match()` | Base | PR | Change |
| --- | ---: | ---: | ---: |
| exact selective lookup, consume one | 1.876 µs | 1.378 µs | 26.5% faster |
| unfiltered match, consume only the first quad | 19.45 ms | 19.39 ms | neutral |
| unfiltered match, consume all 500,000 quads | 252.0 ms | 233.5 ms | 7.3% lower median elapsed time |

The paired full-iteration samples had a median improvement of 10.0%. Full-iteration throughput increased from 1.98 million to 2.14 million quads/second (504 ns/quad to 467 ns/quad).

Fetching the first unfiltered quad already costs about 8% of a complete iteration. This is not a regression introduced by the explicit `Object.keys()` calls. N3's numeric entity IDs are integer-indexed object properties; V8 prepares all indexed keys before entering a `for...in` loop body. The base therefore materializes an internal V8 `FixedArray`, while the PR materializes a JavaScript key array. An isolated base recheck measured 18.46 ms for `for...in` stopped after its first key and 18.90 ms for `Object.keys()` followed by its first key. See [V8's explanation of `for...in` key preparation](https://v8.dev/blog/fast-for-in).

### Memory

- persistent store memory was unchanged within measurement noise
- a paused exact-match iterator retained 2,483 bytes on the base and 1,739 bytes on the PR (30% less)
- a paused subject-only iterator with one result retained 2,187 bytes on the base and 1,851 bytes on the PR (15% less)
- a paused high-fanout iterator retained effectively the same key storage on both revisions: about 1.50 MiB for 50,000 potential results and 15.26 MiB for 500,000 potential results
- closing the iterators and forcing GC returned this additional heap to baseline; no retained-memory leak was detected

## Verification

- complete Jest suite: 6,847 tests passed
- 100% statement, branch, function, and line coverage
- ESLint passed
