### PR TITLE
perf(lexer): identify literal delimiters with direct checks

### DIFF
--- a/src/N3Lexer.js
+++ b/src/N3Lexer.js
@@ -524,9 +524,12 @@ export default class N3Lexer {
   _parseLiteral(input) {
     // Ensure we have enough lookahead to identify triple-quoted strings
     if (input.length >= 3) {
-      // Identify the opening quote(s)
-      const opening = input.match(/^(?:"""|"|'''|'|)/)[0];
-      const openingLength = opening.length;
+      // The caller has already identified a single or double quote.
+      const quote = input[0];
+      const openingLength = input[1] === quote && input[2] === quote ? 3 : 1;
+      let opening = quote;
+      if (openingLength === 3)
+        opening = quote === '"' ? '"""' : "'''";
 
       // Find the next candidate closing quotes
       let closingPos = Math.max(this._literalClosingPos, openingLength);

--- a/test/N3Lexer-test.js
+++ b/test/N3Lexer-test.js
@@ -1945,6 +1945,30 @@ describe('Lexer', () => {
     });
 
     it.each([
+      ['"a\\"b"', 'a"b'],
+      ["'a\\'b'", "a'b"],
+      ['"""a""b\nc"""', 'a""b\nc'],
+      ["'''a''b\nc'''", "a''b\nc"],
+      ['""""""', ''],
+      ["''''''", ''],
+    ])('recognizes the literal delimiter across every split of %s', (input, value) => {
+      for (let split = 0; split <= input.length; split++) {
+        const stream = new EventEmitter(), tokens = [];
+        new Lexer().tokenize(stream, (error, token) => {
+          expect(error).toBeNull();
+          tokens.push({ type: token.type, value: token.value });
+        });
+        stream.emit('data', input.slice(0, split));
+        stream.emit('data', input.slice(split));
+        stream.emit('end');
+        expect(tokens).toEqual([
+          { type: 'literal', value },
+          { type: 'eof', value: '' },
+        ]);
+      }
+    });
+
+    it.each([
       [false, 'ltr'], [false, 'rtl'], [true, 'ltr'], [true, 'rtl'],
     ])('recognizes direction %s / %s across stream splits', (lineMode, direction) => {
       const input = `"hello"@en--${direction}`;


### PR DESCRIPTION
Identify a literal's opening delimiter with direct character checks instead of a regex match. Both callers of `_parseLiteral` have already identified a single or double quote, and the existing three-character lookahead guard remains. Triple delimiters reuse fixed strings, avoiding a new substring and regex match allocation.

This is independent of #721's range/reuse fixes, #727's separator dispatch, and #726's direction markers. Escape handling, closing-delimiter searches, literal values, token lengths, and streaming behavior are unchanged.

All **6,902 tests pass with 100% statement, branch, function, and line coverage**, plus ESLint and Node/browser IIFE/ESM builds. Added tests exercise both quote characters, escaped closing quotes, multiline strings, and empty triple-quoted strings at every two-chunk split. Existing malformed/unterminated literal tests remain unchanged.

Performance compares production Babel builds against main `4607e09` on macOS arm64 / Node 25.1.0: seven paired rounds in rotating fresh-process order, 36 warmup and 36 measured iterations over 8,000-triple documents. Full token/quad digests agree. Values are median paired CPU changes with bootstrap 95% intervals; negative means less CPU.

| Workload | CPU change | 95% interval |
| --- | ---: | ---: |
| lexer: dense | -0.2% | [-10.0%, +1.6%] |
| lexer: multiline | -9.7% | [-12.9%, -7.0%] |
| lexer: all-escaped | -4.5% | [-6.9%, -3.7%] |
| parser: dense | -0.7% | [-1.9%, +2.8%] |
| parser: multiline | -8.4% | [-9.8%, -5.7%] |
| parser: all-escaped | -10.0% | [-12.0%, -1.3%] |

Dense-input controls are consistent with no change. These local synthetic results do not guarantee the same gains for every workload or runtime.

The current branch is rebased on main `e4e2148`, retaining the merged #726 direction-marker optimization. The benchmark tables above describe the original comparison against `4607e09`; they have not been relabeled as measurements of the new base. The rebased source passes the full test suite at 100% coverage, lint, Node/browser builds, and all GitHub checks.
