### PR TITLE
fix(store): handle deletions during iteration

### DIFF
--- a/src/N3Store.js
+++ b/src/N3Store.js
@@ -297,7 +297,9 @@ export default class N3Store {
     const keys0 = key0 ? null : Object.keys(index0);
     for (let i0 = 0, value0 = key0 || keys0[0]; value0;
          value0 = keys0 && keys0[++i0]) {
+      // Mutations can remove keys captured before an earlier yield.
       const index1 = index0[value0];
+      if (!index1) continue; // eslint-disable-line no-continue
       parts[name0] = this._termFromId(entityKeys[value0]);
 
       if (key1 && !(key1 in index1))
@@ -306,6 +308,7 @@ export default class N3Store {
       for (let i1 = 0, value1 = key1 || keys1[0]; value1;
            value1 = keys1 && keys1[++i1]) {
         const index2 = index1[value1];
+        if (!index2) continue; // eslint-disable-line no-continue
         parts[name1] = this._termFromId(entityKeys[value1]);
         const values = Object.keys(index2);
         for (let l = 0; l < values.length; l++) {

--- a/test/N3Store-test.js
+++ b/test/N3Store-test.js
@@ -2234,6 +2234,26 @@ describe('Store', () => {
         expect([...store.match(null, null, null, null)]).toHaveLength(5);
       },
     );
+
+    it('should skip a subject branch deleted during iteration', () => {
+      const firstQuad = new Quad(new NamedNode('s1'), new NamedNode('p1'), new NamedNode('o1'));
+      const secondQuad = new Quad(new NamedNode('s2'), new NamedNode('p1'), new NamedNode('o2'));
+      store = new Store([firstQuad, secondQuad]);
+      const iterator = store.readQuads();
+      const first = iterator.next().value;
+      store.removeQuad(first.subject.value === 's1' ? secondQuad : firstQuad);
+      expect([...iterator]).toHaveLength(0);
+    });
+
+    it('should skip a predicate branch deleted during iteration', () => {
+      const firstQuad = new Quad(new NamedNode('s1'), new NamedNode('p1'), new NamedNode('o1'));
+      const secondQuad = new Quad(new NamedNode('s1'), new NamedNode('p2'), new NamedNode('o2'));
+      store = new Store([firstQuad, secondQuad]);
+      const iterator = store.readQuads(new NamedNode('s1'));
+      const first = iterator.next().value;
+      store.removeQuad(first.predicate.value === 'p1' ? secondQuad : firstQuad);
+      expect([...iterator]).toHaveLength(0);
+    });
   });
 
   const matrix = [true, false, 'instantiated'].flatMap(match => [true, false].map(share => [match, share]));


### PR DESCRIPTION
## Summary

- re-check snapshotted subject and predicate branches while iterating store indices
- skip a branch if it was deleted while the generator was suspended
- cover deletions between yields at both affected index levels

## Context

`_findInIndex()` snapshots wildcard keys before yielding. A caller can delete an unvisited branch before requesting the next result, leaving a captured key whose live lookup is now `undefined`. The iterator then calls `Object.keys(undefined)` and throws.

The added guards restore the mutation-tolerant behavior from before the indexed-read optimization: deleted branches are skipped, while additions and surviving branches retain the existing weakly consistent iteration behavior. The exact-match fast path is unchanged; wildcard traversal gains two allocation-free truthiness checks.

This was discovered while working on #598, but is a general `N3Store` iterator bug and is therefore submitted separately.

## Deleted leaf assessment

I also benchmarked checking each snapshotted leaf key before yielding it. On Node v24.19.0, warmed paired runs yielded 1,048,576 quads per observation across balanced and leaf-heavy index shapes. Broad wildcard scans showed no repeatable difference beyond noise (about 0–2% median). Subject-bound, leaf-heavy scans repeatedly trended 4–7% slower, although their interquartile ranges included parity.

That check is omitted here: it runs once per wildcard result, is not needed to prevent the exception, and would change the longstanding behavior of the snapshotted leaf-key loop. This PR only restores the live branch checks that existed before the indexed-read optimization.

## Verification

- focused regressions fail on `main` with `TypeError: Cannot convert undefined or null to object`
- `test/N3Store-test.js`: 438 passing
- full test suite: 21 suites and 6,878 tests passing, with 100% measured coverage
- ESLint, Node build, and both browser bundle builds pass
