### PR TITLE
fix(lexer): ignore stale callbacks after reuse

### DIFF
--- a/src/N3Lexer.js
+++ b/src/N3Lexer.js
@@ -575,8 +575,8 @@ export default class N3Lexer {
   // ### `tokenize` starts the transformation of an N3 document into an array of tokens.
   // The input can be a string or a stream.
   tokenize(input, callback) {
-    // Old streams may still emit after completion or failure. Keep their
-    // handlers from consuming input or calling back for a later invocation.
+    // Deferred tokenization and stream events can outlive their invocation.
+    // Ignore them once a later call takes ownership of the lexer state.
     const tokenization = this._tokenization = {};
     this._line = 1;
 
@@ -585,7 +585,10 @@ export default class N3Lexer {
       this._input = this._readStartingBom(input);
       // If a callback was passed, asynchronously call it
       if (typeof callback === 'function')
-        queueMicrotask(() => this._tokenizeToEnd(callback, true));
+        queueMicrotask(() => {
+          if (this._tokenization === tokenization)
+            this._tokenizeToEnd(callback, true);
+        });
       // If no callback was passed, tokenize synchronously and return
       else {
         const tokens = [];

--- a/src/N3Lexer.js
+++ b/src/N3Lexer.js
@@ -575,6 +575,9 @@ export default class N3Lexer {
   // ### `tokenize` starts the transformation of an N3 document into an array of tokens.
   // The input can be a string or a stream.
   tokenize(input, callback) {
+    // Old streams may still emit after completion or failure. Keep their
+    // handlers from consuming input or calling back for a later invocation.
+    const tokenization = this._tokenization = {};
     this._line = 1;
 
     // If the input is a string, continuously emit tokens through the callback until the end
@@ -599,7 +602,7 @@ export default class N3Lexer {
         input.setEncoding('utf8');
       // Adds the data chunk to the buffer and parses as far as possible
       input.on('data', data => {
-        if (this._input !== null && data.length !== 0) {
+        if (this._tokenization === tokenization && this._input !== null && data.length !== 0) {
           // Prepend any previous pending writes
           if (this._pendingBuffer) {
             data = Buffer.concat([this._pendingBuffer, data]);
@@ -622,10 +625,13 @@ export default class N3Lexer {
       });
       // Parses until the end
       input.on('end', () => {
-        if (typeof this._input === 'string')
+        if (this._tokenization === tokenization && typeof this._input === 'string')
           this._tokenizeToEnd(callback, true);
       });
-      input.on('error', callback);
+      input.on('error', error => {
+        if (this._tokenization === tokenization)
+          callback(error);
+      });
     }
   }
 }

--- a/test/N3Lexer-test.js
+++ b/test/N3Lexer-test.js
@@ -2041,6 +2041,24 @@ describe('Lexer', () => {
       });
     });
 
+    it.each(['asynchronous', 'synchronous'])('ignores a queued tokenizer superseded by %s string input', mode => {
+      jest.useFakeTimers();
+      try {
+        const lexer = new Lexer(), previousCallback = jest.fn(), nextCallback = jest.fn(),
+            expected = new Lexer().tokenize('<new>');
+        lexer.tokenize('<old>', previousCallback);
+        const result = lexer.tokenize('<new>', mode === 'asynchronous' ? nextCallback : undefined);
+
+        expect(() => jest.runAllTicks()).not.toThrow();
+        expect(previousCallback).not.toHaveBeenCalled();
+        expect(result).toEqual(mode === 'asynchronous' ? undefined : expected);
+        expect(nextCallback.mock.calls).toEqual(mode === 'asynchronous' ? expected.map(token => [null, token]) : []);
+      }
+      finally {
+        jest.useRealTimers();
+      }
+    });
+
     describe.each(['syntax error', 'stream error', 'end'])('reusing a lexer after %s', outcome => {
       it.each(['data', 'end', 'error'])('ignores later %s events from the previous stream', event => {
         jest.useFakeTimers();

--- a/test/N3Lexer-test.js
+++ b/test/N3Lexer-test.js
@@ -2040,6 +2040,40 @@ describe('Lexer', () => {
         expect((() => { lexer.tokenize('<a> bar'); })).toThrow('Unexpected "bar" on line 1.');
       });
     });
+
+    describe.each(['syntax error', 'stream error', 'end'])('reusing a lexer after %s', outcome => {
+      it.each(['data', 'end', 'error'])('ignores later %s events from the previous stream', event => {
+        jest.useFakeTimers();
+        try {
+          const lexer = new Lexer(), stream = new EventEmitter(),
+              previousCallback = jest.fn(), nextCallback = jest.fn();
+          lexer.tokenize(stream, previousCallback);
+          if (outcome === 'syntax error')
+            stream.emit('data', '@\n');
+          else if (outcome === 'stream error')
+            stream.emit('error', new Error('source failed'));
+          else {
+            stream.emit('data', '<old>');
+            stream.emit('end');
+          }
+          const previousCalls = previousCallback.mock.calls.slice();
+          expect(previousCalls.length).toBeGreaterThan(0);
+
+          // String tokenization is deferred, so the old source can still emit
+          // events while the lexer holds the new input.
+          lexer.tokenize('<new>', nextCallback);
+          stream.emit(event, event === 'error' ? new Error('late error') : '<stale>');
+          expect(() => jest.runAllTicks()).not.toThrow();
+
+          expect(nextCallback.mock.calls).toEqual(new Lexer().tokenize('<new>')
+            .map(token => [null, token]));
+          expect(previousCallback.mock.calls).toEqual(previousCalls);
+        }
+        finally {
+          jest.useRealTimers();
+        }
+      });
+    });
   });
 });
 


### PR DESCRIPTION
Reusing a `Lexer` can leave old stream handlers or a queued string tokenizer referring to shared lexer state. If either runs after a later `tokenize` call, it can deliver the new input's tokens to the previous callback or crash when the queued tokenizer encounters a null input.

Give each tokenization an identity and ignore callbacks belonging to earlier invocations. The guard covers stream `data`, `end`, and `error` events as well as the microtask used for callback-based string tokenization. Eleven regression cases cover late stream events after failure or completion, and queued string tokenization superseded by either synchronous or callback-based string input.

The stale-stream bug reproduces on `30c108e`, before #721, so this fix is submitted independently of the lexer coordinate changes.

Validation:
- 6,887 Jest tests pass with 100% statement, branch, function, and line coverage.
- ESLint, Node and browser builds, and `git diff --check` pass.
- Regression tests reproduce the output corruption and null-input crashes before the corresponding guards are added.
