### PR TITLE
perf(lexer): scan escape sequences directly

### DIFF
--- a/perf/N3LexerUnescape-perf.js
+++ b/perf/N3LexerUnescape-perf.js
@@ -1,0 +1,95 @@
+#!/usr/bin/env node
+// Run each checkout in a fresh process, alternating their order between rounds:
+// node --expose-gc perf/N3LexerUnescape-perf.js /path/to/built/checkout unicode8 parser
+const assert = require('assert'),
+    crypto = require('crypto'),
+    path = require('path'),
+    { EventEmitter } = require('events'),
+    { performance } = require('perf_hooks');
+
+const [directory, fixture, mode] = process.argv.slice(2);
+const fixtures = ['fixed', 'unicode4', 'unicode8', 'iri', 'local', 'denseEscapes',
+  'sparseLong', 'plainPrefixed', 'plainMultiline', 'dense'];
+if (!directory || !fixtures.includes(fixture) || !['lexer', 'parser', 'stream'].includes(mode)) {
+  console.error(`Usage: N3LexerUnescape-perf.js built-checkout [${fixtures.join('|')}] [lexer|parser|stream]`);
+  process.exit(1);
+}
+// The same benchmark loads either checkout's production build.
+// eslint-disable-next-line import-x/no-dynamic-require
+const { Lexer, Parser } = require(path.resolve(directory));
+
+const size = fixture === 'sparseLong' ? 256 : fixture === 'denseEscapes' ? 1000 : 8000;
+const prefix = fixture === 'local' || fixture === 'plainPrefixed' ? '@prefix ex: <http://example.org/>.\n' : '';
+const input = prefix + Array.from({ length: size }, (_, i) => {
+  const subject = `<http://example.org/s${i}>`, predicate = '<http://example.org/p>';
+  let raw;
+  switch (fixture) {
+  case 'fixed': raw = String.raw`a\tb\nc\r\f\b\\\"tail`; break;
+  case 'unicode4': raw = String.raw`a\u0041\u00e9\uFfFD\u03B2tail`; break;
+  case 'unicode8': raw = String.raw`a\U00000041\U0001f600\U0010FFFFtail`; break;
+  case 'denseEscapes': raw = String.raw`\n\t\r\u0061\U0001F600`.repeat(32); break;
+  case 'sparseLong': raw = `${'x'.repeat(4096)}\\u0061${'y'.repeat(4096)}`; break;
+  case 'iri': return `<http://example.org/\\u0073${i}> <http://example.org/\\U00000070> <http://example.org/\\U0001f600>.\n`;
+  case 'local': return `ex:item\\~\\-${i} ex:p ex:v\\#\\%${i}.\n`;
+  case 'plainPrefixed': return `ex:s${i} ex:p ex:o${i}.\n`;
+  case 'plainMultiline': return `${subject} ${predicate} """first\n${'x'.repeat(100)}\nlast""".\n`;
+  case 'dense': return `${subject}${predicate}<http://example.org/o${i}>.\n`;
+  }
+  return `${subject} ${predicate} "${raw} ${i}".\n`;
+}).join('');
+const chunks = [];
+for (let i = 0; i < input.length; i += 65536)
+  chunks.push(input.slice(i, i + 65536));
+const parserOptions = { format: fixture === 'dense' ? 'N-Triples' : 'Turtle' };
+const lexerOptions = { lineMode: fixture === 'dense' };
+let consumed = 0;
+
+function run(collect) {
+  if (mode !== 'stream') {
+    const result = mode === 'lexer' ? new Lexer(lexerOptions).tokenize(input) : new Parser(parserOptions).parse(input);
+    consumed += result.length;
+    return collect ? result : undefined;
+  }
+  const source = new EventEmitter(), result = collect ? [] : undefined;
+  new Parser(parserOptions).parse(source, (error, quad) => {
+    if (error)
+      throw error;
+    if (quad) {
+      consumed++;
+      if (collect)
+        result.push(quad);
+    }
+  });
+  for (const chunk of chunks)
+    source.emit('data', chunk);
+  source.emit('end');
+  return result;
+}
+
+// Validate and hash outside the timed loop; do not retain the result array.
+function validate() {
+  const result = run(true);
+  if (mode !== 'lexer')
+    assert.strictEqual(result.length, size);
+  return { count: result.length, digest: crypto.createHash('sha256').update(JSON.stringify(result)).digest('hex') };
+}
+const validation = validate();
+let start = performance.now(), warm = 0;
+while (warm < 8 || performance.now() - start < 350) {
+  run(false);
+  warm++;
+}
+if (typeof global.gc === 'function')
+  global.gc();
+const cpuStart = process.cpuUsage();
+start = performance.now();
+let iterations = 0;
+while (iterations < 16 || performance.now() - start < 600) {
+  run(false);
+  iterations++;
+}
+const wall = performance.now() - start, cpu = process.cpuUsage(cpuStart);
+console.log(JSON.stringify({
+  node: process.version, fixture, mode, bytes: Buffer.byteLength(input), ...validation,
+  warm, iterations, consumed, wallMs: wall / iterations, cpuMs: (cpu.user + cpu.system) / 1000 / iterations,
+}));

--- a/src/N3Lexer.js
+++ b/src/N3Lexer.js
@@ -5,8 +5,6 @@ import namespaces from './IRIs';
 const { xsd } = namespaces;
 const SPACE = 0x20, TAB = 0x09, LF = 0x0A, CR = 0x0D, HASH = 0x23;
 
-// Regular expression and replacement strings to unescape N3 strings
-const escapeSequence = /\\u([a-fA-F0-9]{4})|\\U([a-fA-F0-9]{8})|\\([^])/g;
 // Fixed escape sequences allowed in string literals (ECHAR)
 const stringEscapeReplacements = {
   '\\': '\\', "'": "'", '"': '"',
@@ -512,37 +510,48 @@ export default class N3Lexer {
   // ### `_unescape` replaces N3 escape codes by their corresponding characters,
   // allowing only the fixed escape sequences from the given replacement table
   _unescape(item, replacements) {
-    if (item.indexOf('\\') < 0)
+    let backslash = item.indexOf('\\');
+    if (backslash < 0)
       return item;
-    let invalid = false;
-    const replaced = item.replace(escapeSequence, (sequence, unicode4, unicode8, escapedChar) => {
-      // 4-digit unicode character
-      if (typeof unicode4 === 'string') {
-        const charCode = Number.parseInt(unicode4, 16);
-        if (!isValidCodePoint(charCode)) {
-          invalid = true;
-          return '';
+
+    let result = '', start = 0;
+    // A trailing lone backslash is not an escape sequence.
+    while (backslash >= 0 && backslash + 1 < item.length) {
+      const escapedChar = item[backslash + 1];
+      let end = backslash + 2, replacement;
+      if (escapedChar === 'u' || escapedChar === 'U') {
+        end += escapedChar === 'u' ? 4 : 8;
+        if (end > item.length)
+          return null;
+
+        let charCode = 0;
+        for (let i = backslash + 2; i < end; i++) {
+          let digit = item.charCodeAt(i);
+          if (digit >= 0x30 && digit <= 0x39) // 0–9
+            digit -= 0x30;
+          else if (digit >= 0x41 && digit <= 0x46) // A–F
+            digit -= 0x41 - 10;
+          else if (digit >= 0x61 && digit <= 0x66) // a–f
+            digit -= 0x61 - 10;
+          else
+            return null;
+          // Eight digits can exceed a signed 32-bit integer; avoid bitwise shifts.
+          charCode = charCode * 16 + digit;
         }
-        return String.fromCharCode(charCode);
+        if (!isValidCodePoint(charCode))
+          return null;
+        replacement = String.fromCodePoint(charCode);
       }
-      // 8-digit unicode character
-      if (typeof unicode8 === 'string') {
-        let charCode = Number.parseInt(unicode8, 16);
-        if (!isValidCodePoint(charCode)) {
-          invalid = true;
-          return '';
-        }
-        return charCode <= 0xFFFF ? String.fromCharCode(Number.parseInt(unicode8, 16)) :
-          String.fromCharCode(0xD800 + ((charCode -= 0x10000) >> 10), 0xDC00 + (charCode & 0x3FF));
+      else {
+        if (!(escapedChar in replacements))
+          return null;
+        replacement = replacements[escapedChar];
       }
-      // fixed escape sequence
-      if (escapedChar in replacements)
-        return replacements[escapedChar];
-      // invalid escape sequence
-      invalid = true;
-      return '';
-    });
-    return invalid ? null : replaced;
+      result += item.slice(start, backslash) + replacement;
+      start = end;
+      backslash = item.indexOf('\\', start);
+    }
+    return result + item.slice(start);
   }
 
   // ### `_parseLiteral` parses a literal into an unescaped value

--- a/test/N3Lexer-test.js
+++ b/test/N3Lexer-test.js
@@ -421,6 +421,78 @@ describe('Lexer', () => {
                      { type: 'eof', line: 1 }),
     );
 
+    it.each([
+      [String.raw`\u0000\uD7FF\uE000\uFfFf`, '\0\uD7FF\uE000\uFFFF'],
+      [String.raw`\U0000D7FF\U0000E000\U0010FfFf`, '\uD7FF\uE000\u{10FFFF}'],
+      [String.raw`\u0061f\U000000622`, 'afb2'],
+      [String.raw`\n\u0061\\\U0001F600`, '\na\\😀'],
+      [String.raw`\\u0061\\U0001F600`, String.raw`\u0061\U0001F600`],
+    ])('decodes adjacent escapes in %s exactly once', (raw, value) => {
+      expect(new Lexer().tokenize(`"${raw}" `)[0].value).toBe(value);
+    });
+
+    it.each([
+      '\\u', '\\u0', '\\u123', '\\U', '\\U0000000',
+      '\\UFFFFFFFF', '\\U80000000', '\\u-001', '\\u+001',
+      '\\u 001', '\\u0x41', '\\u00é1',
+    ])('rejects incomplete or invalid Unicode escape %s', raw => {
+      expect(() => new Lexer().tokenize(`"${raw}" `)).toThrow();
+    });
+
+    it.each([['u', 4], ['U', 8]])('validates every hex digit of a \\%s escape', (kind, length) => {
+      for (let position = 0; position < length; position++) {
+        for (const invalid of ['/', ':', '@', 'G', '`', 'g']) {
+          const raw = `\\${kind}${'0'.repeat(position)}${invalid}${'0'.repeat(length - position - 1)}`;
+          expect(() => new Lexer().tokenize(`"${raw}" `)).toThrow();
+        }
+      }
+    });
+
+    it.each([
+      String.raw`"\n\u0061\\\U0001F600" <urn:after>`,
+      String.raw`'\t\U00000061\u0062' <urn:after>`,
+      '"""first\n\\u0061\\U0001F600""" <urn:after>',
+      String.raw`<urn:\u0061\U0001F600> <urn:after>`,
+      String.raw`ex:a\~\#\%b <urn:after>`,
+    ])('decodes escapes at every stream split in %s', input => {
+      function fields({ type, value, prefix, line }) { return { type, value, prefix, line }; }
+      const expected = new Lexer().tokenize(input).map(fields);
+      for (let split = 0; split <= input.length; split++) {
+        const stream = new EventEmitter(), tokens = [];
+        new Lexer().tokenize(stream, (error, token) => {
+          expect(error).toBeNull();
+          tokens.push(fields(token));
+        });
+        stream.emit('data', input.slice(0, split));
+        stream.emit('data', input.slice(split));
+        stream.emit('end');
+        expect(tokens).toEqual(expected);
+      }
+    });
+
+    it.each([String.raw`\u12g4`, String.raw`\U0000000g`, String.raw`\UFFFFFFFF`])(
+      'rejects malformed escape %s at every stream split', raw => {
+        const input = `"${raw}" `;
+        for (let split = 0; split <= input.length; split++) {
+          const stream = new EventEmitter(), errors = [];
+          new Lexer().tokenize(stream, error => {
+            if (error)
+              errors.push(error.message);
+          });
+          stream.emit('data', input.slice(0, split));
+          stream.emit('data', input.slice(split));
+          stream.emit('end');
+          expect(errors).toEqual([`Unexpected ""${raw}"" on line 1.`]);
+        }
+      },
+    );
+
+    it.each([
+      ['plain', 'plain'], ['trailing\\', 'trailing\\'], ['\\ntrailing\\', '\ntrailing\\'],
+    ])('leaves non-escape text intact when unescaping %s', (input, expected) => {
+      expect(new Lexer()._unescape(input, { n: '\n' })).toBe(expected);
+    });
+
     it(
       'should not tokenize a string with invalid characters',
       shouldNotTokenize('"\\uXYZX" ',


### PR DESCRIPTION
When literals, IRIs, or prefixed names contain backslashes, `_unescape` currently runs a global regular-expression replacement with captures and a callback per escape. Replace that with native `indexOf` searches for backslashes, untouched string slices, and direct decoding of fixed and Unicode escapes.

The existing no-backslash fast path and ECHAR/PN_LOCAL_ESC replacement tables are retained. Unicode escapes validate every hex digit and reject surrogates and values above U+10FFFF; eight-digit accumulation uses arithmetic to avoid signed 32-bit overflow. Decoded output is never scanned again, and invalid escapes still return `null`. Token values, ranges, streaming errors, and callback timing are preserved.

This PR is based directly on main `0777d2e` and is independent of #721. The implementation uses explicit ASCII digit ranges; a bit-folding prototype did not show a consistent advantage.

### Performance

Production builds on macOS arm64; five paired fresh-process rounds on Node 24.12.0 and three on Node 25.1.0. The table shows the geometric mean wall-time change against main with exploratory 95% intervals; negative means faster. Rows measure the full parser unless labeled otherwise.

| Workload | Node 24 | Node 25 |
| --- | --- | --- |
| Fixed literal escapes | -35.0% (-37.7% to -32.1%) | -34.0% (-41.6% to -25.4%) |
| Four-digit Unicode escapes | -33.8% (-34.7% to -32.9%) | -37.0% (-39.2% to -34.7%) |
| Eight-digit Unicode escapes | -29.6% (-32.6% to -26.5%) | -32.4% (-37.5% to -26.8%) |
| Escaped IRIs | -34.5% (-36.2% to -32.6%) | -31.6% (-41.4% to -20.2%) |
| Escaped prefixed names | -32.8% (-34.6% to -31.0%) | -34.5% (-38.2% to -30.7%) |
| 160 escapes per literal | -61.7% (-62.5% to -60.9%) | -62.6% (-64.7% to -60.4%) |
| One escape in an 8 KiB literal | -21.7% (-22.7% to -20.8%) | -16.4% (-37.0% to +11.0%) |
| Unescaped prefixed names, lexer | +6.9% (-3.0% to +17.9%) | +1.1% (-30.3% to +46.6%) |
| Unescaped prefixed names, parser | +0.2% (-2.0% to +2.5%) | -1.9% (-9.3% to +6.1%) |
| Unescaped multiline literals | +2.8% (-3.8% to +9.8%) | -5.7% (-15.8% to +5.5%) |
| Unescaped dense N-Triples | -0.9% (-4.6% to +2.9%) | -0.4% (-2.2% to +1.4%) |
| Fixed escapes, streamed parser | -38.6% (-40.1% to -37.1%) | -41.2% (-42.8% to -39.6%) |
| Escaped prefixed names, streamed parser | -33.2% (-35.7% to -30.5%) | -36.4% (-40.1% to -32.5%) |

Short escaped-input parser fixtures improve by about 30–35% on Node 24; the dense-escape fixture improves by about 62%. Unescaped full-parser controls are within measurement noise. The unescaped-prefixed-name lexer point estimate is slower but inconclusive; these synthetic workloads do not establish a universal speedup or guarantee that every workload is regression-free.

Each run warms for at least 350 ms/8 iterations, explicitly collects garbage, then measures at least 600 ms/16 iterations. Fixtures contain 8,000 triples, except dense escapes (1,000) and sparse long literals (256). Streamed rows use synchronous delivery of 64 KiB chunks to exclude file I/O. Complete output hashes must match the baseline. A separate five-round, 26-workload run with GC before warm-up also showed escaped-input gains. Additional parse-plus-JSON-serialization checks retained gains for fixed escapes (27%), dense escapes (55%), and sparse long literals (11%), so consuming the decoded strings is covered too; the eight-digit Unicode serialization result was inconclusive.

`perf/N3LexerUnescape-perf.js` accepts either built checkout, a fixture, and a mode. Run the same script in fresh processes for both checkouts, alternating their order between rounds:

```sh
node --expose-gc perf/N3LexerUnescape-perf.js /path/to/built/baseline unicode8 parser
node --expose-gc perf/N3LexerUnescape-perf.js /path/to/built/candidate unicode8 parser
```

### Validation

- 6,953 tests pass with 100% statement, branch, function, and line coverage; lint and Node/browser IIFE/ESM builds pass.
- Added regression tests for malformed/truncated hex, scalar boundaries, adjacent escapes, decoding exactly once, trailing backslashes, and streaming splits.
- 402,432 differential decoding comparisons, including every four-digit value and randomized eight-digit/invalid sequences, match main.
- 13,695 two-chunk splits and 522 one-character streams match complete baseline token/error objects and callback timing.
- Independent review found no remaining actionable issues; its benchmark GC-placement feedback was incorporated.
