### PR TITLE
ci: validate merge queue commits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ on:
     branches:
     - main
   pull_request:
+  merge_group:
+    types: [checks_requested]
 
 # Least-privilege default for GITHUB_TOKEN; jobs opt into more only where needed.
 permissions:


### PR DESCRIPTION
## Summary

- run the existing CI workflow for GitHub merge-group commits
- report the required `summary` check against the latest `main` before queued PRs merge

## Verification

- `actionlint .github/workflows/ci.yml`
- `git diff --check`

This workflow change must land before enabling the merge queue in the `main` branch protection rule.