### PR TITLE
perf(lexer): skip unescaping strings without backslashes

### DIFF
--- a/src/N3Lexer.js
+++ b/src/N3Lexer.js
@@ -485,6 +485,8 @@ export default class N3Lexer {
   // ### `_unescape` replaces N3 escape codes by their corresponding characters,
   // allowing only the fixed escape sequences from the given replacement table
   _unescape(item, replacements) {
+    if (item.indexOf('\\') < 0)
+      return item;
     let invalid = false;
     const replaced = item.replace(escapeSequence, (sequence, unicode4, unicode8, escapedChar) => {
       // 4-digit unicode character


### PR DESCRIPTION
Return strings without backslashes directly from `_unescape`. Plain prefixed local names and literals currently enter the global replacement path even when they contain no escape sequence. The guard avoids that work while leaving escape decoding and invalid-escape validation unchanged.

This is an independent two-line optimization against `main` (`10eafd3`); it contains none of #721's range or whitespace changes.

Seven paired rounds on macOS arm64 / Node 25.1.0 using production Babel builds measured the following CPU changes against `main`. Fresh process order rotates; each process warms up for 12 iterations and measures 12 more over 8,000 triples. The long-literal case uses 200 literals containing 500 lines each and four warmup/measured iterations. Negative values mean less CPU; brackets are paired-bootstrap 95% intervals. Output counts and full digests agree.

| Workload | CPU change |
| --- | ---: |
| Lexer: plain prefixed names | -25.4% [-46.3%, -17.1%] |
| Lexer: escaped literals with plain prefixed subject/predicate | -9.2% [-10.5%, -3.0%] |
| Lexer: long plain literals | -13.8% [-20.3%, -2.1%] |
| Full parser: multiline literals | -14.3% [-30.1%, -8.3%] |
| Full parser: long plain literals | -14.4% [-23.6%, -2.1%] |
| Lexer: every local name and literal escaped | +3.0% [+2.2%, +3.9%] |
| Full parser: every local name and literal escaped | +2.4% [+2.2%, +5.0%] |

There is a deliberate tradeoff: escaped strings pay the extra backslash check, while plain strings avoid replacement work. The all-escaped control above exposes that cost rather than hiding it behind ordinary subject/predicate names. Follow-up comparisons with `includes` and a regex guard did not remove the tradeoff; the regex guard reduced the benefit on plain prefixed names. These synthetic measurements are not a promise of a universal speedup.

Validation: all 6,889 existing tests pass with 100% statement, branch, function, and line coverage, including plain values, Unicode escapes, local-name escapes, and invalid escape handling. ESLint, Node/browser builds, and `git diff --check` pass. Independent review found no correctness or compatibility issues.
