### PR TITLE
perf(lexer): recognize direction markers without regex matching

### DIFF
--- a/src/N3Lexer.js
+++ b/src/N3Lexer.js
@@ -29,7 +29,6 @@ const lineModeRegExps = {
   _unescapedIri: true,
   _simpleQuotedString: true,
   _langcode: true,
-  _dircode: true,
   _blank: true,
   _newline: true,
   _comment: true,
@@ -48,7 +47,6 @@ export default class N3Lexer {
     this._simpleQuotedString = /^"([^"\\\r\n]*)"(?=[^"])/; // string without escape sequences
     this._simpleApostropheString = /^'([^'\\\r\n]*)'(?=[^'])/;
     this._langcode = /^@([a-z]+(?:-[a-z0-9]+)*)(?=[^a-z0-9])/i;
-    this._dircode = /^--(?:(ltr)|(rtl))/;
     this._prefix = /^((?:[A-Za-z\xc0-\xd6\xd8-\xf6\xf8-\u02ff\u0370-\u037d\u037f-\u1fff\u200c\u200d\u2070-\u218f\u2c00-\u2fef\u3001-\ud7ff\uf900-\ufdcf\ufdf0-\ufffd]|[\ud800-\udb7f][\udc00-\udfff])(?:\.?[\-0-9A-Z_a-z\xb7\xc0-\xd6\xd8-\xf6\xf8-\u037d\u037f-\u1fff\u200c\u200d\u203f\u2040\u2070-\u218f\u2c00-\u2fef\u3001-\ud7ff\uf900-\ufdcf\ufdf0-\ufffd]|[\ud800-\udb7f][\udc00-\udfff])*)?:(?=[#\s<])/;
     this._prefixed = /^((?:[A-Za-z\xc0-\xd6\xd8-\xf6\xf8-\u02ff\u0370-\u037d\u037f-\u1fff\u200c\u200d\u2070-\u218f\u2c00-\u2fef\u3001-\ud7ff\uf900-\ufdcf\ufdf0-\ufffd]|[\ud800-\udb7f][\udc00-\udfff])(?:\.?[\-0-9A-Z_a-z\xb7\xc0-\xd6\xd8-\xf6\xf8-\u037d\u037f-\u1fff\u200c\u200d\u203f\u2040\u2070-\u218f\u2c00-\u2fef\u3001-\ud7ff\uf900-\ufdcf\ufdf0-\ufffd]|[\ud800-\udb7f][\udc00-\udfff])*)?:((?:(?:[0-:A-Z_a-z\xc0-\xd6\xd8-\xf6\xf8-\u02ff\u0370-\u037d\u037f-\u1fff\u200c\u200d\u2070-\u218f\u2c00-\u2fef\u3001-\ud7ff\uf900-\ufdcf\ufdf0-\ufffd]|[\ud800-\udb7f][\udc00-\udfff]|%[0-9a-fA-F]{2}|\\[!#-\/;=?\-@_~])(?:(?:[\.\-0-:A-Z_a-z\xb7\xc0-\xd6\xd8-\xf6\xf8-\u037d\u037f-\u1fff\u200c\u200d\u203f\u2040\u2070-\u218f\u2c00-\u2fef\u3001-\ud7ff\uf900-\ufdcf\ufdf0-\ufffd]|[\ud800-\udb7f][\udc00-\udfff]|%[0-9a-fA-F]{2}|\\[!#-\/;=?\-@_~])*(?:[\-0-:A-Z_a-z\xb7\xc0-\xd6\xd8-\xf6\xf8-\u037d\u037f-\u1fff\u200c\u200d\u203f\u2040\u2070-\u218f\u2c00-\u2fef\u3001-\ud7ff\uf900-\ufdcf\ufdf0-\ufffd]|[\ud800-\udb7f][\udc00-\udfff]|%[0-9a-fA-F]{2}|\\[!#-\/;=?\-@_~]))?)?)(?:[ \t]+|(?=\.?[,;!\^\s#()\[\]\{\}"'<>]))/;
     this._variable = /^\?(?:(?:[A-Z_a-z\xc0-\xd6\xd8-\xf6\xf8-\u02ff\u0370-\u037d\u037f-\u1fff\u200c\u200d\u2070-\u218f\u2c00-\u2fef\u3001-\ud7ff\uf900-\ufdcf\ufdf0-\ufffd]|[\ud800-\udb7f][\udc00-\udfff])(?:[\-0-:A-Z_a-z\xb7\xc0-\xd6\xd8-\xf6\xf8-\u037d\u037f-\u1fff\u200c\u200d\u203f\u2040\u2070-\u218f\u2c00-\u2fef\u3001-\ud7ff\uf900-\ufdcf\ufdf0-\ufffd]|[\ud800-\udb7f][\udc00-\udfff])*)(?=[.,;!\^\s#()\[\]\{\}"'<>])/;
@@ -275,8 +273,12 @@ export default class N3Lexer {
       case '-':
         if (input[1] === '-') {
           // Try to find a direction code
-          if (this._previousMarker === 'langcode' && (match = this._dircode.exec(input)))
-            type = 'dircode', matchLength = 2, value = (match[1] || match[2]), matchLength = value.length + 2;
+          if (this._previousMarker === 'langcode') {
+            if (input.startsWith('--ltr'))
+              type = 'dircode', value = 'ltr', matchLength = 5;
+            else if (input.startsWith('--rtl'))
+              type = 'dircode', value = 'rtl', matchLength = 5;
+          }
           break;
         }
 

--- a/test/N3Lexer-test.js
+++ b/test/N3Lexer-test.js
@@ -1944,6 +1944,28 @@ describe('Lexer', () => {
       ]);
     });
 
+    it.each([
+      [false, 'ltr'], [false, 'rtl'], [true, 'ltr'], [true, 'rtl'],
+    ])('recognizes direction %s / %s across stream splits', (lineMode, direction) => {
+      const input = `"hello"@en--${direction}`;
+      for (let split = 0; split <= input.length; split++) {
+        const stream = new EventEmitter(), tokens = [];
+        new Lexer({ lineMode }).tokenize(stream, (error, token) => {
+          expect(error).toBeNull();
+          tokens.push({ type: token.type, value: token.value });
+        });
+        stream.emit('data', input.slice(0, split));
+        stream.emit('data', input.slice(split));
+        stream.emit('end');
+        expect(tokens).toEqual([
+          { type: 'literal', value: 'hello' },
+          { type: 'langcode', value: 'en' },
+          { type: 'dircode', value: direction },
+          { type: 'eof', value: '' },
+        ]);
+      }
+    });
+
     describe('passing data after the stream has been finished', () => {
       const tokens = [];
       let error;


### PR DESCRIPTION
Recognize the two fixed direction markers (`--ltr` and `--rtl`) with `startsWith` instead of allocating a regex match and captures. Recognition remains gated on the previous language tag, with the same case sensitivity, lexical length, partial-input handling, and suffix behavior. This is independent of the source-range work in #721 and the separator optimization.

On a synthetic 8,000-triple direction-heavy document, median lexer CPU time fell **7.5%** (bootstrap 95% interval: -11.3% to -7.0%). Full-parser CPU was -2.3% (-3.1% to +0.8%), so a parser gain is not established. Dense-input controls were +0.6% (-0.01% to +1.1%) for the lexer and +0.1% (-0.2% to +2.0%) for the parser. These are local measurements, not general throughput guarantees.

Measurements compare production Babel builds with main `4607e09` on macOS arm64 / Node 25.1.0: seven paired rounds in rotating fresh-process order, 24 warmup and 24 measured iterations per process. Token and parsed-quad content digests agree.

Validation: all **6,896 tests pass with 100% coverage**; ESLint and Node/browser IIFE/ESM builds pass. New tests exercise both directions in regular and line mode at every two-chunk split. Existing malformed-marker and suffix tests remain unchanged.
