### PR TITLE
fix(stream-parser): initialize the readable object-mode buffer

### DIFF
--- a/src/N3StreamParser.js
+++ b/src/N3StreamParser.js
@@ -5,8 +5,7 @@ import N3Parser from './N3Parser';
 // ## Constructor
 export default class N3StreamParser extends Transform {
   constructor(options) {
-    super({ decodeStrings: true });
-    this._readableState.objectMode = true;
+    super({ decodeStrings: true, readableObjectMode: true });
 
     // Set up parser with dummy stream to obtain `data` and `end` callbacks
     const parser = new N3Parser(options);

--- a/test/N3StreamParser-test.js
+++ b/test/N3StreamParser-test.js
@@ -14,6 +14,30 @@ describe('StreamParser', () => {
   });
 
   describe('A StreamParser instance', () => {
+    it('bounds unread quads using the object-mode high-water mark', async () => {
+      let produced = 0;
+      const input = new Readable({
+        highWaterMark: 1,
+        read() {
+          this.push(produced++ < 30000 ? '<a> <b> <c>.\n' : null);
+        },
+      });
+      const parser = new StreamParser();
+      const paused = new Promise(resolve => input.once('pause', resolve));
+      try {
+        input.pipe(parser);
+        await paused;
+        expect(parser.readableHighWaterMark).toBe(16);
+        expect(parser.readableLength).toBeGreaterThan(0);
+        expect(parser.readableLength).toBeLessThanOrEqual(16);
+        expect(produced).toBeLessThan(30000);
+      }
+      finally {
+        input.destroy();
+        parser.destroy();
+      }
+    });
+
     it('pauses an imported readable until its quads are consumed', async () => {
       const total = 30000;
       let produced = 0, consumed = 0;


### PR DESCRIPTION
Construct `StreamParser` with `readableObjectMode: true` so its readable high-water mark is initialized in objects. Previously the constructor initialized a byte-mode buffer, then changed the private object-mode flag; that left the threshold at 16,384 quads instead of the normal 16-object default. Writable input remains in byte mode.

A regression test pipes 30,000 one-triple chunks into a parser without consuming the output. It checks `readableHighWaterMark` directly and verifies that the source pauses with at most 16 queued quads. The revised test fails against unfixed main with a high-water mark of 16,384 and passes after the patch. The high-water mark is a buffering threshold; a single large input chunk can still produce more quads synchronously.

Validation: all 6,892 tests pass with 100% coverage; ESLint, Node/browser builds, and `git diff --check` pass.

This fixes pre-existing behavior on `main` and is independent of #721. The base includes the merged `import()` backpressure change from #724 and the lexer optimization from #725.
