### PR TITLE
feat(parser): add token callbacks with a provenance reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,12 +129,13 @@ the callback is invoked one last time with `null` for `quad`
 and a hash of prefixes as third argument.
 <br>
 
-Alternatively, an object can be supplied, where `onQuad`, `onPrefix` and `onComment` are used to listen for `quads`, `prefixes` and `comments` as follows:
+Alternatively, an object can be supplied with named callbacks for quads, prefixes,
+comments, and token processing:
 ```JavaScript
 const parser = new N3.Parser();
 
 parser.parse(tomAndJerry, {
-  // onQuad (required) accepts a listener of type (quad: RDF.Quad) => void
+  // onQuad (optional) receives errors, quads, and completion
   onQuad: (err, quad) => { console.log(quad); },
   // onPrefix (optional) accepts a listener of type (prefix: string, iri: NamedNode) => void
   onPrefix: (prefix, iri) => { console.log(prefix, 'expands to', iri.value); },
@@ -142,6 +143,38 @@ parser.parse(tomAndJerry, {
   onComment: (comment) => { console.log('#', comment); },
 });
 ```
+
+`onToken(token)` runs immediately before a lexer token is processed, and
+`onTokenEnd(token)` runs immediately afterwards, including when processing throws.
+Both are optional synchronous observers; return values are ignored. For example:
+
+```JavaScript
+const tokens = [];
+const quads = parser.parse('<a> <b> "hello"@en.', {
+  onToken: token => tokens.push(token),
+  onTokenEnd: token => { /* Finish per-token bookkeeping here. */ },
+});
+```
+
+Omitting `onQuad` still returns the quads synchronously. With `onQuad`, the same
+observers work with asynchronous string parsing and streaming input. The token
+is the original lexer object: treat it as read-only. Its `line` is one-based;
+`start` and `end` are zero-based UTF-16 columns, with an exclusive end. A multiline
+token also has `endLine`. Whitespace between tokens is outside their ranges.
+
+Each token is observed once, even when the grammar internally reads it more than
+once. This includes `eof`: the final `onQuad(null, null, prefixes)` notification
+occurs between its `onToken` and `onTokenEnd`. Comments participate only when
+comment tokens are enabled by `onComment` or by a custom lexer's `comments`
+option; their `onComment` notification occurs between the two token observers.
+
+`onTokenEnd` also runs if `onToken` throws. Observer exceptions abort parsing and
+propagate through the call delivering tokens; they are not sent to `onQuad` as
+syntax errors. As with JavaScript `finally`, an exception from `onTokenEnd`
+replaces an exception already in flight. Callbacks must not reenter the parser or
+modify its tokens. Synchronous parsing tokenizes the whole string first, so a
+lexer error produces no token events; streaming can emit events before a later
+lexer error. Callbacks are registered separately for each `parse` call.
 
 If no callbacks are provided, parsing happens synchronously returning an array of quads:
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -342,6 +342,20 @@ export default [
     },
   },
 
+  // Reference implementations import the library they demonstrate.
+  {
+    files: ['examples/provenance/**'],
+    rules: {
+      'import-x/no-relative-parent-imports': 0,
+    },
+  },
+  {
+    files: ['examples/provenance/demo.js'],
+    rules: {
+      'no-console': 0,
+    },
+  },
+
   // Browser bundle test runner: a standalone Node script executed outside
   // jest (see test/browser/run.mjs), so console output is its interface.
   {

--- a/examples/provenance/EntityIndex.js
+++ b/examples/provenance/EntityIndex.js
@@ -1,0 +1,23 @@
+// Example adapter: keep provenance's indexing API outside the core Store.
+import { EntityIndex } from '../../src';
+
+export default class ProvenanceEntityIndex extends EntityIndex {
+  lookup(term) {
+    return this._termToNumericId(term);
+  }
+
+  intern(term) {
+    return this._termToNewNumericId(term);
+  }
+
+  resolve(id) {
+    const termId = this._entities[id];
+    return termId === undefined ? undefined : this._termFromId(termId);
+  }
+
+  internQuad(subject, predicate, object, graph = 1) {
+    const key = graph === 1 ? `.${subject}.${predicate}.${object}` :
+      `.${subject}.${predicate}.${object}.${graph}`;
+    return this._ids[key] || (this._ids[this._entities[++this._id] = key] = this._id);
+  }
+}

--- a/examples/provenance/ProvenanceIndex.js
+++ b/examples/provenance/ProvenanceIndex.js
@@ -39,26 +39,6 @@ function isClosedRange(range) {
   return range === null || !Array.isArray(range) || range[4];
 }
 
-function appendOccurrence(target, occurrence) {
-  const startOffset = target.length;
-  for (let index = 0; index < components.length; index++) {
-    const component = components[index], offset = startOffset + index * valuesPerRange;
-    const range = occurrence[component];
-    if (range === null) {
-      target[offset] = 0;
-      target[offset + 1] = 0;
-      target[offset + 2] = 0;
-      target[offset + 3] = 0;
-    }
-    else {
-      target[offset] = range.start.line;
-      target[offset + 1] = range.start.column;
-      target[offset + 2] = range.end.line;
-      target[offset + 3] = range.end.column;
-    }
-  }
-}
-
 function appendPending(target, pending) {
   for (const occurrence of pending)
     appendRanges(target, occurrence[0], occurrence[1], occurrence[2], occurrence[3]);
@@ -117,7 +97,13 @@ export class ProvenanceIndex {
   add(quad, occurrence) {
     // Pack first so malformed public input cannot partially mutate the index.
     const packed = [];
-    appendOccurrence(packed, occurrence);
+    for (const component of components) {
+      const range = occurrence[component];
+      if (range === null)
+        packed.push(0, 0, 0, 0);
+      else
+        packed.push(range.start.line, range.start.column, range.end.line, range.end.column);
+    }
 
     const quadId = this._entityIndex.intern(quad);
     this._finalize(quadId);

--- a/examples/provenance/ProvenanceIndex.js
+++ b/examples/provenance/ProvenanceIndex.js
@@ -1,0 +1,189 @@
+// **N3ProvenanceIndex** stores and resolves the locations of quad occurrences.
+import N3EntityIndex from './EntityIndex';
+
+const components = ['subject', 'predicate', 'object', 'graph'];
+const valuesPerRange = 4;
+const valuesPerOccurrence = components.length * valuesPerRange;
+
+function writeRange(target, offset, range) {
+  if (range === null) {
+    target[offset] = 0;
+    target[offset + 1] = 0;
+    target[offset + 2] = 0;
+    target[offset + 3] = 0;
+    return;
+  }
+  if (Array.isArray(range)) {
+    target[offset] = range[0];
+    target[offset + 1] = range[1];
+    target[offset + 2] = range[2];
+    target[offset + 3] = range[3];
+  }
+  else {
+    target[offset] = range.line;
+    target[offset + 1] = range.start;
+    target[offset + 2] = range.endLine || range.line;
+    target[offset + 3] = range.end;
+  }
+}
+
+function appendRanges(target, subject, predicate, object, graph) {
+  const offset = target.length;
+  writeRange(target, offset, subject);
+  writeRange(target, offset + valuesPerRange, predicate);
+  writeRange(target, offset + valuesPerRange * 2, object);
+  writeRange(target, offset + valuesPerRange * 3, graph);
+}
+
+function isClosedRange(range) {
+  return range === null || !Array.isArray(range) || range[4];
+}
+
+function appendOccurrence(target, occurrence) {
+  const startOffset = target.length;
+  for (let index = 0; index < components.length; index++) {
+    const component = components[index], offset = startOffset + index * valuesPerRange;
+    const range = occurrence[component];
+    if (range === null) {
+      target[offset] = 0;
+      target[offset + 1] = 0;
+      target[offset + 2] = 0;
+      target[offset + 3] = 0;
+    }
+    else {
+      target[offset] = range.start.line;
+      target[offset + 1] = range.start.column;
+      target[offset + 2] = range.end.line;
+      target[offset + 3] = range.end.column;
+    }
+  }
+}
+
+function appendPending(target, pending) {
+  for (const occurrence of pending)
+    appendRanges(target, occurrence[0], occurrence[1], occurrence[2], occurrence[3]);
+}
+
+function readRange(source, offset) {
+  return source[offset] === 0 ? null : {
+    start: { line: source[offset], column: source[offset + 1] },
+    end: { line: source[offset + 2], column: source[offset + 3] },
+  };
+}
+
+function materializeRange(range) {
+  if (range === null)
+    return null;
+  return Array.isArray(range) ? {
+    start: { line: range[0], column: range[1] },
+    end: { line: range[2], column: range[3] },
+  } : {
+    start: { line: range.line, column: range.start },
+    end: { line: range.endLine || range.line, column: range.end },
+  };
+}
+
+export function materializeOccurrence(subject, predicate, object, graph) {
+  return {
+    subject: materializeRange(subject),
+    predicate: materializeRange(predicate),
+    object: materializeRange(object),
+    graph: materializeRange(graph),
+  };
+}
+
+function readOccurrences(source) {
+  const occurrences = new Array(source.length / valuesPerOccurrence);
+  for (let offset = 0, index = 0; offset < source.length; offset += valuesPerOccurrence, index++) {
+    occurrences[index] = {
+      subject: readRange(source, offset),
+      predicate: readRange(source, offset + valuesPerRange),
+      object: readRange(source, offset + valuesPerRange * 2),
+      graph: readRange(source, offset + valuesPerRange * 3),
+    };
+  }
+  return occurrences;
+}
+
+export class ProvenanceIndex {
+  constructor(entityIndex = new N3EntityIndex()) {
+    this._entityIndex = entityIndex;
+    this._quadOccurrences = Object.create(null);
+    this._pendingOccurrences = Object.create(null);
+  }
+
+  // Adds public occurrence data by value. Later changes to `occurrence` do not
+  // alter the index.
+  add(quad, occurrence) {
+    // Pack first so malformed public input cannot partially mutate the index.
+    const packed = [];
+    appendOccurrence(packed, occurrence);
+
+    const quadId = this._entityIndex.intern(quad);
+    this._finalize(quadId);
+    const stored = this._quadOccurrences[quadId];
+    if (stored === undefined)
+      this._quadOccurrences[quadId] = packed;
+    else
+      stored.push(...packed);
+  }
+
+  // Adds the parser's compact, mutable range references. Compound ranges are
+  // finalized when parsing finishes, once their closing token is known.
+  _add(quadId, subject, predicate, object, graph) {
+    const pending = this._pendingOccurrences[quadId];
+    if (pending !== undefined) {
+      pending.push([subject, predicate, object, graph]);
+      return;
+    }
+
+    if (isClosedRange(subject) && isClosedRange(predicate) &&
+        isClosedRange(object) && isClosedRange(graph)) {
+      let stored = this._quadOccurrences[quadId];
+      if (stored === undefined)
+        stored = this._quadOccurrences[quadId] = [];
+      appendRanges(stored, subject, predicate, object, graph);
+      return;
+    }
+
+    this._pendingOccurrences[quadId] = [[subject, predicate, object, graph]];
+  }
+
+  _finalize(quadId) {
+    const pending = this._pendingOccurrences[quadId];
+    if (pending === undefined)
+      return;
+
+    let stored = this._quadOccurrences[quadId];
+    if (stored === undefined)
+      stored = this._quadOccurrences[quadId] = [];
+    appendPending(stored, pending);
+    delete this._pendingOccurrences[quadId];
+  }
+
+  _finalizeAll() {
+    const allPending = this._pendingOccurrences;
+    this._pendingOccurrences = Object.create(null);
+    for (const quadId in allPending) {
+      let stored = this._quadOccurrences[quadId];
+      if (stored === undefined)
+        stored = this._quadOccurrences[quadId] = [];
+      appendPending(stored, allPending[quadId]);
+    }
+  }
+
+  get(quad) {
+    const quadId = this._entityIndex.lookup(quad);
+    if (quadId === undefined)
+      return [];
+    this._finalize(quadId);
+    const occurrences = this._quadOccurrences[quadId];
+    return occurrences === undefined ? [] : readOccurrences(occurrences);
+  }
+
+  *[Symbol.iterator]() {
+    this._finalizeAll();
+    for (const quadId in this._quadOccurrences)
+      yield [this._entityIndex.resolve(quadId), readOccurrences(this._quadOccurrences[quadId])];
+  }
+}

--- a/examples/provenance/ProvenanceParser.js
+++ b/examples/provenance/ProvenanceParser.js
@@ -1,0 +1,66 @@
+// **N3ProvenanceParser** parses a document and indexes each quad utterance by
+// the locations emitted by N3TermLocationParser.
+import N3TermLocationParser from './TermLocationParser';
+import N3EntityIndex from './EntityIndex';
+import { ProvenanceIndex, materializeOccurrence } from './ProvenanceIndex';
+
+export { ProvenanceIndex };
+
+function isComplete(event) {
+  for (let i = 1; i < event.length; i++)
+    if (Array.isArray(event[i]) && !event[i][4])
+      return false;
+  return true;
+}
+
+export default class N3ProvenanceParser {
+  constructor(options = {}) { this._options = options || {}; }
+
+  parse(input) {
+    if (typeof input !== 'string')
+      throw new TypeError('ProvenanceParser.parse only accepts a string');
+
+    const { entityIndex: suppliedEntityIndex, onQuad, ...parserOptions } = this._options,
+        entityIndex = suppliedEntityIndex || new N3EntityIndex({ factory: parserOptions.factory }),
+        provenance = new ProvenanceIndex(entityIndex),
+        emitted = onQuad && [];
+    let nextEmission = 0, callbackFailed = false;
+    function flushEvents() {
+      while (emitted && nextEmission < emitted.length && isComplete(emitted[nextEmission])) {
+        const event = emitted[nextEmission++];
+        try {
+          onQuad(event[0], materializeOccurrence(event[1], event[2], event[3], event[4]));
+        }
+        catch (error) {
+          callbackFailed = true;
+          throw error;
+        }
+      }
+      if (emitted && nextEmission === emitted.length)
+        emitted.length = nextEmission = 0;
+    }
+    const parser = new N3TermLocationParser({
+      ...parserOptions,
+      entityIndex,
+      onQuad: (quad, quadId, subject, predicate, object, graph) => {
+        provenance._add(quadId, subject, predicate, object, graph);
+        if (emitted) {
+          emitted.push([quad, subject, predicate, object, graph]);
+          flushEvents();
+        }
+      },
+    });
+    let quads;
+    try {
+      quads = parser.parse(input);
+    }
+    catch (error) {
+      if (!callbackFailed)
+        flushEvents();
+      throw error;
+    }
+    provenance._finalizeAll();
+    flushEvents();
+    return { quads, provenance, prefixes: parser._prefixes };
+  }
+}

--- a/examples/provenance/README.md
+++ b/examples/provenance/README.md
@@ -1,0 +1,113 @@
+# Callback-based provenance reference
+
+This is a working experiment, adapted from
+[jeswr/N3.js#20](https://github.com/jeswr/N3.js/pull/20), for evaluating the public
+`Parser.parse` callbacks `onToken` and `onTokenEnd`. These files are deliberately
+outside `src`, N3's exports, and the published package. The first commit of this
+proposal contains only the callback API, its tests, and its documentation; the
+reference implementation is a separate commit that can be left out when landing.
+
+The callbacks replace the old private `_readToken` override. They are public
+observation points, **not a complete public grammar-extension API**. This example
+still subclasses private entity, literal, context, factory, and quad-emission
+methods to associate RDF terms with individual lexical occurrences. Its index
+adapter also uses N3 EntityIndex internals. An external package using this design
+must pin a compatible N3 version and retain integration tests when upgrading.
+
+## Try it
+
+From this repository after installing development dependencies:
+
+```sh
+node -r @babel/register examples/provenance/demo.js
+npm test -- --runInBand test/N3ProvenanceParser-test.js
+```
+
+```js
+import ProvenanceParser from './ProvenanceParser';
+import { Store } from '../../src'; // Use 'n3' in a separate package.
+
+const source = '<s> <p> "text"@en .\n<s> <p> "text"@en .';
+const { quads, provenance, prefixes } = new ProvenanceParser({
+  baseIRI: 'https://example.org/',
+  onQuad(quad, occurrence) {
+    // Optional: complete public occurrence ranges, in parse order.
+  },
+}).parse(source);
+
+const store = new Store(quads);
+const rebuiltQuad = store.getQuads(null, null, null, null)[0];
+console.log(provenance.get(rebuiltQuad)); // Two occurrences of this RDF quad.
+```
+
+`ProvenanceParser.parse` takes a string and returns `{ quads, provenance,
+prefixes }`. Each occurrence is `{ subject, predicate, object, graph }`. A
+component is either `null` (no lexical spelling) or:
+
+```js
+{
+  start: { line: 1, column: 0 },
+  end: { line: 1, column: 3 },
+}
+```
+
+Lines are one-based and columns count zero-based UTF-16 code units. Ends are
+exclusive. CRLF is one line break; CR and LF also break lines. Ranges refer to
+original source spellings, including escape sequences. Literals include their
+language, direction, or datatype suffix; compounds include their closing token.
+
+## What is tracked
+
+- Each repeated quad remains a distinct occurrence. The index groups by RDF
+  value, so lookup works after a Store reconstructs the quad or deduplicates it.
+- Subject/predicate abbreviations reuse the corresponding lexical ranges.
+- IRIs, prefixed names, blank-node labels, literals, variables, predicate
+  abbreviations, graphs, `()`, nonempty lists, property lists, formulas, and
+  triple terms carry ranges.
+- Parser-generated terms, such as list-tail nodes, `rdf:first`/`rdf:rest`
+  predicates, and reification scaffolding, carry `null` ranges.
+- N3 inverse predicates attach source ranges to the resulting quad positions.
+- Frozen and interning RDF/JS factories work: source metadata is held in temporary
+  occurrence wrappers rather than written onto emitted RDF/JS terms.
+
+`ProvenanceIndex.get(quad)` returns fresh occurrence objects. `add(quad,
+occurrence)` copies public range data. Iteration yields `[quad, occurrences]`
+pairs. Internally, an occurrence uses 16 numeric values (four coordinates for
+each component); zero line numbers encode `null`. Open compound ranges remain
+pending until parsing finishes. The example `EntityIndex` can also be shared
+with `new Store({ entityIndex })`.
+
+## Token lifecycle and streaming
+
+`TermLocationParser` uses `onToken` to set the current token and extend pending
+literal ranges. `onTokenEnd` clears temporary literal construction state and
+records the new literal's range after the grammar has consumed the token. This
+ordering handles adjacent N3 literals, where one token can both finish the
+previous literal and start another.
+
+The location parser inherits synchronous, callback, and stream input modes. Its
+constructor's internal `onQuad(quad, quadId, subject, predicate, object, graph)`
+receives compact, possibly still-open ranges; the facade adds indexing and
+complete public occurrence notifications. The string-only facade creates a new
+location parser per call, avoiding state leakage between documents. It is not
+a streaming provenance facade.
+
+A lexer error in synchronous parsing occurs before any provenance events. A
+later grammar error leaves already emitted `onQuad` events intact; events waiting
+for an unclosed compound are not emitted. Consumer exceptions abort immediately.
+Ranges on a custom lexer's tokens are validated before provenance processing.
+EOF and enabled comments are observable through the public token callbacks;
+comments do not disturb pending literal provenance.
+
+## Validation and extraction
+
+`test/N3ParserTokenCallbacks-test.js` tests the public callback contract without
+importing this example. `test/N3ProvenanceParser-test.js` tests the reference,
+including value-based lookup, duplicate occurrences, immutable factories,
+compound ranges, literal suffixes, current N3 inverse behavior, error delivery,
+and stream chunk boundaries.
+
+To land only the extension points, select the first callback commit. No Store,
+lexer, provenance class, or new package export is needed by that commit. The
+example commit also updates lint configuration so these demonstration files are
+checked alongside the main code.

--- a/examples/provenance/TermLocationParser.js
+++ b/examples/provenance/TermLocationParser.js
@@ -1,0 +1,304 @@
+// **N3TermLocationParser** tracks lexical term occurrences while parsing and
+// emits their compact source ranges alongside each quad.
+import { Parser as N3Parser, termToId } from '../../src';
+import N3EntityIndex from './EntityIndex';
+
+const compoundContexts = new Set(['blank', 'list', 'formula', '<<(', '<<']),
+    compoundTokens = new Set(['[', '(', '{', '<<(', '<<']);
+
+class TermOccurrence {
+  constructor(term, range) {
+    this.term = term;
+    this.range = range;
+    this.entityId = 0;
+  }
+
+  get id() { return termToId(this.term); }
+  get termType() { return this.term && this.term.termType; }
+  get value() { return this.term && this.term.value; }
+}
+
+function unwrap(value) {
+  return value instanceof TermOccurrence ? value.term : value;
+}
+
+function locate(value, range) {
+  return new TermOccurrence(unwrap(value), range);
+}
+
+function tokenRange(token, closed) {
+  return [token.line, token.start, token.endLine || token.line, token.end, closed];
+}
+
+function closeRange(range, token) {
+  range[2] = token.endLine || token.line;
+  range[3] = token.end;
+  range[4] = true;
+}
+
+function occurrenceRange(value) {
+  return value instanceof TermOccurrence ? value.range : null;
+}
+
+export default class N3TermLocationParser extends N3Parser {
+  constructor(options = {}) {
+    const { onQuad, entityIndex, ...parserOptions } = options;
+    super(parserOptions);
+
+    this._onQuad = onQuad || (() => {});
+    this._entityIndex = entityIndex || new N3EntityIndex({ factory: this._factory });
+    this._sourceRange = null;
+    this._literalRange = null;
+    this._constructingLiteralRange = null;
+    this._currentToken = null;
+    this._blankNodeRanges = null;
+    this._validateTokenRange = parserOptions.lexer !== undefined;
+    this._untrackedFactory = this._factory;
+    this._factory = {};
+
+    for (const name of ['namedNode', 'variable'])
+      this._factory[name] = (...args) => this._untrackedFactory[name](...args);
+    this._factory.blankNode = (...args) => {
+      const term = this._untrackedFactory.blankNode(...args),
+          range = this._blankNodeRanges && this._blankNodeRanges.length ?
+            this._blankNodeRanges.shift() :
+            this._currentToken && (this._currentToken.type === '[' || this._currentToken.type === '{') ?
+              this._sourceRange : null;
+      return range === null ? term : new TermOccurrence(term, range);
+    };
+    this._factory.literal = (...args) => {
+      for (let i = 0; i < args.length; i++)
+        args[i] = unwrap(args[i]);
+      return new TermOccurrence(
+        this._untrackedFactory.literal(...args), this._constructingLiteralRange || this._sourceRange,
+      );
+    };
+    this._factory.quad = (...args) => {
+      for (let i = 0; i < args.length; i++)
+        args[i] = unwrap(args[i]);
+      const term = this._untrackedFactory.quad(...args),
+          context = this._contextStack[this._contextStack.length - 1];
+      if (!context || !((context.type === '<<(' && this._currentToken.type === ')>>') ||
+                        (context.type === '<<' && this._currentToken.type === '>>')))
+        return term;
+      closeRange(context.sourceRange, this._currentToken);
+      return new TermOccurrence(term, context.sourceRange);
+    };
+  }
+
+  // A quantified entity can reuse an earlier RDF term, but each lexical use is
+  // a distinct occurrence.
+  _readEntity(token, quantifier) {
+    const blankNodeRanges = this._blankNodeRanges;
+    this._blankNodeRanges = null;
+    // Quantification in the core parser uses N3 terms' private IDs. Resolve
+    // it here by value so external RDF/JS factories work as well.
+    let term = super._readEntity(token, true);
+    if (term !== undefined && !quantifier && this._n3Mode) {
+      const id = termToId(unwrap(term));
+      if (id in this._quantified)
+        term = this._quantified[id];
+    }
+    this._blankNodeRanges = blankNodeRanges;
+    return term === undefined || this._readCallback === this._readPrefixIRI ?
+      term : locate(term, this._sourceRange);
+  }
+
+  // Predicate abbreviations resolve to parser constants, so give the constant
+  // a fresh occurrence for this spelling.
+  _readPredicate(token) {
+    const next = super._readPredicate(token);
+    if ((token.type === 'abbreviation' || token.type === 'inverse') && this._predicate !== null)
+      this._predicate = locate(this._predicate, this._sourceRange);
+    return next;
+  }
+
+  _saveContext(type, graph, subject, predicate, object) {
+    // Preserve the core parser's raw rdf:nil sentinel until its empty-list
+    // identity checks have run. Only occurrence metadata leaves this adapter.
+    if (type === 'item' && this._emptyListRange && object === this.RDF_NIL)
+      object = locate(object, this._emptyListRange);
+
+    super._saveContext(type, graph, subject, predicate, object);
+    if (compoundContexts.has(type))
+      this._contextStack[this._contextStack.length - 1].sourceRange = this._sourceRange;
+  }
+
+  _restoreContext(type, token) {
+    const context = this._contextStack[this._contextStack.length - 1];
+    if (context && context.type === type && context.sourceRange)
+      closeRange(context.sourceRange, token);
+    return super._restoreContext(type, token);
+  }
+
+  // Use the public token lifecycle; no private token dispatch override.
+  parse(input, quadCallback, prefixCallback, versionCallback) {
+    const callbacks = typeof quadCallback === 'function' ?
+      { onQuad: quadCallback, onPrefix: prefixCallback, onVersion: versionCallback } :
+      { ...quadCallback };
+    const { onToken, onTokenEnd } = callbacks;
+    callbacks.onToken = token => {
+      this._beginToken(token);
+      if (onToken) onToken(token);
+    };
+    callbacks.onTokenEnd = token => {
+      this._endToken(token);
+      if (onTokenEnd) onTokenEnd(token);
+    };
+    return super.parse(input, callbacks);
+  }
+
+  _beginToken(token) {
+    if (token.type === 'comment') return;
+    if (this._validateTokenRange) {
+      if (!Number.isFinite(token.line) || !Number.isFinite(token.start) ||
+          token.endLine !== undefined && !Number.isFinite(token.endLine) ||
+          !Number.isFinite(token.end))
+        throw new TypeError('Lexical provenance requires lexer tokens with numeric line, start, end, and multiline endLine');
+    }
+    this._currentToken = token;
+    this._sourceRange = compoundTokens.has(token.type) ? tokenRange(token, false) : token;
+
+    // Plain strings are constructed while processing a later token. Keep one
+    // mutable range so a language, direction, or datatype suffix is included.
+    if (this._literalRange !== null &&
+        (token.type === 'langcode' || token.type === 'dircode' ||
+         token.type === 'type' || token.type === 'typeIRI'))
+      closeRange(this._literalRange, token);
+
+    // A dircode replaces the language-only term that was constructed for the
+    // same lexical literal, so its factory call still belongs to that range.
+    if (token.type === 'dircode')
+      this._constructingLiteralRange = this._literalRange;
+  }
+
+  _endToken(token) {
+    if (token.type === 'comment') return;
+    this._constructingLiteralRange = null;
+
+    // Install a plain literal's pending range only after the callback. The
+    // callback can first complete the preceding literal and then consume this
+    // same token recursively (notably for adjacent N3 literals).
+    if (token.type === 'literal')
+      this._literalRange = token.prefix.length === 0 ? tokenRange(token, true) : null;
+    // A language literal may still be replaced by a directional literal.
+    else if (this._readCallback !== this._readDirCode)
+      this._literalRange = null;
+  }
+
+  _completeLiteral(token, component) {
+    this._constructingLiteralRange = this._literalRange;
+    try {
+      return super._completeLiteral(token, component);
+    }
+    finally {
+      this._constructingLiteralRange = null;
+    }
+  }
+
+  _readListItem(token) {
+    const context = this._contextStack[this._contextStack.length - 1];
+    if (token.type !== ')') {
+      const headRange = this._subject === null ? context.sourceRange : null;
+      this._blankNodeRanges = token.type === '[' || token.type === '{' ?
+        [headRange, this._sourceRange] : [headRange];
+    }
+
+    // Empty lists use a raw singleton inside the grammar. Attach their
+    // occurrence after the grammar has checked that sentinel by identity.
+    // Explicit rdf:nil terms are already wrapped, even with an interning factory.
+    const emptyRange = token.type === ')' && this._subject === null ? context.sourceRange : null;
+    this._emptyListRange = emptyRange;
+    try {
+      const next = super._readListItem(token);
+      if (emptyRange) {
+        for (const component of ['_subject', '_predicate', '_object'])
+          if (this[component] === this.RDF_NIL)
+            this[component] = locate(this[component], emptyRange);
+      }
+      return next;
+    }
+    finally {
+      this._blankNodeRanges = null;
+      this._emptyListRange = null;
+    }
+  }
+
+  _readFormulaTail(token) {
+    if (token.type !== '}')
+      return super._readFormulaTail(token);
+
+    const context = this._contextStack[this._contextStack.length - 1],
+        formula = this._graph,
+        range = context.sourceRange,
+        empty = this._emptyFormula,
+        component = context.subject === formula ? 'subject' :
+                    context.predicate === formula ? 'predicate' : 'object';
+    const next = super._readFormulaTail(token);
+    if (empty && this._emptyFormulaAsTrue)
+      this[`_${component}`] = locate(this.N3_TRUE, range);
+    return next;
+  }
+
+  _readNamedGraphLabel(token) {
+    if (token.type === '[')
+      this._namedGraphRange = this._sourceRange;
+    return super._readNamedGraphLabel(token);
+  }
+
+  _readNamedGraphBlankLabel(token) {
+    if (token.type === ']') {
+      closeRange(this._namedGraphRange, token);
+      this._blankNodeRanges = [this._namedGraphRange];
+    }
+    try {
+      return super._readNamedGraphBlankLabel(token);
+    }
+    finally {
+      this._blankNodeRanges = null;
+      this._namedGraphRange = null;
+    }
+  }
+
+  _termId(value) {
+    if (value instanceof TermOccurrence)
+      return value.entityId || (value.entityId = this._entityIndex.intern(value.term));
+    return this._entityIndex.intern(value);
+  }
+
+  _emit(subject, predicate, object, graph) {
+    this._emitLocated(subject, predicate, object, graph);
+  }
+
+  _emitInDirection(subject, predicate, object, graph, inversePredicate) {
+    if (inversePredicate)
+      this._emitLocated(object, predicate, subject, graph);
+    else
+      this._emitLocated(subject, predicate, object, graph);
+  }
+
+  _emitCurrentInDirection(subject, predicate, object, graph) {
+    this._emitInDirection(subject, predicate, object, graph, this._inversePredicate);
+  }
+
+  _emitLocated(subject, predicate, object, graph) {
+    // Nested empty lists emit their membership before _readListItem returns.
+    if (this._emptyListRange && predicate === this.RDF_FIRST && object === this.RDF_NIL)
+      object = locate(object, this._emptyListRange);
+    graph = graph || this.DEFAULTGRAPH;
+    const quad = this._untrackedFactory.quad(
+      unwrap(subject), unwrap(predicate), unwrap(object), unwrap(graph),
+    );
+    if (!quad || quad.termType !== 'Quad')
+      throw new TypeError('ProvenanceParser requires an RDF/JS-compatible data factory');
+
+    const quadId = this._entityIndex.internQuad(
+      this._termId(subject), this._termId(predicate), this._termId(object),
+      graph === this.DEFAULTGRAPH ? 1 : this._termId(graph),
+    );
+    this._onQuad(quad, quadId,
+      occurrenceRange(subject), occurrenceRange(predicate),
+      occurrenceRange(object), occurrenceRange(graph));
+    this._callback(null, quad);
+  }
+}

--- a/examples/provenance/demo.js
+++ b/examples/provenance/demo.js
@@ -1,0 +1,7 @@
+import { Store } from '../../src';
+import ProvenanceParser from './ProvenanceParser';
+
+const source = '<s> <p> "text"@en .\n<s> <p> "text"@en .';
+const { quads, provenance } = new ProvenanceParser({ baseIRI: 'https://example.org/' }).parse(source);
+const store = new Store(quads);
+console.log(JSON.stringify(provenance.get(store.getQuads(null, null, null, null)[0]), null, 2));

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "build:browser:iife": "node scripts/build-browser-bundle.js iife",
     "build:browser:esm": "node scripts/build-browser-bundle.js esm",
     "test": "jest",
-    "lint": "eslint src perf test spec",
+    "lint": "eslint src perf test spec examples/provenance",
     "prepare": "npm run build",
     "spec": "npm run spec-1-1 && npm run spec-1-2",
     "spec-1-1": "npm run spec-1-1-turtle && npm run spec-1-1-ntriples && npm run spec-1-1-nquads && npm run spec-1-1-trig",

--- a/src/N3Parser.js
+++ b/src/N3Parser.js
@@ -1564,14 +1564,17 @@ export default class N3Parser {
 
   // ### `parse` parses the N3 input and emits each parsed quad through the onQuad callback.
   parse(input, quadCallback, prefixCallback, versionCallback) {
-    // The second parameter accepts an object { onQuad: ..., onPrefix: ..., onComment: ...}
+    // The second parameter also accepts an object of named callbacks.
     // As a second and third parameter it still accepts a separate quadCallback and prefixCallback for backward compatibility as well
-    let onQuad, onPrefix, onComment, onVersion;
-    if (quadCallback && (quadCallback.onQuad || quadCallback.onPrefix || quadCallback.onComment || quadCallback.onVersion)) {
+    let onQuad, onPrefix, onComment, onVersion, onToken, onTokenEnd;
+    if (quadCallback && (quadCallback.onQuad || quadCallback.onPrefix || quadCallback.onComment || quadCallback.onVersion ||
+                         quadCallback.onToken || quadCallback.onTokenEnd)) {
       onQuad = quadCallback.onQuad;
       onPrefix = quadCallback.onPrefix;
       onComment = quadCallback.onComment;
       onVersion = quadCallback.onVersion;
+      onToken = quadCallback.onToken;
+      onTokenEnd = quadCallback.onTokenEnd;
     }
     else {
       onQuad = quadCallback;
@@ -1595,41 +1598,59 @@ export default class N3Parser {
     this._quantified = Object.create(null);
     this._emptyFormula = false;
 
-    // Parse synchronously if no quad callback is given
+    let readToken = token => {
+      return this._readCallback = this._readCallback(token);
+    };
+
+    // Comments bypass the grammar, but participate in the token lifecycle.
+    if (onComment || this._lexer.comments) {
+      this._lexer.comments = true;
+      const readGrammarToken = readToken;
+      readToken = token => {
+        if (token.type !== 'comment')
+          return readGrammarToken(token);
+        if (onComment) onComment(token.value);
+        return this._readCallback;
+      };
+    }
+
+    // Install observers once per parse, leaving the ordinary token path intact.
+    if (onToken || onTokenEnd) {
+      const consumeToken = readToken;
+      readToken = token => {
+        try {
+          try {
+            if (onToken) onToken(token);
+            return consumeToken(token);
+          }
+          finally {
+            if (onTokenEnd) onTokenEnd(token);
+          }
+        }
+        catch (error) {
+          // A consumer exception aborts this parse, including later chunks.
+          this._readCallback = null;
+          throw error;
+        }
+      };
+    }
+
+    // Parse synchronously if no quad callback is given.
     if (!onQuad) {
       const quads = [];
       let error;
       this._callback = (e, t) => { e ? (error = e) : t && quads.push(t); };
-      this._lexer.tokenize(input).every(token => {
-        return this._readCallback = this._readCallback(token);
-      });
+      this._lexer.tokenize(input).every(readToken);
       if (error) throw error;
       return quads;
     }
 
-    let processNextToken = (error, token) => {
+    const processNextToken = (error, token) => {
       if (error !== null)
         this._callback(error), this._callback = noop;
       else if (this._readCallback)
-        this._readCallback = this._readCallback(token);
+        readToken(token);
     };
-
-    // Enable checking for comments on every token when a commentCallback has been set
-    if (onComment) {
-      // Enable the lexer to return comments as tokens first (disabled by default)
-      this._lexer.comments = true;
-      // Patch the processNextToken function
-      processNextToken = (error, token) => {
-        if (error !== null)
-          this._callback(error), this._callback = noop;
-        else if (this._readCallback) {
-          if (token.type === 'comment')
-            onComment(token.value);
-          else
-            this._readCallback = this._readCallback(token);
-        }
-      };
-    }
 
     // Parse asynchronously otherwise, executing the read callback when a token arrives
     this._callback = onQuad;

--- a/test/N3ParserTokenCallbacks-test.js
+++ b/test/N3ParserTokenCallbacks-test.js
@@ -1,0 +1,143 @@
+import { Parser, Lexer } from '../src';
+import { EventEmitter } from 'events';
+
+const document = '<s> <p> "hello"@en .';
+
+function record(events) {
+  return {
+    onToken: token => events.push(['before', token]),
+    onTokenEnd: token => events.push(['after', token]),
+  };
+}
+
+describe('Parser token callbacks', () => {
+  it('observes each token once before and after processing, including EOF', () => {
+    const events = [];
+    const quads = new Parser().parse(document, record(events));
+    const tokens = new Lexer().tokenize(document);
+    expect(quads).toHaveLength(1);
+    expect(events).toEqual(tokens.flatMap(token => [['before', token], ['after', token]]));
+    expect(events[0][1]).toBe(events[1][1]);
+  });
+
+  it.each(['onToken', 'onTokenEnd'])('accepts %s alone without changing synchronous return values', name => {
+    const tokens = [];
+    const quads = new Parser().parse(document, { [name]: token => tokens.push(token) });
+    expect(quads).toEqual(new Parser().parse(document));
+    expect(tokens).toEqual(new Lexer().tokenize(document));
+  });
+
+  it('ignores observer return values', () => {
+    const quads = new Parser().parse(document, { onToken: () => false, onTokenEnd: () => false });
+    expect(quads).toHaveLength(1);
+  });
+
+  it('brackets quad and completion callbacks with the corresponding token callbacks', async () => {
+    const events = [];
+    await new Promise((resolve, reject) => {
+      new Parser().parse('<s> <p> <o>.', {
+        onToken: token => events.push(`before:${token.type}`),
+        onTokenEnd: token => events.push(`after:${token.type}`),
+        onQuad: (error, quad) => {
+          if (error) return reject(error);
+          events.push(quad ? 'quad' : 'complete');
+          if (!quad) resolve();
+        },
+      });
+    });
+    expect(events.slice(-6)).toEqual(['before:.', 'quad', 'after:.', 'before:eof', 'complete', 'after:eof']);
+  });
+
+  it('has identical token events for a string and one-character stream chunks', () => {
+    const expected = [], actual = [], quads = [], input = new EventEmitter();
+    new Parser().parse(document, record(expected));
+    new Parser().parse(input, {
+      ...record(actual),
+      onQuad: (error, quad) => { if (error) throw error; if (quad) quads.push(quad); },
+    });
+    for (const char of document) input.emit('data', char);
+    input.emit('end');
+    expect(actual).toEqual(expected);
+    expect(quads).toHaveLength(1);
+  });
+
+  it('observes enabled comments around onComment without sending them to the grammar', () => {
+    const events = [];
+    const quads = new Parser().parse('# note\n<s> <p> <o>.', {
+      onToken: token => events.push(`before:${token.type}`),
+      onTokenEnd: token => events.push(`after:${token.type}`),
+      onComment: comment => events.push(comment),
+    });
+    expect(events.slice(0, 3)).toEqual(['before:comment', ' note', 'after:comment']);
+    expect(quads).toHaveLength(1);
+  });
+
+  it('supports comment-enabled custom lexers without requiring onComment', () => {
+    const events = [];
+    new Parser({ lexer: new Lexer({ comments: true }) }).parse('# note\n', record(events));
+    expect(events.map(([phase, token]) => `${phase}:${token.type}`))
+      .toEqual(['before:comment', 'after:comment', 'before:eof', 'after:eof']);
+  });
+
+  it('does not enable comment tokens just by registering token observers', () => {
+    const events = [];
+    new Parser().parse('# note\n', record(events));
+    expect(events.map(([, token]) => token.type)).toEqual(['eof', 'eof']);
+  });
+
+  it('does not retain callbacks on reuse, including after enabling comments', () => {
+    const parser = new Parser(), events = [], comments = [];
+    parser.parse('# first\n', { ...record(events), onComment: text => comments.push(text) });
+    const previous = events.slice();
+    expect(parser.parse('# second\n<s> <p> <o>.')).toHaveLength(1);
+    expect(events).toEqual(previous);
+    expect(comments).toEqual([' first']);
+  });
+
+  it('ends the offending token and stops at a grammar error', () => {
+    const events = [];
+    expect(() => new Parser().parse('<s> . <p> <o>.', record(events))).toThrow('Unexpected .');
+    expect(events.map(([phase, token]) => `${phase}:${token.type}`))
+      .toEqual(['before:IRI', 'after:IRI', 'before:.', 'after:.']);
+  });
+
+  it('does not emit synchronous token events when lexing fails before parsing', () => {
+    const events = [];
+    expect(() => new Parser().parse('<s> <p> <o>. "unterminated', record(events))).toThrow();
+    expect(events).toEqual([]);
+  });
+
+  it.each(['onToken', 'onTokenEnd', 'onQuad'])('aborts later stream chunks when %s throws', name => {
+    const error = new Error('consumer failed'), events = [], input = new EventEmitter();
+    const callbacks = {
+      ...record(events),
+      onQuad: (error, quad) => { if (error) throw error; },
+    };
+    callbacks[name] = () => { throw error; };
+    new Parser().parse(input, callbacks);
+    expect(() => input.emit('data', '<s> <p> <o>. ')).toThrow(error);
+    const stopped = events.slice();
+    input.emit('data', '<a> <b> <c>. ');
+    input.emit('end');
+    expect(events).toEqual(stopped);
+  });
+
+  it('runs onTokenEnd for cleanup when onToken throws', () => {
+    const error = new Error('stop'), ended = [];
+    expect(() => new Parser().parse(document, {
+      onToken: () => { throw error; },
+      onTokenEnd: token => ended.push(token),
+    })).toThrow(error);
+    expect(ended).toEqual([new Lexer().tokenize(document)[0]]);
+  });
+
+  it('does not synthesize token events for input stream errors', () => {
+    const events = [], errors = [], input = new EventEmitter(), error = new Error('input failed');
+    new Parser().parse(input, {
+      ...record(events), onQuad: error => errors.push(error),
+    });
+    input.emit('error', error);
+    expect(events).toEqual([]);
+    expect(errors).toEqual([error]);
+  });
+});

--- a/test/N3ProvenanceParser-test.js
+++ b/test/N3ProvenanceParser-test.js
@@ -1,0 +1,964 @@
+import { Lexer, Parser, Store, DataFactory } from '../src';
+import ProvenanceParser, { ProvenanceIndex } from '../examples/provenance/ProvenanceParser';
+import EntityIndex from '../examples/provenance/EntityIndex';
+import N3TermLocationParser from '../examples/provenance/TermLocationParser';
+import rdfDataModel from '@rdfjs/data-model';
+import { isomorphic } from 'rdf-isomorphic';
+import { EventEmitter } from 'events';
+
+const BASE_IRI = 'http://example.org/';
+
+function parse(doc, options = {}) {
+  return new ProvenanceParser({ baseIRI: BASE_IRI, blankNodePrefix: '', ...options }).parse(doc);
+}
+function offset(doc, position) {
+  const newline = /\r\n|\r|\n/g;
+  let lineStart = 0;
+  for (let line = 1; line < position.line; line++) {
+    const match = newline.exec(doc);
+    lineStart = match.index + match[0].length;
+  }
+  return lineStart + position.column;
+}
+function slice(doc, range) {
+  return doc.slice(offset(doc, range.start), offset(doc, range.end));
+}
+function frozenInterningFactory() {
+  const terms = new Map(), factory = Object.create(DataFactory);
+  factory.namedNode = value => {
+    let term = terms.get(value);
+    if (term === undefined)
+      terms.set(value, term = Object.freeze(DataFactory.namedNode(value)));
+    return term;
+  };
+  factory.literal = (...args) => Object.freeze(DataFactory.literal(...args));
+  factory.blankNode = (...args) => Object.freeze(DataFactory.blankNode(...args));
+  factory.variable = (...args) => Object.freeze(DataFactory.variable(...args));
+  factory.defaultGraph = () => Object.freeze(DataFactory.defaultGraph());
+  factory.quad = (...args) => Object.freeze(DataFactory.quad(...args));
+  return factory;
+}
+
+describe('ProvenanceParser', () => {
+  describe('utterance multiset semantics', () => {
+    it('records two utterances for the same quad uttered twice', () => {
+      const doc = '<s> <p> <o> .\n<s> <p> <o> .';
+      const { quads, provenance } = parse(doc);
+      expect(quads).toHaveLength(2);
+      const utts = provenance.get(quads[0]);
+      expect(utts).toHaveLength(2);
+      expect(slice(doc, utts[0].subject)).toBe('<s>');
+      expect(utts[0].subject.start).not.toEqual(utts[1].subject.start);
+    });
+
+    it('packs occurrence data directly for duplicate utterances', () => {
+      const doc = '<s> <p> <o> .\n<s> <p> <o> .\n<s> <p> <o> .';
+      const { quads, provenance } = parse(doc);
+      expect(provenance.get(quads[0])).toHaveLength(3);
+      const occurrences = Object.values(provenance._quadOccurrences)[0];
+      expect(occurrences).toHaveLength(48);
+      expect(occurrences.every(value => typeof value === 'number')).toBe(true);
+    });
+
+    it('reuses the subject span across a predicateObjectList', () => {
+      const doc = '<s> <p1> <o1> ;\n    <p2> <o2> .';
+      const { quads, provenance } = parse(doc);
+      const [u1] = provenance.get(quads[0]);
+      const [u2] = provenance.get(quads[1]);
+      expect(u1.subject).toEqual(u2.subject);
+      expect(slice(doc, u2.predicate)).toBe('<p2>');
+      expect(u2.predicate.start.line).toBe(2);
+    });
+
+    it.each([
+      ['LF', '\n'],
+      ['CRLF', '\r\n'],
+      ['CR', '\r'],
+    ])('converts indented line positions after %s to source offsets', (_, newline) => {
+      const doc = `<s> <p> <o> .${newline}  <s2> <p2> <o2> .`;
+      const { quads, provenance } = parse(doc);
+      const [utterance] = provenance.get(quads[1]);
+      expect(utterance.subject.start).toEqual({ line: 2, column: 2 });
+      expect(slice(doc, utterance.subject)).toBe('<s2>');
+    });
+
+    it('carries all four ranges in N-Quads', () => {
+      const doc = '<http://e/s> <http://e/p> <http://e/o> <http://e/g> .';
+      const { quads, provenance } = parse(doc, { format: 'application/n-quads' });
+      const occurrence = provenance.get(quads[0])[0];
+      expect(['subject', 'predicate', 'object', 'graph'].map(component => slice(doc, occurrence[component])))
+        .toEqual(['<http://e/s>', '<http://e/p>', '<http://e/o>', '<http://e/g>']);
+    });
+
+    it('associates inverted N3 terms with their resulting quad positions', () => {
+      const doc = '<o> is <p> of <s> .';
+      const { quads, provenance } = parse(doc, { format: 'text/n3' });
+      const occurrence = provenance.get(quads[0])[0];
+      expect(['subject', 'predicate', 'object'].map(component => slice(doc, occurrence[component])))
+        .toEqual(['<s>', '<p>', '<o>']);
+    });
+
+    it.each([
+      ['LF', '\n'],
+      ['CRLF', '\r\n'],
+      ['CR', '\r'],
+    ])('converts a multiline literal containing %s to a source range', (_, newline) => {
+      const lexicalLiteral = `"""first${newline}second"""`;
+      const doc = `<s> <p> ${lexicalLiteral} .`;
+      const { quads, provenance } = parse(doc);
+      const location = provenance.get(quads[0])[0].object;
+      expect(location).toEqual({
+        start: { line: 1, column: 8 },
+        end: { line: 2, column: 9 },
+      });
+      expect(slice(doc, location)).toBe(lexicalLiteral);
+    });
+
+    it('includes a suffix after a multiline literal', () => {
+      const literal = '"""first\nsecond"""@en--rtl';
+      const doc = `<s> <p> ${literal} .`;
+      const { quads, provenance } = parse(doc);
+      expect(slice(doc, provenance.get(quads[0])[0].object)).toBe(literal);
+    });
+
+    it('accounts for a byte-order mark when converting line positions', () => {
+      const doc = '\uFEFF<s> <p> <o> .';
+      const { quads, provenance } = parse(doc);
+      const subject = provenance.get(quads[0])[0].subject;
+      expect(subject.start).toEqual({ line: 1, column: 1 });
+      expect(slice(doc, subject)).toBe('<s>');
+    });
+
+    it('covers original escaped spellings rather than decoded values', () => {
+      const doc = '@prefix ex: <http://e/>. ex:s ex:p\\-x "a\\tb" .';
+      const { quads, provenance } = parse(doc);
+      const occurrence = provenance.get(quads[0])[0];
+      expect(slice(doc, occurrence.subject)).toBe('ex:s');
+      expect(slice(doc, occurrence.predicate)).toBe('ex:p\\-x');
+      expect(slice(doc, occurrence.object)).toBe('"a\\tb"');
+    });
+
+    it('gives anonymous property-list terms their complete span', () => {
+      const doc = '[ <p> <o> ] <q> <r> .';
+      const { quads, provenance } = parse(doc);
+      const inner = quads.find(q => q.predicate.value === `${BASE_IRI}p`);
+      const [u] = provenance.get(inner);
+      expect(slice(doc, u.subject)).toBe('[ <p> <o> ]');
+      expect(slice(doc, u.object)).toBe('<o>');
+    });
+
+    it('spans literals, including language-tagged ones', () => {
+      const doc = '<s> <p> "hello"@en .';
+      const { quads, provenance } = parse(doc);
+      const [u] = provenance.get(quads[0]);
+      expect(slice(doc, u.object)).toBe('"hello"@en');
+    });
+  });
+
+  describe('value-keyed lookup', () => {
+    it('allows occurrences to be added through the public API', () => {
+      const provenance = new ProvenanceIndex();
+      const quad = DataFactory.quad(
+        DataFactory.namedNode('x:s'), DataFactory.namedNode('x:p'), DataFactory.namedNode('x:o'),
+      );
+      const occurrence = { subject: null, predicate: null, object: null, graph: null };
+      provenance.add(quad, occurrence);
+      expect(provenance.get(quad)).toEqual([occurrence]);
+      provenance.add(quad, occurrence);
+      expect(provenance.get(quad)).toHaveLength(2);
+    });
+
+    it('snapshots public additions and returns fresh occurrence values', () => {
+      const provenance = new ProvenanceIndex();
+      const quad = DataFactory.quad(
+        DataFactory.namedNode('x:s'), DataFactory.namedNode('x:p'), DataFactory.namedNode('x:o'),
+      );
+      const occurrence = {
+        subject: { start: { line: 1, column: 0 }, end: { line: 1, column: 3 } },
+        predicate: null,
+        object: null,
+        graph: null,
+      };
+      provenance.add(quad, occurrence);
+      occurrence.subject.start.column = 99;
+      const first = provenance.get(quad);
+      first[0].subject.start.column = 88;
+      expect(provenance.get(quad)[0].subject.start.column).toBe(0);
+    });
+
+    it('does not retain partial data when a public occurrence is malformed', () => {
+      const provenance = new ProvenanceIndex(), quad = DataFactory.quad(
+        DataFactory.namedNode('x:s'), DataFactory.namedNode('x:p'), DataFactory.namedNode('x:o'),
+      );
+      expect(() => provenance.add(quad, {
+        subject: { start: { line: 1, column: 0 }, end: { line: 1, column: 3 } },
+      })).toThrow();
+      expect([...provenance]).toEqual([]);
+
+      const occurrence = { subject: null, predicate: null, object: null, graph: null };
+      provenance.add(quad, occurrence);
+      expect(provenance.get(quad)).toEqual([occurrence]);
+    });
+
+    it('does not allocate an entity ID for an unknown lookup', () => {
+      const entityIndex = new EntityIndex(), provenance = new ProvenanceIndex(entityIndex);
+      const quad = DataFactory.quad(
+        DataFactory.namedNode('x:s'), DataFactory.namedNode('x:p'), DataFactory.namedNode('x:o'),
+      );
+      const allocatedIds = entityIndex._id;
+      expect(provenance.get(quad)).toEqual([]);
+      expect(entityIndex._id).toBe(allocatedIds);
+    });
+
+    it('returns no occurrences for a known but unrecorded quad', () => {
+      const entityIndex = new EntityIndex(), provenance = new ProvenanceIndex(entityIndex);
+      const quad = DataFactory.quad(
+        DataFactory.namedNode('x:s'), DataFactory.namedNode('x:p'), DataFactory.namedNode('x:o'),
+      );
+      entityIndex.intern(quad);
+      expect(provenance.get(quad)).toEqual([]);
+    });
+
+    it('appends pending parser data after an existing public occurrence', () => {
+      const entityIndex = new EntityIndex(), provenance = new ProvenanceIndex(entityIndex);
+      const quad = DataFactory.quad(
+        DataFactory.namedNode('x:s'), DataFactory.namedNode('x:p'), DataFactory.namedNode('x:o'),
+      );
+      const occurrence = { subject: null, predicate: null, object: null, graph: null };
+      provenance.add(quad, occurrence);
+      const range = [1, 0, 1, 3, false], quadId = entityIndex.lookup(quad);
+      provenance._add(quadId, range, null, null, null);
+      expect(provenance.get(quad)).toHaveLength(2);
+    });
+
+    it('groups multiple pending occurrences before compacting them', () => {
+      const entityIndex = new EntityIndex(), provenance = new ProvenanceIndex(entityIndex);
+      const quad = DataFactory.quad(
+        DataFactory.namedNode('x:s'), DataFactory.namedNode('x:p'), DataFactory.namedNode('x:o'),
+      );
+      const quadId = entityIndex.intern(quad), range = [1, 0, 1, 3, false];
+      provenance._add(quadId, range, null, null, null);
+      provenance._add(quadId, range, null, null, null);
+      range[4] = true;
+      expect(provenance.get(quad)).toHaveLength(2);
+    });
+
+    it('finalizes pending data behind an existing compact occurrence', () => {
+      const entityIndex = new EntityIndex(), provenance = new ProvenanceIndex(entityIndex);
+      const quad = DataFactory.quad(
+        DataFactory.namedNode('x:s'), DataFactory.namedNode('x:p'), DataFactory.namedNode('x:o'),
+      );
+      provenance.add(quad, { subject: null, predicate: null, object: null, graph: null });
+      const range = [1, 0, 1, 3, false];
+      provenance._add(entityIndex.lookup(quad), range, null, null, null);
+      range[4] = true;
+      provenance._finalizeAll();
+      expect(provenance.get(quad)).toHaveLength(2);
+    });
+
+    it('keeps closed occurrences behind an earlier pending occurrence', () => {
+      const entityIndex = new EntityIndex(), provenance = new ProvenanceIndex(entityIndex);
+      const quad = DataFactory.quad(
+        DataFactory.namedNode('x:s'), DataFactory.namedNode('x:p'), DataFactory.namedNode('x:o'),
+      );
+      const quadId = entityIndex.intern(quad), range = [1, 2, 1, 5, false];
+      provenance._add(quadId, range, null, null, null);
+      provenance._add(quadId, null, null, null, null);
+      range[4] = true;
+      expect(provenance.get(quad).map(({ subject }) => subject && subject.start.column))
+        .toEqual([2, null]);
+    });
+
+    it('resolves quads reconstructed by a store', () => {
+      const doc = '<s> <p> "lit" .';
+      const { quads, provenance } = parse(doc);
+      const store = new Store(quads);
+      const rebuilt = store.getQuads(null, null, null)[0];
+      expect(rebuilt).not.toBe(quads[0]);
+      expect(provenance.get(rebuilt)).toHaveLength(1);
+    });
+
+    it('shares compact numeric quad identities with an N3 entity index', () => {
+      const entityIndex = new EntityIndex();
+      const { quads, provenance } = parse('<s> <p> "lit" .', { entityIndex });
+      const allocatedIds = entityIndex._id;
+      const quadId = entityIndex._termToNumericId(quads[0]);
+      expect(quadId).toEqual(expect.any(Number));
+      expect(Object.getPrototypeOf(provenance._quadOccurrences)).toBeNull();
+      expect(provenance._quadOccurrences[quadId]).toHaveLength(16);
+
+      const store = new Store({ entityIndex });
+      store.addQuads(quads);
+      expect(entityIndex._id).toBe(allocatedIds);
+      expect(provenance.get(store.getQuads(null, null, null)[0])).toHaveLength(1);
+    });
+
+    it('preserves duplicate insertion order', () => {
+      const doc = '<s> <p> <o> .\n\n  <s> <p> <o> .';
+      const { quads, provenance } = parse(doc);
+      const occurrences = provenance.get(quads[0]);
+      expect(occurrences.map(({ subject }) => subject.start)).toEqual([
+        { line: 1, column: 0 },
+        { line: 3, column: 2 },
+      ]);
+    });
+  });
+
+  describe('TriG', () => {
+    it('carries the graph label span', () => {
+      const doc = '<g> { <s> <p> <o> }';
+      const { quads, provenance } = parse(doc, { format: 'application/trig' });
+      const [u] = provenance.get(quads[0]);
+      expect(slice(doc, u.graph)).toBe('<g>');
+    });
+  });
+
+  describe('RDF 1.2', () => {
+    it('spans annotation-derived reification quads', () => {
+      const doc = '<s> <p> <o> ~ <r> {| <a> <b> |} .';
+      const { quads, provenance } = parse(doc);
+      const reifies = quads.find(q => q.predicate.value.endsWith('#reifies'));
+      const [u] = provenance.get(reifies);
+      expect(slice(doc, u.subject)).toBe('<r>');
+      const annot = quads.find(q => q.predicate.value === `${BASE_IRI}a`);
+      const [ua] = provenance.get(annot);
+      expect(slice(doc, ua.object)).toBe('<b>');
+    });
+  });
+
+  describe('coverage of span-less and exotic terms', () => {
+    it("spans the complete 'a' predicate", () => {
+      const doc = '<s> a <C> .';
+      const { quads, provenance } = parse(doc);
+      const [u] = provenance.get(quads[0]);
+      expect(slice(doc, u.predicate)).toBe('a');
+      expect(slice(doc, u.object)).toBe('<C>');
+    });
+
+    it.each([
+      ['=', '='],
+      ['=>', '=>'],
+      ['<=', '<='],
+    ])('spans the complete %s predicate abbreviation', (operator, expected) => {
+      const doc = `<s> ${operator} <o> .`;
+      const { quads, provenance } = parse(doc, { format: 'text/n3' });
+      expect(slice(doc, provenance.get(quads[0])[0].predicate)).toBe(expected);
+    });
+
+    it('spans language-tagged literals inside collections', () => {
+      const doc = '<s> <p> ("x"@en) .';
+      const { quads, provenance } = parse(doc);
+      const first = quads.find(q => q.predicate.value.endsWith('#first'));
+      const [u] = provenance.get(first);
+      expect(slice(doc, u.object)).toBe('"x"@en');
+    });
+
+    it('spans subject literals in N3 mode', () => {
+      const doc = '"s" <p> <o> .';
+      const { quads, provenance } = parse(doc, { format: 'text/n3' });
+      const [u] = provenance.get(quads[0]);
+      expect(slice(doc, u.subject)).toBe('"s"');
+    });
+
+    it('spans predicate literals in N3 mode', () => {
+      const doc = '<s> "p" <o> .';
+      const { quads, provenance } = parse(doc, { format: 'text/n3' });
+      const [u] = provenance.get(quads[0]);
+      expect(slice(doc, u.predicate)).toBe('"p"');
+    });
+
+    it.each([
+      ['"s" "p" "o" .', ['"s"', '"p"', '"o"']],
+      ['"s" 42 "o" .', ['"s"', '42', '"o"']],
+      ['42 "p" true .', ['42', '"p"', 'true']],
+      ['"s"@en "p" "o" .', ['"s"@en', '"p"', '"o"']],
+    ])('keeps adjacent N3 term ranges independent in %s', (doc, expected) => {
+      const { quads, provenance } = parse(doc, { format: 'text/n3' });
+      const occurrence = provenance.get(quads[0])[0];
+      expect(['subject', 'predicate', 'object'].map(component => slice(doc, occurrence[component])))
+        .toStrictEqual(expected);
+    });
+
+    it('keeps adjacent literal ranges independent inside a collection', () => {
+      const doc = '<s> <p> ("a" "b" 42 "c") .';
+      const { quads, provenance } = parse(doc, { format: 'text/n3' });
+      const items = quads.filter(q => q.predicate.value.endsWith('#first'));
+      expect(items.map(q => slice(doc, provenance.get(q)[0].object)))
+        .toStrictEqual(['"a"', '"b"', '42', '"c"']);
+    });
+
+    // Numbers and booleans reach the parser as a single `literal` token whose
+    // prefix already holds the datatype, so they bypass the pending literal-token path.
+    it('spans pre-datatyped object literals', () => {
+      const doc = '<s> <p> 42, 1.5e0, true .';
+      const { quads, provenance } = parse(doc);
+      expect(quads.map(q => slice(doc, provenance.get(q)[0].object)))
+        .toStrictEqual(['42', '1.5e0', 'true']);
+    });
+
+    it('spans pre-datatyped literals in collections', () => {
+      const doc = '<s> <p> (42) .';
+      const { quads, provenance } = parse(doc);
+      const first = quads.find(q => q.predicate.value.endsWith('#first'));
+      expect(slice(doc, provenance.get(first)[0].object)).toBe('42');
+    });
+
+    it('spans pre-datatyped subject and predicate literals in N3 mode', () => {
+      const doc = '42 true <o> .';
+      const { quads, provenance } = parse(doc, { format: 'text/n3' });
+      const [u] = provenance.get(quads[0]);
+      expect(slice(doc, u.subject)).toBe('42');
+      expect(slice(doc, u.predicate)).toBe('true');
+    });
+
+    it('indexes triple terms', () => {
+      const doc = '<a> <b> <<( <s> <p> <o> )>> .';
+      const { quads, provenance } = parse(doc);
+      expect(provenance.get(quads[0])).toHaveLength(1);
+    });
+
+    it('spans rdf:nil denoted by an empty collection', () => {
+      const doc = '() <p> <o> .';
+      const { quads, provenance } = parse(doc);
+      const [u] = provenance.get(quads[0]);
+      expect(slice(doc, u.subject)).toBe('()');
+    });
+
+    it('spans complete non-empty and nested collections', () => {
+      const doc = '(<a> (<b>)) <p> <o> .';
+      const { quads, provenance } = parse(doc);
+      const outer = quads.find(q => q.predicate.value === `${BASE_IRI}p`);
+      expect(slice(doc, provenance.get(outer)[0].subject)).toBe('(<a> (<b>))');
+      const nestedMembership = quads.find(q => q.predicate.value.endsWith('#first') &&
+        q.object.termType === 'BlankNode');
+      expect(slice(doc, provenance.get(nestedMembership)[0].object)).toBe('(<b>)');
+    });
+
+    it('spans a collection used as a predicate', () => {
+      const doc = '<s> (<p>) <o> .';
+      const { quads, provenance } = parse(doc, { format: 'text/n3' });
+      const outer = quads.find(q => q.object.value.endsWith('/o'));
+      expect(slice(doc, provenance.get(outer)[0].predicate)).toBe('(<p>)');
+    });
+
+    it('leaves generated list cells and predicates without ranges', () => {
+      const doc = '(<a> <b>) <p> <o> .';
+      const { quads, provenance } = parse(doc);
+      const second = quads.find(q => q.predicate.value.endsWith('#first') && q.object.value.endsWith('/b'));
+      const occurrence = provenance.get(second)[0];
+      expect(occurrence.subject).toBeNull();
+      expect(occurrence.predicate).toBeNull();
+    });
+
+    it('spans a property list used as a list item', () => {
+      const doc = '([ <p> <o> ]) <q> <r> .';
+      const { quads, provenance } = parse(doc);
+      const membership = quads.find(q => q.predicate.value.endsWith('#first'));
+      expect(slice(doc, provenance.get(membership)[0].object)).toBe('[ <p> <o> ]');
+    });
+
+    it('leaves path-generated terms without ranges', () => {
+      const doc = '<s>!<p> <q> <o> .';
+      const { quads, provenance } = parse(doc, { format: 'text/n3' });
+      const path = quads.find(q => q.predicate.value === `${BASE_IRI}p`);
+      const outer = quads.find(q => q.predicate.value === `${BASE_IRI}q`);
+      expect(provenance.get(path)[0].object).toBeNull();
+      expect(provenance.get(outer)[0].subject).toBeNull();
+    });
+
+    it('leaves explicit-quantifier list structure without ranges', () => {
+      const doc = '@forAll <x>. <x> <p> <o> .';
+      const { quads, provenance } = parse(doc, { format: 'text/n3', explicitQuantifiers: true });
+      const item = quads.find(q => q.predicate.value.endsWith('#first'));
+      const occurrence = provenance.get(item)[0];
+      expect(occurrence.subject).toBeNull();
+      expect(occurrence.predicate).toBeNull();
+      expect(slice(doc, occurrence.object)).toBe('<x>');
+    });
+
+    it('spans complete anonymous property lists and formulas', () => {
+      const doc = '[ <p> <o> ] <q> { <s> <p2> <o2> } .';
+      const { quads, provenance } = parse(doc, { format: 'text/n3' });
+      const outer = quads.find(q => q.predicate.value === `${BASE_IRI}q`);
+      const occurrence = provenance.get(outer)[0];
+      expect(slice(doc, occurrence.subject)).toBe('[ <p> <o> ]');
+      expect(slice(doc, occurrence.object)).toBe('{ <s> <p2> <o2> }');
+      const inner = quads.find(q => q.predicate.value === `${BASE_IRI}p2`);
+      expect(slice(doc, provenance.get(inner)[0].graph)).toBe('{ <s> <p2> <o2> }');
+    });
+
+    it('spans formulas whose final statement has explicit punctuation', () => {
+      const doc = '{ <s> <p> <o> . } <q> <r> .';
+      const { quads, provenance } = parse(doc, { format: 'text/n3' });
+      const outer = quads.find(q => q.predicate.value === `${BASE_IRI}q`);
+      expect(slice(doc, provenance.get(outer)[0].subject)).toBe('{ <s> <p> <o> . }');
+    });
+
+    it('spans a formula used as a predicate', () => {
+      const doc = '<s> { <a> <b> <c> } <o> .';
+      const { quads, provenance } = parse(doc, { format: 'text/n3' });
+      const outer = quads.find(q => q.subject.value === `${BASE_IRI}s`);
+      expect(slice(doc, provenance.get(outer)[0].predicate)).toBe('{ <a> <b> <c> }');
+    });
+
+    it('spans an empty formula that denotes true', () => {
+      const doc = '{} <p> <o> .';
+      const { quads, provenance } = parse(doc, { format: 'text/n3', emptyFormulaAsTrue: true });
+      expect(slice(doc, provenance.get(quads[0])[0].subject)).toBe('{}');
+    });
+
+    it('spans complete RDF-star triple terms', () => {
+      const doc = '<a> <b> <<( <s> <p> <o> )>> .';
+      const { quads, provenance } = parse(doc);
+      expect(slice(doc, provenance.get(quads[0])[0].object)).toBe('<<( <s> <p> <o> )>>');
+    });
+
+    it('preserves an invalid RDF-star closing-token error', () => {
+      expect(() => parse('<a> <b> <<( <s> <p> <o> >> .'))
+        .toThrow('Expected )>> but got >>');
+    });
+
+    it('spans the complete embedded triple in N3 reification', () => {
+      const doc = '<a> <b> << <s> <p> <o> >> .';
+      const { quads, provenance } = parse(doc, { format: 'text/n3' });
+      const reifies = quads.find(q => q.predicate.value.endsWith('#reifies'));
+      const occurrence = provenance.get(reifies)[0];
+      expect(occurrence.subject).toBeNull();
+      expect(slice(doc, occurrence.object)).toBe('<< <s> <p> <o> >>');
+    });
+
+    it('uses the lexical range of an explicit reifier', () => {
+      const doc = '<a> <b> << <s> <p> <o> ~ <r> >> .';
+      const { quads, provenance } = parse(doc, { format: 'text/n3' });
+      const reifies = quads.find(q => q.predicate.value.endsWith('#reifies'));
+      expect(slice(doc, provenance.get(reifies)[0].subject)).toBe('<r>');
+    });
+
+    it('preserves an invalid N3 reification closing-token error', () => {
+      expect(() => parse('<a> <b> << <s> <p> <o> )>> .', { format: 'text/n3' }))
+        .toThrow('Expected >> but got )>>');
+    });
+
+    it('spans a blank named graph label as []', () => {
+      const doc = 'GRAPH [] { <s> <p> <o> . }';
+      const { quads, provenance } = parse(doc, { format: 'application/trig' });
+      expect(slice(doc, provenance.get(quads[0])[0].graph)).toBe('[]');
+    });
+
+    it('spans an IRI following the GRAPH keyword', () => {
+      const doc = 'GRAPH <g> { <s> <p> <o> . }';
+      const { quads, provenance } = parse(doc, { format: 'application/trig' });
+      expect(slice(doc, provenance.get(quads[0])[0].graph)).toBe('<g>');
+    });
+
+    it('preserves an invalid blank graph-label error', () => {
+      expect(() => parse('GRAPH [ <g> { <s> <p> <o> . }', { format: 'application/trig' }))
+        .toThrow('Invalid graph label');
+    });
+
+    it('constructs without options', () => {
+      const { quads } = new ProvenanceParser().parse('<http://x/s> <http://x/p> <http://x/o> .');
+      expect(quads).toHaveLength(1);
+    });
+
+    it('iterates over utterance lists without exposing counts', () => {
+      const { provenance } = parse('<s> <p> <o> .\n<s> <p> <o2> .');
+      const entries = [...provenance];
+      expect(entries.map(([, occurrences]) => occurrences.length)).toEqual([1, 1]);
+      expect(entries[0][0].termType).toBe('Quad');
+      expect(provenance).not.toHaveProperty('size');
+      expect(provenance).not.toHaveProperty('utteranceCount');
+      expect(new ProvenanceIndex().get(DataFactory.quad(
+        DataFactory.namedNode('x:s'), DataFactory.namedNode('x:p'), DataFactory.namedNode('x:o'),
+      ))).toEqual([]);
+    });
+  });
+
+  describe('occurrence tracking', () => {
+    it('keeps the opening token active for delayed literal construction', () => {
+      const doc = '<s> <p> "typed"^^<type>, "directed"@en--ltr, 42 .';
+      const { quads, provenance } = parse(doc);
+      expect(quads.map(q => slice(doc, provenance.get(q)[0].object)))
+        .toStrictEqual(['"typed"^^<type>', '"directed"@en--ltr', '42']);
+    });
+
+    it('uses a null source token for implicit reification terms', () => {
+      const { quads, provenance } = parse('<s> <p> <o> ~ .');
+      const reifies = quads.find(q => q.predicate.value.endsWith('#reifies'));
+      expect(reifies).toBeDefined();
+      expect(Object.getOwnPropertySymbols(reifies)).toHaveLength(0);
+      expect(Object.getOwnPropertySymbols(reifies.subject)).toHaveLength(0);
+      expect(Object.getOwnPropertySymbols(reifies.object)).toHaveLength(0);
+      expect(provenance.get(reifies)[0].subject).toBeNull();
+      expect(provenance.get(reifies)[0].object).toBeNull();
+    });
+
+    it('does not attach private metadata to emitted terms', () => {
+      const { quads } = parse('<s> <p> <o> .');
+      expect(Object.getOwnPropertySymbols(quads[0])).toHaveLength(0);
+      expect(Object.getOwnPropertySymbols(quads[0].subject)).toHaveLength(0);
+      expect(Object.getOwnPropertySymbols(quads[0].predicate)).toHaveLength(0);
+      expect(Object.getOwnPropertySymbols(quads[0].object)).toHaveLength(0);
+    });
+
+    it('locates each use of a quantified entity at its own token', () => {
+      const doc = '@forAll <x>. <x> <p> <o> .';
+      const { quads, provenance } = parse(doc, { format: 'text/n3' });
+      const quad = quads.find(({ predicate }) => predicate.value === `${BASE_IRI}p`);
+      const [{ subject }] = provenance.get(quad);
+      expect(offset(doc, subject.start)).toBe(doc.lastIndexOf('<x>'));
+    });
+
+    it('locates simultaneous uses of one quantified term independently', () => {
+      const doc = '@forAll <x>. <x> <x> <x> .';
+      const { quads, provenance } = parse(doc, { format: 'text/n3' });
+      const quad = quads[quads.length - 1], occurrence = provenance.get(quad)[0];
+      expect([occurrence.subject, occurrence.predicate, occurrence.object]
+        .map(range => [range.start.column, range.end.column]))
+        .toEqual([[13, 16], [17, 20], [21, 24]]);
+    });
+
+    it('locates interned terms independently without mutating them', () => {
+      const factory = frozenInterningFactory();
+
+      const doc = '<x> <x> <x> .';
+      const { quads, provenance } = parse(doc, { factory });
+      expect(quads[0].subject).toBe(quads[0].predicate);
+      expect(quads[0].predicate).toBe(quads[0].object);
+      const occurrence = provenance.get(quads[0])[0];
+      expect([occurrence.subject, occurrence.predicate, occurrence.object]
+        .map(range => [range.start.column, range.end.column]))
+        .toEqual([[0, 3], [4, 7], [8, 11]]);
+      expect(Object.getOwnPropertySymbols(quads[0].subject)).toHaveLength(0);
+    });
+
+    it('does not confuse an interned rdf:nil term with a list placeholder', () => {
+      const nil = '<http://www.w3.org/1999/02/22-rdf-syntax-ns#nil>',
+          doc = `${nil} <p> () .`,
+          { quads, provenance } = parse(doc, { factory: frozenInterningFactory() }),
+          occurrence = provenance.get(quads[0])[0];
+      expect(slice(doc, occurrence.subject)).toBe(nil);
+      expect(slice(doc, occurrence.object)).toBe('()');
+    });
+
+    it('supports quantified terms from an RDF/JS factory without internal IDs', () => {
+      const doc = '@forAll <x>. <x> <p> <o> .',
+          { quads, provenance } = parse(doc, { format: 'text/n3', factory: rdfDataModel }),
+          quad = quads[quads.length - 1];
+      expect(quad.subject.termType).toBe('Variable');
+      expect(quad.predicate.value).toBe(`${BASE_IRI}p`);
+      expect(quad.object.value).toBe(`${BASE_IRI}o`);
+      expect(slice(doc, provenance.get(quad)[0].subject)).toBe('<x>');
+    });
+
+    it('carries the location of an IRI property-list identifier', () => {
+      const doc = '[id <s> <p> <o>].';
+      const { quads, provenance } = parse(doc, { format: 'text/n3' });
+      expect(slice(doc, provenance.get(quads[0])[0].subject)).toBe('<s>');
+    });
+
+    it('propagates entity parse errors', () => {
+      expect(() => parse('<s> <p> .')).toThrow('Expected entity but got .');
+    });
+
+    it('passes raw factory terms to inherited prefix callbacks', () => {
+      const prefixes = [];
+      new N3TermLocationParser({ factory: rdfDataModel }).parse(
+        '@prefix ex: <http://example.com/>. ex:s ex:p ex:o.',
+        { onPrefix: (...args) => prefixes.push(args) },
+      );
+      expect(prefixes).toEqual([['ex', rdfDataModel.namedNode('http://example.com/')]]);
+    });
+
+    it('preserves custom factory receivers and method arities', () => {
+      function recordingFactory(calls) {
+        const factory = Object.create(DataFactory);
+        for (const name of ['namedNode', 'blankNode', 'variable', 'literal', 'defaultGraph', 'quad']) {
+          Object.defineProperty(factory, name, {
+            value(...args) {
+              calls.push({ name, arity: args.length, receiver: this });
+              return DataFactory[name](...args);
+            },
+          });
+        }
+        return factory;
+      }
+
+      const doc = '<s> <p> [ <q> "value" ] .\n<s> <p> <<( <x> <y> _:z )>> .';
+      const plainCalls = [], trackedCalls = [];
+      new Parser({ baseIRI: BASE_IRI, blankNodePrefix: '', factory: recordingFactory(plainCalls) }).parse(doc);
+      const trackedFactory = recordingFactory(trackedCalls);
+      parse(doc, { factory: trackedFactory });
+      expect(trackedCalls.map(({ name, arity }) => ({ name, arity })))
+        .toStrictEqual(plainCalls.map(({ name, arity }) => ({ name, arity })));
+      expect(trackedCalls.every(({ receiver }) => receiver === trackedFactory)).toBe(true);
+
+      const variableCalls = [], variableFactory = recordingFactory(variableCalls);
+      parse('?s <p> <o> .', { format: 'text/n3', factory: variableFactory });
+      expect(variableCalls.find(({ name }) => name === 'variable').receiver).toBe(variableFactory);
+    });
+
+    it('uses the custom factory when reconstructing indexed quads', () => {
+      class CustomNamedNode {
+        constructor(value) { this.termType = 'NamedNode'; this.value = value; }
+      }
+      const factory = Object.create(DataFactory);
+      factory.namedNode = value => new CustomNamedNode(value);
+      const { provenance } = parse('<s> <p> <o> .', { factory });
+      const [[quad]] = provenance;
+      expect(quad.subject).toBeInstanceOf(CustomNamedNode);
+      expect(quad.predicate).toBeInstanceOf(CustomNamedNode);
+      expect(quad.object).toBeInstanceOf(CustomNamedNode);
+    });
+
+    it('rejects a non-RDF/JS quad factory with a clear error', () => {
+      const factory = {
+        namedNode: value => value,
+        blankNode: value => `_:${value || 'b'}`,
+        variable: value => `?${value}`,
+        literal: value => `"${value}"`,
+        defaultGraph: () => '',
+        quad: (s, p, o, g) => ({ s, p, o, g }),
+      };
+      expect(() => parse('<s> <p> <o> .', { factory }))
+        .toThrow('ProvenanceParser requires an RDF/JS-compatible data factory');
+    });
+
+    it('does not change what the parser emits', () => {
+      const doc = '@prefix ex: <http://ex.example/>.\nex:s ex:p [ ex:q (1 2) ], "x"@en--ltr .';
+      // anonymous blank node labels come from a global counter, so compare
+      // with labels normalized by order of first appearance
+      function normalize(quads) {
+        const seen = new Map();
+        function label(l) {
+          if (!seen.has(l)) seen.set(l, `bn${seen.size}`);
+          return seen.get(l);
+        }
+        return quads.map(q => JSON.stringify(q.toJSON(), (k, v, o) => v))
+          .map((s, i) => JSON.parse(s))
+          .map(j => JSON.parse(JSON.stringify(j), (k, v) =>
+            v && v.termType === 'BlankNode' ? { ...v, value: label(v.value) } : v));
+      }
+      const plain = new Parser({ baseIRI: BASE_IRI, blankNodePrefix: '' }).parse(doc);
+      const tracked = parse(doc);
+      expect(normalize(tracked.quads)).toEqual(normalize(plain));
+    });
+  });
+
+  describe('facade behavior', () => {
+    it('constructs with null options', () => {
+      expect(new ProvenanceParser(null).parse('<s> <p> <o> .').quads).toHaveLength(1);
+    });
+
+    it('rejects streaming input immediately', () => {
+      expect(() => new ProvenanceParser().parse({ on() {} }))
+        .toThrow('ProvenanceParser.parse only accepts a string');
+    });
+
+    it.each(['line', 'start', 'end'])('rejects custom lexer tokens without a numeric %s coordinate', field => {
+      const lexer = {
+        tokenize(input) {
+          return new Lexer().tokenize(input).map(token => {
+            const copy = { ...token };
+            delete copy[field];
+            return copy;
+          });
+        },
+      };
+      expect(() => parse('<s> <p> <o> .', { lexer }))
+        .toThrow('Lexical provenance requires lexer tokens with numeric line, start, end, and multiline endLine');
+    });
+
+    it('rejects a non-numeric custom-lexer endLine', () => {
+      const lexer = {
+        tokenize(input) {
+          return new Lexer().tokenize(input).map(token => ({ ...token, endLine: 'invalid' }));
+        },
+      };
+      expect(() => parse('<s> <p> <o> .', { lexer }))
+        .toThrow('Lexical provenance requires lexer tokens with numeric line, start, end, and multiline endLine');
+    });
+
+    it('accepts N3Lexer itself as a custom lexer for multiline tokens', () => {
+      const doc = '<s> <p> """a\nb""" .', { quads, provenance } = parse(doc, { lexer: new Lexer() });
+      expect(slice(doc, provenance.get(quads[0])[0].object)).toBe('"""a\nb"""');
+    });
+
+    it('validates coordinates on every custom-lexer token', () => {
+      const lexer = {
+        tokenize(input) {
+          const tokens = new Lexer().tokenize(input).map(token => ({ ...token }));
+          delete tokens[1].start;
+          return tokens;
+        },
+      };
+      expect(() => parse('<s> <p> <o> .', { lexer }))
+        .toThrow('Lexical provenance requires lexer tokens with numeric line, start, end, and multiline endLine');
+    });
+
+    it('can be reused without carrying prefixes or occurrences across parses', () => {
+      const parser = new ProvenanceParser({ baseIRI: BASE_IRI });
+      const first = parser.parse('@prefix ex: <http://ex/>. ex:s ex:p ex:o.');
+      const second = parser.parse('<s> <p> <o>.');
+      expect(first.prefixes.ex).toBe('http://ex/');
+      expect(second.prefixes.ex).toBeUndefined();
+      expect(second.provenance.get(first.quads[0])).toEqual([]);
+    });
+
+    it('calls onQuad in parse order with complete public ranges', () => {
+      const events = [], doc = '[ <p> <o> ] <q> <r> .';
+      const result = parse(doc, { onQuad: (quad, occurrence) => events.push([quad, occurrence]) });
+      expect(events.map(([quad]) => quad)).toEqual(result.quads);
+      expect(slice(doc, events[0][1].subject)).toBe('[ <p> <o> ]');
+    });
+
+    it('emits completed quads before a later parse error', () => {
+      const events = [];
+      expect(() => new ProvenanceParser({
+        baseIRI: BASE_IRI,
+        onQuad: (...args) => events.push(args),
+      }).parse('<s> <p> <o> . <unfinished>')).toThrow();
+      expect(events).toHaveLength(1);
+      expect(events[0][0].subject.value).toBe(`${BASE_IRI}s`);
+    });
+
+    it('emits a completed compound range before a later parse error', () => {
+      const events = [];
+      expect(() => new ProvenanceParser({
+        baseIRI: BASE_IRI,
+        format: 'text/n3',
+        onQuad: (...args) => events.push(args),
+      }).parse('[ <p> <o> ] . <unfinished>')).toThrow();
+      expect(events).toHaveLength(1);
+      expect(events[0][1].subject).toEqual({
+        start: { line: 1, column: 0 },
+        end: { line: 1, column: 11 },
+      });
+    });
+
+    it('stops emitting when an onQuad callback throws', () => {
+      const error = new Error('stop'), events = [];
+      expect(() => parse('[ <p> <o> ] <q> <r> .', {
+        onQuad: quad => {
+          events.push(quad);
+          throw error;
+        },
+      })).toThrow(error);
+      expect(events).toHaveLength(1);
+    });
+
+    it('supports the inherited callback path in the internal location parser', done => {
+      const events = [];
+      new N3TermLocationParser({ onQuad: (...args) => events.push(args) })
+        .parse('<s> <p> <o> .', (error, quad) => {
+          if (error)
+            return done(error);
+          if (quad)
+            return;
+          expect(events).toHaveLength(1);
+          done();
+        });
+    });
+
+    it('constructs the internal location parser without options', () => {
+      expect(new N3TermLocationParser().parse('<s> <p> <o> .')).toHaveLength(1);
+    });
+  });
+});
+
+
+describe('Callback-based provenance integration', () => {
+  it.each([
+    ['turtle', '(() ()) <p> <o>.'],
+    ['text/n3', '(() ()) <p> <o>.'],
+    ['text/n3', '<s> () ().'],
+    ['text/n3', '(()!<p> ()^<q>) <r> <o>.'],
+  ])('keeps lexical empty lists distinct from synthetic rdf:nil in %s: %s', (format, doc) => {
+    const { quads, provenance } = parse(doc, { format });
+    expect(isomorphic(quads, new Parser({ baseIRI: BASE_IRI, format }).parse(doc))).toBe(true);
+    const occurrences = quads.map(quad => [quad, provenance.get(quad)[0]]);
+    const lexical = occurrences.flatMap(([quad, occurrence]) =>
+      ['subject', 'predicate', 'object'].filter(component => occurrence[component] &&
+        quad[component].value.endsWith('#nil')).map(component => slice(doc, occurrence[component])));
+    expect(lexical).toContain('()');
+    const tails = occurrences.filter(([quad]) => quad.predicate.value.endsWith('#rest') &&
+      quad.object.value.endsWith('#nil'));
+    expect(tails.map(([, occurrence]) => occurrence.object)).toEqual(tails.map(() => null));
+  });
+
+  it.each([
+    '[ <p> <o>; is <q> of <r> ] <a> <b>.',
+    '{ <s> is <p> of <o>; <q> <r> }.',
+    '<s> is <p> of <o> {| <q> <r> |}.',
+    '<a> <b> <<( <s> is <p> of <o> )>>.',
+    '<s> <- (<a>) <o>.',
+  ])('preserves current N3 inverse semantics and term locations: %s', doc => {
+    const { quads, provenance } = parse(doc, { format: 'text/n3' });
+    expect(isomorphic(quads, new Parser({ baseIRI: BASE_IRI, format: 'text/n3' }).parse(doc))).toBe(true);
+    for (const quad of quads) {
+      const occurrence = provenance.get(quad)[0];
+      const lexical = ['subject', 'predicate', 'object'].filter(component =>
+        occurrence[component] && quad[component].termType === 'NamedNode' &&
+        quad[component].value.startsWith(BASE_IRI));
+      expect(lexical.map(component => slice(doc, occurrence[component])))
+        .toEqual(lexical.map(component => `<${quad[component].value.slice(BASE_IRI.length)}>`));
+    }
+  });
+
+  it('composes public observers and comments without losing literal suffix ranges', () => {
+    const doc = '<s> <p> "text" # between\n @en--rtl .', before = [], after = [], comments = [];
+    const parser = new N3TermLocationParser({ baseIRI: BASE_IRI });
+    const quads = parser.parse(doc, {
+      onToken: token => before.push(token),
+      onTokenEnd: token => after.push(token),
+      onComment: comment => comments.push(comment),
+    });
+    expect(quads[0].object.direction).toBe('rtl');
+    expect(before).toEqual(after);
+    expect(comments).toEqual([' between']);
+  });
+
+  it('keeps locations identical across every two-chunk split', () => {
+    const doc = '\uFEFF<g> { [ <p> """a\r\nb"""@en--rtl ] <q> (() <x>) . }';
+    const expected = parse(doc, { format: 'trig' });
+    const expectedRanges = expected.quads.map(quad => expected.provenance.get(quad)[0]);
+    for (let split = 0; split <= doc.length; split++) {
+      const input = new EventEmitter(), entityIndex = new EntityIndex(),
+          index = new ProvenanceIndex(entityIndex), quads = [];
+      new N3TermLocationParser({
+        baseIRI: BASE_IRI, format: 'trig', entityIndex,
+        onQuad: (quad, id, ...ranges) => index._add(id, ...ranges),
+      }).parse(input, (error, quad) => {
+        if (error) throw error;
+        if (quad) quads.push(quad);
+      });
+      input.emit('data', doc.slice(0, split));
+      input.emit('data', doc.slice(split));
+      input.emit('end');
+      expect(isomorphic(quads, expected.quads)).toBe(true);
+      expect(quads.map(quad => index.get(quad)[0])).toEqual(expectedRanges);
+    }
+  });
+
+  it('supports resolving unknown IDs and interning a default-graph tuple', () => {
+    const index = new EntityIndex();
+    expect(index.resolve(999)).toBeUndefined();
+    const term = DataFactory.namedNode('urn:value'), id = index.intern(term);
+    const quadId = index.internQuad(id, id, id);
+    expect(index.resolve(quadId)).toEqual(DataFactory.quad(term, term, term));
+  });
+});
+
+
+describe('Empty-list identity with interning factories', () => {
+  it.each([
+    '<http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> () ().',
+    '() <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> ().',
+    '() () <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil>.',
+  ])('preserves the separate lexical spellings in %s', doc => {
+    const { quads, provenance } = parse(doc, { format: 'text/n3', factory: frozenInterningFactory() });
+    const occurrence = provenance.get(quads[0])[0];
+    expect(['subject', 'predicate', 'object'].map(component => slice(doc, occurrence[component])))
+      .toEqual(doc.slice(0, -1).split(' '));
+  });
+});


### PR DESCRIPTION
This proposal adds public `onToken(token)` and `onTokenEnd(token)` callbacks to `Parser.parse`, then uses them in a complete term-location/provenance reference implementation. It continues the work in [jeswr/N3.js#20](https://github.com/jeswr/N3.js/pull/20) on top of the merged lexer ranges from #721.

The draft keeps the callback API separate so it can be extracted and landed independently:

1. **`17301c3` — public callbacks, contract tests, and documentation.** This changes only `N3Parser.js`, the README, and a standalone callback test file. No observer calls or checks are added to the ordinary per-token path when callbacks are absent.
2. **Reference implementation and tests.** `examples/provenance` contains the location parser, compact provenance index, an EntityIndex adapter, documentation, and a runnable demo. Nothing is added to N3's exports or published package, and this commit needs no further core parser, lexer, or Store changes.

3. **`2efdb07` — simplify public occurrence packing.** Write the four component ranges directly in one loop, removing the separate offset-calculation helper. This retains the same 16-number storage, atomic validation, and copying behavior. Seven alternating fresh-process samples per runtime on Node 24/25 found performance-neutral public insertion times (median changes −0.6% and −1.2%).

The reference is more complete than fork PR #16's term-symbol prototype: it handles frozen/interning factories, complete compound and literal-suffix ranges, current N3 emission rules, and ordered callbacks with partial-error behavior. Those guarantees require additional state. The packed representation retains its separate handling of unfinished ranges because simpler storage alternatives did not establish equivalent performance across the tested workloads.

The callbacks observe each token once around processing, including EOF and enabled comment tokens, across synchronous and streaming parsing. Return values are ignored. `onTokenEnd` runs for cleanup even if processing or `onToken` throws; consumer exceptions stop subsequent token dispatch. The README specifies ordering with quad/comment/completion callbacks, coordinate units, and error behavior.

The reference replaces the private `_readToken` override with the public callbacks and retains the complete provenance behavior: duplicate occurrences with value-based quad lookup, original lexical spellings, literal suffixes, multiline ranges, nested lists/property lists/formulas/triple terms, named graphs, inverse predicates, and null ranges for generated terms. Frozen/interning RDF/JS factories work. The original proposal's parser changes have been adapted to current main, including the newer N3 inverse-predicate routing.

**Scope of the extension point:** these callbacks make token observation public. The reference still subclasses private grammar/factory methods and uses EntityIndex internals to correlate terms with syntax. Its README explicitly records those dependencies and the need to pin/test a compatible N3 version; this is not a claim that the complete provenance implementation now uses only public APIs.

Validation:

- Callback commit alone: **6,961 tests, 100% coverage**.
- Complete proposal: **7,073 tests, 100% statement/branch/function/line coverage**, including 112 provenance tests.
- Added regressions cover callback lifecycle/errors/reuse, nested empty lists with interning factories, current N3 inverse semantics, and every two-chunk split of a document with BOM, CRLF, a multiline directional literal, and nested compounds.
- ESLint (including the example), Node/browser builds, the runnable provenance demo, and independent code review pass.
- Local throughput check on macOS arm64, Node 24.12.0 and 25.1.0: five alternating fresh-process samples per case, 300 ms warmup and at least 500 ms measurement. With observers disabled, median changes across dense N-Triples, literal N-Triples, mixed Turtle, mixed N3, and streaming N-Triples ranged from **−2.8% to +1.8%**, with no material regression established. Registering both empty observers added roughly **0–5.6%** relative to the new disabled path, before any provenance work.

Try the reference after installing dependencies:

```sh
node -r @babel/register examples/provenance/demo.js
npm test -- --runInBand test/N3ProvenanceParser-test.js
```

To land only the requested extension points, select the first commit; the full reference can remain a separate external experiment.

