### PR TITLE
Avoid redundant writer term access

### DIFF
--- a/src/N3Writer.js
+++ b/src/N3Writer.js
@@ -90,7 +90,8 @@ export default class N3Writer {
       // Write the graph's label if it has changed
       // (the id-based fast path of `equals` would conflate
       // the empty named node `<>` with the default graph)
-      if (!graph.equals(this._graph) || graph.termType !== this._graph.termType) {
+      if (graph !== this._graph &&
+          (!graph.equals(this._graph) || graph.termType !== this._graph.termType)) {
         // Close the previous graph and start the new one
         this._write((this._subject === null ? '' : (this._inDefaultGraph ? '.\n' : '\n}\n')) +
                     (DEFAULTGRAPH.equals(graph) ? '' : `${this._encodeIriOrBlank(graph)} {\n`));
@@ -98,9 +99,9 @@ export default class N3Writer {
         this._subject = null;
       }
       // Don't repeat the subject if it's the same
-      if (subject.equals(this._subject)) {
+      if (subject === this._subject || subject.equals(this._subject)) {
         // Don't repeat the predicate if it's the same
-        if (predicate.equals(this._predicate))
+        if (predicate === this._predicate || predicate.equals(this._predicate))
           this._write(`, ${this._encodeObject(object)}`, done);
         // Same subject, different predicate
         else
@@ -179,9 +180,12 @@ export default class N3Writer {
       value = value.replace(escapeAll, characterReplacer);
 
     // Write a language-tagged literal
-    const direction = literal.direction ? `--${literal.direction}` : '';
-    if (literal.language)
-      return `"${value}"@${literal.language}${direction}`;
+    const language = literal.language;
+    if (language) {
+      const literalDirection = literal.direction;
+      const direction = literalDirection ? `--${literalDirection}` : '';
+      return `"${value}"@${language}${direction}`;
+    }
 
     // Write dedicated literals per data type
     if (this._lineMode) {


### PR DESCRIPTION
## Summary

- short-circuit term equality when the writer receives the same object again
- read literal language and direction getters once
- avoid reading direction at all for literals without a language tag

RDF terms are immutable and equality is reflexive, so these fast paths preserve serialization behavior for both N3 terms and custom RDF/JS terms.

## Performance

Measured on Node 25.1.0 with 500,000 quad writes per sample to a null sink, after warm-up using the median of 11 runs:

| Workload | Before | After | Improvement |
| --- | ---: | ---: | ---: |
| plain literals | 187.19 ms | 163.18 ms | 12.8% |
| directional language literals | 299.89 ms | 223.88 ms | 25.3% |
| repeated identical subject and predicate | 168.45 ms | 160.04 ms | 5.0% |

## Verification

- complete Jest suite: 6,847 tests passed
- 100% statement, branch, function, and line coverage
- ESLint passed