### PR TITLE
fix(ci): watch consumed RDF test suites

### DIFF
--- a/.github/workflows/refresh-spec-cache.yml
+++ b/.github/workflows/refresh-spec-cache.yml
@@ -20,10 +20,25 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          for suite in rdf11 rdf12; do
-            sha=$(gh api "repos/w3c/rdf-tests/commits?sha=gh-pages&path=rdf/$suite&per_page=1" --jq '.[0].sha')
-            [[ "$sha" =~ ^[0-9a-f]{40}$ ]] || { echo "Bad SHA for $suite: '$sha'" >&2; exit 1; }
-            echo "$suite $sha"
+          paths=(
+            rdf/rdf11/rdf-n-triples
+            rdf/rdf11/rdf-n-quads
+            rdf/rdf11/rdf-turtle
+            rdf/rdf11/rdf-trig
+            rdf/rdf12/rdf-n-triples/syntax
+            rdf/rdf12/rdf-n-quads/syntax
+            rdf/rdf12/rdf-turtle/syntax
+            rdf/rdf12/rdf-trig/syntax
+          )
+          for path in "${paths[@]}"; do
+            sha=$(gh api repos/w3c/rdf-tests/commits \
+              --method GET \
+              -f sha=gh-pages \
+              -f path="$path" \
+              -F per_page=1 \
+              --jq '.[0].sha')
+            [[ "$sha" =~ ^[0-9a-f]{40}$ ]] || { echo "Bad SHA for $path: '$sha'" >&2; exit 1; }
+            echo "$path $sha"
           done > spec/cache-key.txt
       - uses: peter-evans/create-pull-request@v8
         with:
@@ -33,7 +48,6 @@ jobs:
           commit-message: 'chore(ci): refetch upstream spec suites'
           title: 'chore(ci): refetch upstream spec suites'
           body: >-
-            The w3c/rdf-tests suites changed upstream. Merging rotates the
-            spec jobs' fixture cache key so they refetch the suites cold.
-            Note: CI does not run automatically on workflow-created PRs;
-            close and reopen (or push) to trigger it.
+            One or more of the exact w3c/rdf-tests syntax suites exercised by
+            N3.js changed upstream. Merging rotates the spec jobs' fixture
+            cache key so they refetch the suites cold.

--- a/spec/cache-key.txt
+++ b/spec/cache-key.txt
@@ -1,2 +1,8 @@
-rdf11 d163beb0a59f82f501d07e793b55b9c12b498972
-rdf12 a5e6eff7e2582c81a55b7f9f41f51b71728df1b8
+rdf/rdf11/rdf-n-triples a4087116d5f1df52c0485ba5f0a7a7b0fbd662fd
+rdf/rdf11/rdf-n-quads a4087116d5f1df52c0485ba5f0a7a7b0fbd662fd
+rdf/rdf11/rdf-turtle a4087116d5f1df52c0485ba5f0a7a7b0fbd662fd
+rdf/rdf11/rdf-trig d163beb0a59f82f501d07e793b55b9c12b498972
+rdf/rdf12/rdf-n-triples/syntax d20621fa03dc04e7b7d6c8a7acd06be4494d2741
+rdf/rdf12/rdf-n-quads/syntax d20621fa03dc04e7b7d6c8a7acd06be4494d2741
+rdf/rdf12/rdf-turtle/syntax a4087116d5f1df52c0485ba5f0a7a7b0fbd662fd
+rdf/rdf12/rdf-trig/syntax d20621fa03dc04e7b7d6c8a7acd06be4494d2741


### PR DESCRIPTION
## Summary

- fingerprint each of the eight RDF syntax-suite directories N3.js actually exercises
- stop generated reports and unrelated files under `rdf/rdf12` from rotating the fixture cache
- make future refresh PR descriptions accurately state what changed

## Why

PR #714 was a false-positive refresh: `rdf12` advanced from `648e817` to `a5e6eff`, but the intervening changes under `rdf/rdf12` were generated EARL/report files. The four RDF 1.2 syntax suites consumed by N3.js did not change.

## Verification

- resolved all eight path-specific revisions from `w3c/rdf-tests` on `gh-pages`
- `npm test` — 6,847 tests passed with 100% coverage
- `npm run lint`
- `actionlint .github/workflows/refresh-spec-cache.yml`
- `git diff --check`
