### PR TITLE
Optimize bound quad counts

### DIFF
--- a/src/N3Store.js
+++ b/src/N3Store.js
@@ -351,7 +351,7 @@ export default class N3Store {
 
   // ### `_countInIndex` counts matching quads in a three-layered index.
   // The index base is `index0` and the keys at each level are `key0`, `key1`, and `key2`.
-  // A key and any keys after it can be undefined, which is interpreted as a wildcard.
+  // A key and any keys after it can be null or undefined, which is interpreted as a wildcard.
   _countInIndex(index0, key0, key1, key2) {
     let count = 0, index1, index2;
 

--- a/src/N3Store.js
+++ b/src/N3Store.js
@@ -351,25 +351,29 @@ export default class N3Store {
 
   // ### `_countInIndex` counts matching quads in a three-layered index.
   // The index base is `index0` and the keys at each level are `key0`, `key1`, and `key2`.
-  // Any of these keys can be undefined, which is interpreted as a wildcard.
+  // A key and any keys after it can be undefined, which is interpreted as a wildcard.
   _countInIndex(index0, key0, key1, key2) {
-    let count = 0, tmp, index1, index2;
+    let count = 0, index1, index2;
 
-    // If a key is specified, count only that part of index 0
-    if (key0) (tmp = index0, index0 = {})[key0] = tmp[key0];
-    for (const value0 in index0) {
-      if (index1 = index0[value0]) {
-        // If a key is specified, count only that part of index 1
-        if (key1) (tmp = index1, index1 = {})[key1] = tmp[key1];
-        for (const value1 in index1) {
-          if (index2 = index1[value1]) {
-            // If a key is specified, count the quad if it exists
-            if (key2) (key2 in index2) && count++;
-            // Otherwise, count all quads
-            else count += index2[SIZE];
-          }
-        }
+    // Bound outer keys can be looked up directly.
+    if (key0) {
+      if (!(index1 = index0[key0]))
+        return 0;
+      if (key1) {
+        if (!(index2 = index1[key1]))
+          return 0;
+        return key2 ? (key2 in index2 ? 1 : 0) : index2[SIZE];
       }
+
+      for (const value1 in index1)
+        count += index1[value1][SIZE];
+      return count;
+    }
+
+    for (const value0 in index0) {
+      index1 = index0[value0];
+      for (const value1 in index1)
+        count += index1[value1][SIZE];
     }
     return count;
   }


### PR DESCRIPTION
## Summary

- look up bound outer index keys directly in countQuads
- avoid allocating temporary wrapper objects for selective counts
- retain the existing wildcard traversal

## Performance

Measured on Node 25.1.0 with a 50,000-quad sparse store, 500,000 calls per sample, after warm-up using the median of 11 runs:

| Query | Before | After | Improvement |
| --- | ---: | ---: | ---: |
| subject + predicate + object | 451.92 ms | 102.19 ms | 77.4% |
| subject + predicate | 400.90 ms | 88.72 ms | 77.9% |
| subject | 338.62 ms | 149.93 ms | 55.7% |

Unbound whole-store counting showed no material regression.

## Verification

- complete Jest suite: 6,847 tests passed
- 100% statement, branch, function, and line coverage
- ESLint passed