### PR TITLE
fix(stream-parser): respect backpressure when importing readable streams

### DIFF
--- a/src/N3StreamParser.js
+++ b/src/N3StreamParser.js
@@ -38,9 +38,13 @@ export default class N3StreamParser extends Transform {
 
   // ### Parses a stream of strings
   import(stream) {
-    stream.on('data',  chunk => { this.write(chunk); });
-    stream.on('end',   ()      => { this.end(); });
     stream.on('error', error => { this.emit('error', error); });
+    if (typeof stream.pipe === 'function')
+      stream.pipe(this);
+    else {
+      stream.on('data', chunk => { this.write(chunk); });
+      stream.on('end',  ()    => { this.end(); });
+    }
     return this;
   }
 }

--- a/test/N3StreamParser-test.js
+++ b/test/N3StreamParser-test.js
@@ -1,5 +1,6 @@
 import { StreamParser, NamedNode } from '../src';
 import { Readable, Writable } from 'readable-stream';
+import { EventEmitter } from 'events';
 
 describe('StreamParser', () => {
   describe('The StreamParser export', () => {
@@ -13,6 +14,49 @@ describe('StreamParser', () => {
   });
 
   describe('A StreamParser instance', () => {
+    it('pauses an imported readable until its quads are consumed', async () => {
+      const total = 30000;
+      let produced = 0, consumed = 0;
+      const input = new Readable({
+        highWaterMark: 1,
+        read() {
+          this.push(produced++ < total ? '<a> <b> <c>.\n' : null);
+        },
+      });
+      const parser = new StreamParser();
+      const ended = new Promise((resolve, reject) => {
+        parser.once('end', resolve);
+        parser.once('error', reject);
+      });
+      try {
+        expect(parser.import(input)).toBe(parser);
+        await new Promise(resolve => setImmediate(resolve));
+        expect(produced).toBeLessThan(total);
+        parser.on('data', () => { consumed++; });
+        await ended;
+        expect(consumed).toBe(total);
+      }
+      finally {
+        input.destroy();
+        parser.destroy();
+      }
+    });
+
+    it('imports an event source without a pipe method', async () => {
+      const input = new EventEmitter(), parser = new StreamParser(), quads = [];
+      const ended = new Promise((resolve, reject) => {
+        parser.once('end', resolve);
+        parser.once('error', reject);
+      });
+      parser.on('data', quad => { quads.push(quad); });
+      expect(parser.import(input)).toBe(parser);
+      input.emit('data', '<a> <b> <c>.');
+      input.emit('end');
+      await ended;
+      expect(quads).toHaveLength(1);
+      expect(quads[0].subject.value).toBe('a');
+    });
+
     it('parses the empty stream', shouldParse([], 0));
 
     it('parses the zero-length stream', shouldParse([''], 0));


### PR DESCRIPTION
Use `stream.pipe(this)` when importing a readable stream so its producer pauses when the parser's buffers fill and resumes as quads are consumed. Previously `import()` attached a `data` listener and ignored `write()` returning false, allowing an unread parser to consume and retain the entire source.

Keep explicit source-error forwarding and the existing data/end listener fallback for RDF/JS event sources that do not provide `pipe()`. The return value remains the parser.

The regression test imports 30,000 one-triple chunks, checks that production pauses before exhausting the input, then consumes and verifies all 30,000 quads. It fails on the original implementation and passes with this patch. A second test covers an EventEmitter-only source.

Validation: all 6,891 tests pass with 100% coverage; ESLint, Node/browser builds, and `git diff --check` pass.

This fixes pre-existing behavior on `main` and is independent of #721 and the separate readable-buffer initialization change.
