### PR TITLE
perf(lexer): dispatch separators by character

### DIFF
--- a/src/N3Lexer.js
+++ b/src/N3Lexer.js
@@ -3,6 +3,7 @@ import { Buffer } from 'buffer';
 import namespaces from './IRIs';
 
 const { xsd } = namespaces;
+const SPACE = 0x20, TAB = 0x09, LF = 0x0A, CR = 0x0D, HASH = 0x23;
 
 // Regular expression and replacement strings to unescape N3 strings
 const escapeSequence = /\\u([a-fA-F0-9]{4})|\\U([a-fA-F0-9]{8})|\\([^])/g;
@@ -30,10 +31,8 @@ const lineModeRegExps = {
   _simpleQuotedString: true,
   _langcode: true,
   _blank: true,
-  _newline: true,
-  _comment: true,
+  _commentLine: true,
   _whitespace: true,
-  _endOfFile: true,
 };
 const invalidRegExp = /$0^/;
 
@@ -58,10 +57,8 @@ export default class N3Lexer {
     this._n3Verb = /^(?:has|is|of)(?=[\s#()\[\]\{\}"'<>?_+\-0-9])/;
     this._n3Id = /^id(?=[\s#<])/;
     this._shortPredicates = /^a(?=[\s#()\[\]\{\}"'<>])/;
-    this._newline = /^[ \t]*(?:#[^\n\r]*)?(?:\r\n|\n|\r)[ \t]*/;
-    this._comment = /#([^\n\r]*)/;
+    this._commentLine = /^[ \t]*#([^\n\r]*)(?:\r\n|\n|\r)[ \t]*/;
     this._whitespace = /^[ \t]+/;
-    this._endOfFile = /^(?:#[^\n\r]*)?$/;
     options = options || {};
 
     // Whether the log:isImpliedBy predicate is supported
@@ -94,28 +91,56 @@ export default class N3Lexer {
     let input = this._input;
     let currentLineLength = input.length;
     while (true) {
-      // Count and skip whitespace lines
-      let whiteSpaceMatch, comment;
-      while (whiteSpaceMatch = this._newline.exec(input)) {
-        // Try to find a comment
-        if (this.comments && (comment = this._comment.exec(whiteSpaceMatch[0])))
-          emitToken('comment', comment[1], '', this._line, whiteSpaceMatch[0].length);
-        // Advance the input
-        input = input.slice(whiteSpaceMatch[0].length);
-        currentLineLength = input.length;
-        this._line++;
+      // Consume one separator line at a time, including its following indentation.
+      while (true) {
+        let charCode = input.charCodeAt(0), separatorLength = 0;
+        if (charCode === SPACE || charCode === TAB) {
+          const next = input.charCodeAt(1);
+          separatorLength = next === SPACE || next === TAB ?
+            this._whitespace.exec(input)[0].length : 1;
+          charCode = input.charCodeAt(separatorLength);
+        }
+        if (charCode === HASH) {
+          const comment = this._commentLine.exec(input);
+          if (comment) {
+            if (this.comments)
+              emitToken('comment', comment[1], '', this._line, comment[0].length);
+            input = input.slice(comment[0].length);
+            currentLineLength = input.length;
+            this._line++;
+          }
+          else {
+            // A comment without a line ending stays buffered until EOF.
+            input = input.slice(separatorLength);
+            if (!inputFinished)
+              return this._input = input;
+            if (this.comments)
+              emitToken('comment', input.slice(1), '', this._line, input.length);
+            input = '';
+            break;
+          }
+        }
+        else if (charCode === LF || charCode === CR) {
+          separatorLength += charCode === CR && input.charCodeAt(separatorLength + 1) === LF ? 2 : 1;
+          // Indentation is part of the same separator match as the newline.
+          const next = input.charCodeAt(separatorLength);
+          if (next === SPACE || next === TAB) {
+            const following = input.charCodeAt(separatorLength + 1);
+            separatorLength += following === SPACE || following === TAB ?
+              this._whitespace.exec(input.slice(separatorLength))[0].length : 1;
+          }
+          input = input.slice(separatorLength);
+          currentLineLength = input.length;
+          this._line++;
+        }
+        else {
+          if (separatorLength !== 0)
+            input = input.slice(separatorLength);
+          break;
+        }
       }
-      // Skip whitespace on current line
-      if (!whiteSpaceMatch && (whiteSpaceMatch = this._whitespace.exec(input)))
-        input = input.slice(whiteSpaceMatch[0].length);
-
-      // Stop for now if we're at the end
-      if (this._endOfFile.test(input)) {
-        // If the input is finished, emit EOF
+      if (input.length === 0) {
         if (inputFinished) {
-          // Try to find a final comment
-          if (this.comments && (comment = this._comment.exec(input)))
-            emitToken('comment', comment[1], '', this._line, input.length);
           input = null;
           emitToken('eof', '', '', this._line, 0);
         }

--- a/test/N3Lexer-test.js
+++ b/test/N3Lexer-test.js
@@ -1966,6 +1966,29 @@ describe('Lexer', () => {
       }
     });
 
+    it.each([false, true])('keeps separator tokens across stream splits with comments=%s', comments => {
+      const input = '\t# first\n \t#\r  <s>\n\t# final';
+      const expected = [
+        { type: 'comment', value: ' first', prefix: '', line: 1 },
+        { type: 'comment', value: '', prefix: '', line: 2 },
+        { type: 'IRI', value: 's', prefix: '', line: 3 },
+        { type: 'comment', value: ' final', prefix: '', line: 4 },
+        { type: 'eof', value: '', prefix: '', line: 4 },
+      ].filter(token => comments || token.type !== 'comment');
+      for (let split = 0; split <= input.length; split++) {
+        const stream = new EventEmitter(), tokens = [];
+        new Lexer({ comments }).tokenize(stream, (error, token) => {
+          expect(error).toBeNull();
+          const { type, value, prefix, line } = token;
+          tokens.push({ type, value, prefix, line });
+        });
+        stream.emit('data', input.slice(0, split));
+        stream.emit('data', input.slice(split));
+        stream.emit('end');
+        expect(tokens).toEqual(expected);
+      }
+    });
+
     describe('passing data after the stream has been finished', () => {
       const tokens = [];
       let error;


### PR DESCRIPTION
Avoid three separator regex attempts before every token by dispatching on the next character. Single spaces/tabs and line endings use direct checks; longer horizontal runs retain regex scanning. Complete comment lines are consumed in one match, and unfinished comments remain buffered until their line ending or EOF arrives.

The remaining `_whitespace.exec()` and `_commentLine.exec()` calls intentionally scan runs in native regex code. Comparing direct JavaScript loops with this implementation improved some short runs, but screening found about 19% more parser CPU for 128-character indentation and 31% more for 512-character comments. A bounded short-whitespace loop improved lexer-only timing in seven-round confirmations without establishing an end-to-end parser gain, so the simpler scanner is retained.

This extracts the general separator optimization from #721. Named `SPACE`, `TAB`, `LF`, `CR`, and `HASH` constants, explicit `separatorLength`, and a `_commentLine` pattern make the hot path readable while keeping each operation local. The scanner preserves main's existing token objects, callback timing, and line-mode behavior; the coordinate and split-CRLF corrections belong to #721.

Merge this PR before #721, then rebase #721 to combine its range bookkeeping with this scanner. The PRs both target main and touch the same separator block; their combined implementation has already passed the range tests and generated coordinate checks.

Validation: all **6,898 tests pass with 100% statement, branch, function, and line coverage**, plus ESLint and Node/browser IIFE/ESM builds. Differential checks against main cover 3,600 generated documents, 29,220 two-chunk splits, and one-character chunks, including complete token objects, errors, and callback boundaries. The combined scanner and #721 range fixes pass 6,915 tests with 100% coverage, plus 5,654 independent coordinate checks, 2,231 streaming comparisons, and 28 lexer-reuse pairs.

Performance compares the published source with main `4607e09` using production Babel builds on macOS arm64 / Node 25.1.0. Seven paired rounds rotate fresh-process order, with 36 warmup and 36 measured iterations over 8,000-triple documents; streamed lexers use fresh instances and 64 KiB chunks. Full token/quad digests agree. Values are median paired CPU changes with bootstrap 95% intervals; negative means less CPU.

| Workload | CPU change | 95% interval |
| --- | ---: | ---: |
| lexer: dense | -49.3% | [-50.1%, -46.7%] |
| lexer: comments | -37.5% | [-37.7%, -36.8%] |
| lexer: comments-off | -13.1% | [-14.9%, -12.8%] |
| lexer: multiline | -31.5% | [-32.6%, -22.3%] |
| parser: dense | -13.9% | [-15.6%, -12.2%] |
| parser: comments | -10.4% | [-11.1%, -10.0%] |
| parser: comments-off | -10.6% | [-11.7%, -9.6%] |
| parser: multiline | -22.0% | [-22.7%, -21.3%] |
| stream: dense | -24.8% | [-39.2%, -23.8%] |
| stream: comments | -25.7% | [-28.0%, -24.2%] |
| stream: comments-off | +3.7% | [-10.2%, +8.9%] |
| stream: multiline | -34.4% | [-37.9%, -28.1%] |

The comments-off streamed result is inconclusive; it does not establish an improvement or regression. These synthetic timings are sensitive to runtime warmup and workload and are not application throughput guarantees. The earlier comment-body scanner showed a comment-heavy parser slowdown in one run; consuming each complete comment line in one match removed that observed slowdown in the final confirmation.

Additional seven-round checks (24 warmup and measured iterations):

| Workload | CPU change | 95% interval |
| --- | ---: | ---: |
| stream: dense, 8-byte chunks | -20.6% | [-20.9%, -19.0%] |
| lexer: deep-indent | -5.5% | [-11.0%, -2.2%] |
| lexer: crlf | -39.4% | [-40.4%, -33.5%] |
| lexer: long-space | -27.7% | [-34.4%, -25.9%] |

The current branch is rebased on main `e4e2148`, retaining the merged #726 direction-marker optimization. The benchmark tables above describe the original comparison against `4607e09`; they have not been relabeled as measurements of the new base. The rebased source passes the full test suite at 100% coverage, lint, Node/browser builds, and all GitHub checks.
